### PR TITLE
Guard refresh_init_apps() to only run on first startup

### DIFF
--- a/shard_core/service/app_installation/__init__.py
+++ b/shard_core/service/app_installation/__init__.py
@@ -12,6 +12,8 @@ from .exceptions import AppAlreadyInstalled, AppDoesNotExist, AppNotInstalled
 
 log = logging.getLogger(__name__)
 
+STORE_KEY_INITIAL_APPS_INSTALLED = "initial_apps_installed"
+
 
 async def install_app_from_store(
     name: str,
@@ -99,7 +101,7 @@ async def reinstall_app(name: str):
 
 async def refresh_init_apps():
     try:
-        database.get_value("initial_apps_installed")
+        database.get_value(STORE_KEY_INITIAL_APPS_INSTALLED)
         log.debug("initial apps already installed on first startup, skipping")
         return
     except KeyError:
@@ -113,7 +115,7 @@ async def refresh_init_apps():
         log.info(f"installing initial app {app_name}")
         await install_app_from_store(app_name, InstallationReason.CONFIG)
 
-    database.set_value("initial_apps_installed", True)
+    database.set_value(STORE_KEY_INITIAL_APPS_INSTALLED, True)
     log.debug("refreshed initial apps")
 
 


### PR DESCRIPTION
## Summary

- `refresh_init_apps()` was called on every startup, which would re-install initial apps that a user had previously uninstalled.
- Added a persistent DB flag `"initial_apps_installed"` using the existing `get_value`/`set_value` primitives in `database.py`.
- On first startup the flag is absent, so initial apps are installed normally and the flag is written afterwards.
- On subsequent startups the flag is present, so `refresh_init_apps()` logs and returns early without touching any apps.
- Updated `test_add_init_app` (full-env test) to clear the flag before calling `refresh_init_apps()` a second time, since the flag is set during lifespan startup.

Closes #28

## Test plan

- [x] `test_refresh_init_apps_skipped_if_flag_set` — unit test: sets flag, mocks `install_app_from_store`, asserts it is NOT called
- [x] `test_refresh_init_apps_installs_on_first_startup` — unit test: clears flag, mocks `install_app_from_store`, asserts it IS called and flag is set afterwards
- [x] `test_add_init_app` — full-env integration test: clears flag before second call, confirms new app is installed (requires `TEST_ENV=full`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)