### PR TITLE
Replace TinyDB with PostgreSQL

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,6 +1,13 @@
 path_root: "/"
 path_root_host: "/home/shard"
 
+db:
+  host: postgres
+  port: 5432
+  dbname: shard_core
+  user: shard_core
+  password: shard_core
+
 dns:
   zone: freeshard.cloud
   prefix length: 6

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,28 @@ networks:
   portal:
     name: portal
 
+volumes:
+  postgres_data:
+
 services:
+
+  postgres:
+    image: postgres:17
+    container_name: postgres
+    restart: always
+    environment:
+      - POSTGRES_DB=shard_core
+      - POSTGRES_USER=shard_core
+      - POSTGRES_PASSWORD=shard_core
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - portal
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U shard_core"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   traefik:
     image: traefik:v3.6
@@ -43,6 +64,9 @@ services:
       - FREESHARD_TRAEFIK_ACME_EMAIL=user@example.com
       - FREESHARD_TRAEFIK_DISABLE_SSL=${DISABLE_SSL}
       - FREESHARD_PATH_ROOT_HOST=${FREESHARD_DIR:?}
+    depends_on:
+      postgres:
+        condition: service_healthy
 
   web-terminal:
     image: ghcr.io/freeshardbase/web-terminal:0.37.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,9 @@ urls = { "Homepage" = "https://github.com/FreeshardBase/shard_core" }
 requires-python = ">=3.13"
 dependencies = [
     "gconf~=0.9.3",
-    "tinydb",
-    "tinydb-serialization",
+    "psycopg[binary]",
+    "psycopg_pool",
+    "yoyo-migrations[postgresql_psycopg]",
     "uvicorn",
     "fastapi[standard]",
     "websockets",
@@ -26,7 +27,6 @@ dependencies = [
     "pyyaml",
     "docker",
     "python-gitlab",
-    "psycopg[binary]",
     "cachetools",
     "blinker",
     "requests",
@@ -55,7 +55,8 @@ dev = [
     "yappi",
     "responses",
     "aioresponses",
-    "datamodel-code-generator[http]"
+    "datamodel-code-generator[http]",
+    "black"
 ]
 
 [tool.setuptools]

--- a/shard_core/data_model/profile.py
+++ b/shard_core/data_model/profile.py
@@ -4,7 +4,7 @@ from typing import Optional
 from pydantic import BaseModel
 
 from shard_core.data_model.backend.shard_model import ShardBase
-from shard_core.database.database import set_value, get_value
+from shard_core.database import database
 from shard_core.data_model.app_meta import VMSize
 
 
@@ -34,10 +34,10 @@ class Profile(BaseModel):
         )
 
 
-def set_profile(profile: Profile | None):
-    set_value("profile", profile.dict() if profile else "None")
+async def set_profile(profile: Profile | None):
+    await database.set_value("profile", profile.dict() if profile else "None")
 
 
-def get_profile() -> Profile | None:
-    value = get_value("profile")
+async def get_profile() -> Profile | None:
+    value = await database.get_value("profile")
     return None if value == "None" else Profile.parse_obj(value)

--- a/shard_core/data_model/terminal.py
+++ b/shard_core/data_model/terminal.py
@@ -52,4 +52,6 @@ async def _update_terminal_last_connection_async(terminal: Terminal):
     async with db_conn() as conn:
         existing = await terminals_db.get_by_id(conn, terminal.id)
         if existing:
-            await terminals_db.update(conn, terminal.id, {"last_connection": datetime.utcnow()})
+            await terminals_db.update(
+                conn, terminal.id, {"last_connection": datetime.utcnow()}
+            )

--- a/shard_core/data_model/terminal.py
+++ b/shard_core/data_model/terminal.py
@@ -1,11 +1,10 @@
+import asyncio
 from datetime import datetime
 from enum import Enum
 from typing import Optional
 
 from pydantic import BaseModel
-from tinydb import Query
 
-from shard_core.database.database import terminals_table
 from shard_core.service import human_encoding
 from shard_core.util.signals import on_terminal_auth
 
@@ -43,7 +42,14 @@ class InputTerminal(BaseModel):
 
 @on_terminal_auth.connect
 def update_terminal_last_connection(terminal: Terminal):
-    with terminals_table() as terminals:  # type: Table
-        existing_terminal = Terminal(**(terminals.get(Query().id == terminal.id)))
-        existing_terminal.last_connection = datetime.utcnow()
-        terminals.update(existing_terminal.dict(), Query().id == existing_terminal.id)
+    asyncio.create_task(_update_terminal_last_connection_async(terminal))
+
+
+async def _update_terminal_last_connection_async(terminal: Terminal):
+    from shard_core.database.connection import db_conn
+    from shard_core.database import terminals as terminals_db
+
+    async with db_conn() as conn:
+        existing = await terminals_db.get_by_id(conn, terminal.id)
+        if existing:
+            await terminals_db.update(conn, terminal.id, {"last_connection": datetime.utcnow()})

--- a/shard_core/database/app_usage.py
+++ b/shard_core/database/app_usage.py
@@ -1,0 +1,30 @@
+import logging
+from datetime import datetime
+
+from psycopg import AsyncConnection
+from psycopg.rows import dict_row
+from psycopg.types.json import Jsonb
+
+log = logging.getLogger(__name__)
+
+
+async def insert(conn: AsyncConnection, track: dict):
+    async with conn.cursor() as cur:
+        await cur.execute(
+            """INSERT INTO app_usage_tracks (timestamp, installed_apps)
+               VALUES (%(timestamp)s, %(installed_apps)s)""",
+            {
+                "timestamp": track["timestamp"],
+                "installed_apps": Jsonb(track["installed_apps"]),
+            },
+        )
+
+
+async def search_by_time_range(conn: AsyncConnection, start: datetime, end: datetime) -> list[dict]:
+    async with conn.cursor(row_factory=dict_row) as cur:
+        await cur.execute(
+            """SELECT * FROM app_usage_tracks
+               WHERE timestamp >= %(start)s AND timestamp < %(end)s""",
+            {"start": start, "end": end},
+        )
+        return await cur.fetchall()

--- a/shard_core/database/app_usage.py
+++ b/shard_core/database/app_usage.py
@@ -20,7 +20,9 @@ async def insert(conn: AsyncConnection, track: dict):
         )
 
 
-async def search_by_time_range(conn: AsyncConnection, start: datetime, end: datetime) -> list[dict]:
+async def search_by_time_range(
+    conn: AsyncConnection, start: datetime, end: datetime
+) -> list[dict]:
     async with conn.cursor(row_factory=dict_row) as cur:
         await cur.execute(
             """SELECT * FROM app_usage_tracks

--- a/shard_core/database/backups.py
+++ b/shard_core/database/backups.py
@@ -1,0 +1,33 @@
+import logging
+
+from psycopg import AsyncConnection
+from psycopg.rows import dict_row
+from psycopg.types.json import Jsonb
+
+log = logging.getLogger(__name__)
+
+
+async def insert(conn: AsyncConnection, report: dict):
+    async with conn.cursor() as cur:
+        await cur.execute(
+            """INSERT INTO backups (directories, start_time, end_time)
+               VALUES (%(directories)s, %(start_time)s, %(end_time)s)""",
+            {
+                "directories": Jsonb(report["directories"]),
+                "start_time": report["startTime"],
+                "end_time": report["endTime"],
+            },
+        )
+
+
+async def get_latest(conn: AsyncConnection) -> dict | None:
+    async with conn.cursor(row_factory=dict_row) as cur:
+        await cur.execute("SELECT * FROM backups ORDER BY end_time DESC LIMIT 1")
+        row = await cur.fetchone()
+        if row:
+            return {
+                "directories": row["directories"],
+                "startTime": row["start_time"],
+                "endTime": row["end_time"],
+            }
+        return None

--- a/shard_core/database/connection.py
+++ b/shard_core/database/connection.py
@@ -1,0 +1,32 @@
+import logging
+from contextlib import asynccontextmanager
+
+import gconf
+from psycopg_pool import AsyncConnectionPool
+
+log = logging.getLogger(__name__)
+
+_pool: AsyncConnectionPool | None = None
+
+
+async def make_and_open_connection_pool():
+    global _pool
+    db = gconf.get("db")
+    conninfo = f"host={db['host']} port={db['port']} dbname={db['dbname']} user={db['user']} password={db['password']}"
+    _pool = AsyncConnectionPool(conninfo=conninfo, min_size=2, max_size=10, open=False)
+    await _pool.open()
+    log.debug("opened connection pool")
+
+
+async def close_connection_pool():
+    global _pool
+    if _pool:
+        await _pool.close()
+        _pool = None
+        log.debug("closed connection pool")
+
+
+@asynccontextmanager
+async def db_conn():
+    async with _pool.connection() as conn:
+        yield conn

--- a/shard_core/database/connection.py
+++ b/shard_core/database/connection.py
@@ -2,6 +2,7 @@ import logging
 from contextlib import asynccontextmanager
 
 import gconf
+import psycopg.conninfo
 from psycopg_pool import AsyncConnectionPool
 
 log = logging.getLogger(__name__)
@@ -12,7 +13,13 @@ _pool: AsyncConnectionPool | None = None
 async def make_and_open_connection_pool():
     global _pool
     db = gconf.get("db")
-    conninfo = f"host={db['host']} port={db['port']} dbname={db['dbname']} user={db['user']} password={db['password']}"
+    conninfo = psycopg.conninfo.make_conninfo(
+        host=db["host"],
+        port=db["port"],
+        dbname=db["dbname"],
+        user=db["user"],
+        password=db["password"],
+    )
     _pool = AsyncConnectionPool(conninfo=conninfo, min_size=2, max_size=10, open=False)
     await _pool.open()
     log.debug("opened connection pool")

--- a/shard_core/database/database.py
+++ b/shard_core/database/database.py
@@ -1,6 +1,10 @@
 import logging
 
-from shard_core.database.connection import db_conn, make_and_open_connection_pool, close_connection_pool
+from shard_core.database.connection import (
+    db_conn,
+    make_and_open_connection_pool,
+    close_connection_pool,
+)
 from shard_core.database.migration import migrate
 from shard_core.database import kv_store
 

--- a/shard_core/database/database.py
+++ b/shard_core/database/database.py
@@ -1,121 +1,33 @@
 import logging
-import threading
-import time
-import traceback
-from contextlib import contextmanager
-from pathlib import Path
-from typing import Iterator
 
-import gconf
-from tinydb import TinyDB, Query, JSONStorage
-from tinydb.table import Table
-from tinydb_serialization import SerializationMiddleware
-from tinydb_serialization.serializers import DateTimeSerializer
+from shard_core.database.connection import db_conn, make_and_open_connection_pool, close_connection_pool
+from shard_core.database.migration import migrate
+from shard_core.database import kv_store
 
 log = logging.getLogger(__name__)
 
-global_db_lock = threading.RLock()
+
+async def init_database():
+    migrate()
+    await make_and_open_connection_pool()
+    log.info("database initialized")
 
 
-def init_database():
-    file = Path(gconf.get("path_root")) / "core" / "shard_core_db.json"
-    if file.is_dir():
-        raise Exception(f"{file} is a directory, should be a file or not existing")
-    if not file.exists():
-        file.parent.mkdir(parents=True, exist_ok=True)
-        file.touch()
-        log.info(f"initialized database at {file}")
-    else:
-        log.debug(f"database already exists at {file}")
+async def shutdown_database():
+    await close_connection_pool()
+    log.info("database shut down")
 
 
-@contextmanager
-def get_db() -> TinyDB:
-    serialization = SerializationMiddleware(JSONStorage)
-    serialization.register_serializer(DateTimeSerializer(), "TinyDate")
-
-    start_time = time.monotonic()
-    with global_db_lock:
-        wait_time = time.monotonic()
-        with TinyDB(
-            Path(gconf.get("path_root")) / "core" / "shard_core_db.json",
-            storage=serialization,
-            sort_keys=True,
-            indent=2,
-            create_dirs=True,
-        ) as db_:
-            yield db_
-        end_time = time.monotonic()
-        if end_time - start_time > 1:
-            log.debug(
-                f"waiting for db_lock for {wait_time - start_time :.3f}s, "
-                f"operation took {end_time - wait_time :.3f}s"
-            )
-            log.debug("Stacktrace:\n" + "".join(traceback.format_stack()))
+async def get_value(key: str):
+    async with db_conn() as conn:
+        return await kv_store.get_value(conn, key)
 
 
-@contextmanager
-def installed_apps_table() -> Iterator[Table]:
-    with get_db() as db:
-        yield db.table("installed_apps")
+async def set_value(key: str, value):
+    async with db_conn() as conn:
+        await kv_store.set_value(conn, key, value)
 
 
-@contextmanager
-def identities_table() -> Iterator[Table]:
-    with get_db() as db:
-        yield db.table("identities")
-
-
-@contextmanager
-def terminals_table() -> Iterator[Table]:
-    with get_db() as db:
-        yield db.table("terminals")
-
-
-@contextmanager
-def peers_table() -> Iterator[Table]:
-    with get_db() as db:
-        yield db.table("peers")
-
-
-@contextmanager
-def backups_table() -> Iterator[Table]:
-    with get_db() as db:
-        yield db.table("backups")
-
-
-@contextmanager
-def tours_table() -> Iterator[Table]:
-    with get_db() as db:
-        yield db.table("tours")
-
-
-@contextmanager
-def app_usage_track_table() -> Iterator[Table]:
-    with get_db() as db:
-        yield db.table("app_usage_track")
-
-
-def get_value(key: str):
-    with get_db() as db:
-        if result := db.get(Query().key == key):
-            return result["value"]
-        else:
-            raise KeyError(key)
-
-
-def set_value(key: str, value):
-    with get_db() as db:
-        db.upsert(
-            {
-                "key": key,
-                "value": value,
-            },
-            Query().key == key,
-        )
-
-
-def remove_value(key: str):
-    with get_db() as db:
-        removed_ids = db.remove(Query().key == key)
-    return len(removed_ids) > 0
+async def remove_value(key: str) -> bool:
+    async with db_conn() as conn:
+        return await kv_store.remove_value(conn, key)

--- a/shard_core/database/identities.py
+++ b/shard_core/database/identities.py
@@ -43,10 +43,15 @@ async def insert(conn: AsyncConnection, identity: dict):
         )
 
 
+_UPDATABLE_COLUMNS = {"name", "email", "description", "private_key", "is_default"}
+
+
 async def update(conn: AsyncConnection, id: str, data: dict):
     set_clauses = []
     params = {"_id": id}
     for key, value in data.items():
+        if key not in _UPDATABLE_COLUMNS:
+            raise ValueError(f"Invalid column: {key}")
         set_clauses.append(f"{key} = %({key})s")
         params[key] = value
     if not set_clauses:

--- a/shard_core/database/identities.py
+++ b/shard_core/database/identities.py
@@ -1,0 +1,63 @@
+import logging
+from typing import Optional
+
+from psycopg import AsyncConnection
+from psycopg.rows import dict_row
+
+log = logging.getLogger(__name__)
+
+
+async def get_all(conn: AsyncConnection) -> list[dict]:
+    async with conn.cursor(row_factory=dict_row) as cur:
+        await cur.execute("SELECT * FROM identities")
+        return await cur.fetchall()
+
+
+async def get_by_id(conn: AsyncConnection, id: str) -> Optional[dict]:
+    async with conn.cursor(row_factory=dict_row) as cur:
+        await cur.execute("SELECT * FROM identities WHERE id = %(id)s", {"id": id})
+        return await cur.fetchone()
+
+
+async def get_default(conn: AsyncConnection) -> Optional[dict]:
+    async with conn.cursor(row_factory=dict_row) as cur:
+        await cur.execute("SELECT * FROM identities WHERE is_default = TRUE")
+        return await cur.fetchone()
+
+
+async def search_by_name(conn: AsyncConnection, name: str) -> list[dict]:
+    async with conn.cursor(row_factory=dict_row) as cur:
+        await cur.execute(
+            "SELECT * FROM identities WHERE name ILIKE %(pattern)s",
+            {"pattern": f"%{name}%"},
+        )
+        return await cur.fetchall()
+
+
+async def insert(conn: AsyncConnection, identity: dict):
+    async with conn.cursor() as cur:
+        await cur.execute(
+            """INSERT INTO identities (id, name, email, description, private_key, is_default)
+               VALUES (%(id)s, %(name)s, %(email)s, %(description)s, %(private_key)s, %(is_default)s)""",
+            identity,
+        )
+
+
+async def update(conn: AsyncConnection, id: str, data: dict):
+    set_clauses = []
+    params = {"_id": id}
+    for key, value in data.items():
+        set_clauses.append(f"{key} = %({key})s")
+        params[key] = value
+    if not set_clauses:
+        return
+    sql = f"UPDATE identities SET {', '.join(set_clauses)} WHERE id = %(_id)s"
+    async with conn.cursor() as cur:
+        await cur.execute(sql, params)
+
+
+async def count(conn: AsyncConnection) -> int:
+    async with conn.cursor() as cur:
+        await cur.execute("SELECT COUNT(*) FROM identities")
+        row = await cur.fetchone()
+        return row[0]

--- a/shard_core/database/installed_apps.py
+++ b/shard_core/database/installed_apps.py
@@ -16,7 +16,9 @@ async def get_all(conn: AsyncConnection) -> list[dict]:
 
 async def get_by_name(conn: AsyncConnection, name: str) -> Optional[dict]:
     async with conn.cursor(row_factory=dict_row) as cur:
-        await cur.execute("SELECT * FROM installed_apps WHERE name = %(name)s", {"name": name})
+        await cur.execute(
+            "SELECT * FROM installed_apps WHERE name = %(name)s", {"name": name}
+        )
         return await cur.fetchone()
 
 
@@ -60,13 +62,17 @@ async def update_last_access(conn: AsyncConnection, name: str, last_access: date
 
 async def contains(conn: AsyncConnection, name: str) -> bool:
     async with conn.cursor() as cur:
-        await cur.execute("SELECT 1 FROM installed_apps WHERE name = %(name)s", {"name": name})
+        await cur.execute(
+            "SELECT 1 FROM installed_apps WHERE name = %(name)s", {"name": name}
+        )
         return await cur.fetchone() is not None
 
 
 async def remove(conn: AsyncConnection, name: str):
     async with conn.cursor() as cur:
-        await cur.execute("DELETE FROM installed_apps WHERE name = %(name)s", {"name": name})
+        await cur.execute(
+            "DELETE FROM installed_apps WHERE name = %(name)s", {"name": name}
+        )
 
 
 async def count(conn: AsyncConnection) -> int:

--- a/shard_core/database/installed_apps.py
+++ b/shard_core/database/installed_apps.py
@@ -1,0 +1,76 @@
+import logging
+from datetime import datetime
+from typing import Optional
+
+from psycopg import AsyncConnection
+from psycopg.rows import dict_row
+
+log = logging.getLogger(__name__)
+
+
+async def get_all(conn: AsyncConnection) -> list[dict]:
+    async with conn.cursor(row_factory=dict_row) as cur:
+        await cur.execute("SELECT * FROM installed_apps")
+        return await cur.fetchall()
+
+
+async def get_by_name(conn: AsyncConnection, name: str) -> Optional[dict]:
+    async with conn.cursor(row_factory=dict_row) as cur:
+        await cur.execute("SELECT * FROM installed_apps WHERE name = %(name)s", {"name": name})
+        return await cur.fetchone()
+
+
+async def insert(conn: AsyncConnection, app: dict):
+    async with conn.cursor() as cur:
+        await cur.execute(
+            """INSERT INTO installed_apps (name, installation_reason, status, last_access)
+               VALUES (%(name)s, %(installation_reason)s, %(status)s, %(last_access)s)""",
+            app,
+        )
+
+
+async def update_status(conn: AsyncConnection, name: str, status: str) -> int:
+    async with conn.cursor() as cur:
+        await cur.execute(
+            "UPDATE installed_apps SET status = %(status)s WHERE name = %(name)s",
+            {"name": name, "status": status},
+        )
+        return cur.rowcount
+
+
+async def update(conn: AsyncConnection, name: str, data: dict):
+    async with conn.cursor() as cur:
+        await cur.execute(
+            """UPDATE installed_apps
+               SET installation_reason = %(installation_reason)s,
+                   status = %(status)s,
+                   last_access = %(last_access)s
+               WHERE name = %(name)s""",
+            {"name": name, **data},
+        )
+
+
+async def update_last_access(conn: AsyncConnection, name: str, last_access: datetime):
+    async with conn.cursor() as cur:
+        await cur.execute(
+            "UPDATE installed_apps SET last_access = %(last_access)s WHERE name = %(name)s",
+            {"name": name, "last_access": last_access},
+        )
+
+
+async def contains(conn: AsyncConnection, name: str) -> bool:
+    async with conn.cursor() as cur:
+        await cur.execute("SELECT 1 FROM installed_apps WHERE name = %(name)s", {"name": name})
+        return await cur.fetchone() is not None
+
+
+async def remove(conn: AsyncConnection, name: str):
+    async with conn.cursor() as cur:
+        await cur.execute("DELETE FROM installed_apps WHERE name = %(name)s", {"name": name})
+
+
+async def count(conn: AsyncConnection) -> int:
+    async with conn.cursor() as cur:
+        await cur.execute("SELECT COUNT(*) FROM installed_apps")
+        row = await cur.fetchone()
+        return row[0]

--- a/shard_core/database/kv_store.py
+++ b/shard_core/database/kv_store.py
@@ -8,7 +8,9 @@ log = logging.getLogger(__name__)
 
 async def get_value(conn: AsyncConnection, key: str):
     async with conn.cursor() as cur:
-        await cur.execute("SELECT value FROM kv_store WHERE key = %(key)s", {"key": key})
+        await cur.execute(
+            "SELECT value FROM kv_store WHERE key = %(key)s", {"key": key}
+        )
         row = await cur.fetchone()
         if row:
             return row[0]

--- a/shard_core/database/kv_store.py
+++ b/shard_core/database/kv_store.py
@@ -1,0 +1,31 @@
+import logging
+
+from psycopg import AsyncConnection
+from psycopg.types.json import Jsonb
+
+log = logging.getLogger(__name__)
+
+
+async def get_value(conn: AsyncConnection, key: str):
+    async with conn.cursor() as cur:
+        await cur.execute("SELECT value FROM kv_store WHERE key = %(key)s", {"key": key})
+        row = await cur.fetchone()
+        if row:
+            return row[0]
+        raise KeyError(key)
+
+
+async def set_value(conn: AsyncConnection, key: str, value):
+    async with conn.cursor() as cur:
+        await cur.execute(
+            """INSERT INTO kv_store (key, value)
+               VALUES (%(key)s, %(value)s)
+               ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value""",
+            {"key": key, "value": Jsonb(value)},
+        )
+
+
+async def remove_value(conn: AsyncConnection, key: str) -> bool:
+    async with conn.cursor() as cur:
+        await cur.execute("DELETE FROM kv_store WHERE key = %(key)s", {"key": key})
+        return cur.rowcount > 0

--- a/shard_core/database/migration.py
+++ b/shard_core/database/migration.py
@@ -1,0 +1,25 @@
+import logging
+from pathlib import Path
+
+import gconf
+import psycopg
+from yoyo import get_backend
+from yoyo import read_migrations
+
+log = logging.getLogger(__name__)
+
+
+def migrate():
+    db = gconf.get("db")
+    conn_string = f"postgresql+psycopg://{db['user']}:{db['password']}@{db['host']}:{db['port']}/{db['dbname']}"
+    try:
+        backend = get_backend(conn_string)
+    except psycopg.OperationalError as e:
+        log.exception(f"failed to connect to {conn_string}", e)
+        raise e
+    migrations_path = Path.cwd() / "migrations"
+    migrations = read_migrations(str(migrations_path))
+    log.debug(f"Reading migrations: {migrations}")
+    with backend.lock():
+        backend.apply_migrations(backend.to_apply(migrations))
+    log.debug("Migration applied")

--- a/shard_core/database/peers.py
+++ b/shard_core/database/peers.py
@@ -1,0 +1,88 @@
+import logging
+from typing import Optional
+
+from psycopg import AsyncConnection
+from psycopg.rows import dict_row
+
+log = logging.getLogger(__name__)
+
+
+async def get_all(conn: AsyncConnection) -> list[dict]:
+    async with conn.cursor(row_factory=dict_row) as cur:
+        await cur.execute("SELECT * FROM peers")
+        return await cur.fetchall()
+
+
+async def get_by_id_prefix(conn: AsyncConnection, id_prefix: str) -> Optional[dict]:
+    async with conn.cursor(row_factory=dict_row) as cur:
+        await cur.execute(
+            "SELECT * FROM peers WHERE id LIKE %(pattern)s LIMIT 1",
+            {"pattern": f"{id_prefix}:%"},
+        )
+        return await cur.fetchone()
+
+
+async def search_by_name(conn: AsyncConnection, name: str) -> list[dict]:
+    async with conn.cursor(row_factory=dict_row) as cur:
+        await cur.execute(
+            "SELECT * FROM peers WHERE name ILIKE %(pattern)s",
+            {"pattern": f"%{name}%"},
+        )
+        return await cur.fetchall()
+
+
+async def insert(conn: AsyncConnection, peer: dict):
+    async with conn.cursor() as cur:
+        await cur.execute(
+            """INSERT INTO peers (id, name, public_bytes_b64, is_reachable)
+               VALUES (%(id)s, %(name)s, %(public_bytes_b64)s, %(is_reachable)s)""",
+            peer,
+        )
+
+
+async def upsert(conn: AsyncConnection, peer: dict):
+    async with conn.cursor() as cur:
+        await cur.execute(
+            """INSERT INTO peers (id, name, public_bytes_b64, is_reachable)
+               VALUES (%(id)s, %(name)s, %(public_bytes_b64)s, %(is_reachable)s)
+               ON CONFLICT (id) DO UPDATE SET
+                   name = EXCLUDED.name,
+                   public_bytes_b64 = EXCLUDED.public_bytes_b64,
+                   is_reachable = EXCLUDED.is_reachable""",
+            peer,
+        )
+
+
+async def update_by_id(conn: AsyncConnection, id: str, data: dict):
+    set_clauses = []
+    params = {"_id": id}
+    for key, value in data.items():
+        set_clauses.append(f"{key} = %({key})s")
+        params[key] = value
+    if not set_clauses:
+        return
+    sql = f"UPDATE peers SET {', '.join(set_clauses)} WHERE id = %(_id)s"
+    async with conn.cursor() as cur:
+        await cur.execute(sql, params)
+
+
+async def update_by_id_prefix(conn: AsyncConnection, id_prefix: str, data: dict):
+    set_clauses = []
+    params = {"_pattern": f"{id_prefix}:%"}
+    for key, value in data.items():
+        set_clauses.append(f"{key} = %({key})s")
+        params[key] = value
+    if not set_clauses:
+        return
+    sql = f"UPDATE peers SET {', '.join(set_clauses)} WHERE id LIKE %(_pattern)s"
+    async with conn.cursor() as cur:
+        await cur.execute(sql, params)
+
+
+async def remove_by_id_prefix(conn: AsyncConnection, id_prefix: str) -> int:
+    async with conn.cursor() as cur:
+        await cur.execute(
+            "DELETE FROM peers WHERE id LIKE %(pattern)s",
+            {"pattern": f"{id_prefix}:%"},
+        )
+        return cur.rowcount

--- a/shard_core/database/peers.py
+++ b/shard_core/database/peers.py
@@ -53,10 +53,15 @@ async def upsert(conn: AsyncConnection, peer: dict):
         )
 
 
+_UPDATABLE_COLUMNS = {"name", "public_bytes_b64", "is_reachable"}
+
+
 async def update_by_id(conn: AsyncConnection, id: str, data: dict):
     set_clauses = []
     params = {"_id": id}
     for key, value in data.items():
+        if key not in _UPDATABLE_COLUMNS:
+            raise ValueError(f"Invalid column: {key}")
         set_clauses.append(f"{key} = %({key})s")
         params[key] = value
     if not set_clauses:
@@ -70,6 +75,8 @@ async def update_by_id_prefix(conn: AsyncConnection, id_prefix: str, data: dict)
     set_clauses = []
     params = {"_pattern": f"{id_prefix}:%"}
     for key, value in data.items():
+        if key not in _UPDATABLE_COLUMNS:
+            raise ValueError(f"Invalid column: {key}")
         set_clauses.append(f"{key} = %({key})s")
         params[key] = value
     if not set_clauses:

--- a/shard_core/database/terminals.py
+++ b/shard_core/database/terminals.py
@@ -1,0 +1,60 @@
+import logging
+from datetime import datetime
+from typing import Optional
+
+from psycopg import AsyncConnection
+from psycopg.rows import dict_row
+
+log = logging.getLogger(__name__)
+
+
+async def get_all(conn: AsyncConnection) -> list[dict]:
+    async with conn.cursor(row_factory=dict_row) as cur:
+        await cur.execute("SELECT * FROM terminals")
+        return await cur.fetchall()
+
+
+async def get_by_id(conn: AsyncConnection, id: str) -> Optional[dict]:
+    async with conn.cursor(row_factory=dict_row) as cur:
+        await cur.execute("SELECT * FROM terminals WHERE id = %(id)s", {"id": id})
+        return await cur.fetchone()
+
+
+async def get_by_name(conn: AsyncConnection, name: str) -> Optional[dict]:
+    async with conn.cursor(row_factory=dict_row) as cur:
+        await cur.execute("SELECT * FROM terminals WHERE name = %(name)s", {"name": name})
+        return await cur.fetchone()
+
+
+async def insert(conn: AsyncConnection, terminal: dict):
+    async with conn.cursor() as cur:
+        await cur.execute(
+            """INSERT INTO terminals (id, name, icon, last_connection)
+               VALUES (%(id)s, %(name)s, %(icon)s, %(last_connection)s)""",
+            terminal,
+        )
+
+
+async def update(conn: AsyncConnection, id: str, data: dict):
+    set_clauses = []
+    params = {"_id": id}
+    for key, value in data.items():
+        set_clauses.append(f"{key} = %({key})s")
+        params[key] = value
+    if not set_clauses:
+        return
+    sql = f"UPDATE terminals SET {', '.join(set_clauses)} WHERE id = %(_id)s"
+    async with conn.cursor() as cur:
+        await cur.execute(sql, params)
+
+
+async def remove(conn: AsyncConnection, id: str):
+    async with conn.cursor() as cur:
+        await cur.execute("DELETE FROM terminals WHERE id = %(id)s", {"id": id})
+
+
+async def count(conn: AsyncConnection) -> int:
+    async with conn.cursor() as cur:
+        await cur.execute("SELECT COUNT(*) FROM terminals")
+        row = await cur.fetchone()
+        return row[0]

--- a/shard_core/database/terminals.py
+++ b/shard_core/database/terminals.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import datetime
 from typing import Optional
 
 from psycopg import AsyncConnection
@@ -22,7 +21,9 @@ async def get_by_id(conn: AsyncConnection, id: str) -> Optional[dict]:
 
 async def get_by_name(conn: AsyncConnection, name: str) -> Optional[dict]:
     async with conn.cursor(row_factory=dict_row) as cur:
-        await cur.execute("SELECT * FROM terminals WHERE name = %(name)s", {"name": name})
+        await cur.execute(
+            "SELECT * FROM terminals WHERE name = %(name)s", {"name": name}
+        )
         return await cur.fetchone()
 
 

--- a/shard_core/database/terminals.py
+++ b/shard_core/database/terminals.py
@@ -36,10 +36,15 @@ async def insert(conn: AsyncConnection, terminal: dict):
         )
 
 
+_UPDATABLE_COLUMNS = {"name", "icon", "last_connection"}
+
+
 async def update(conn: AsyncConnection, id: str, data: dict):
     set_clauses = []
     params = {"_id": id}
     for key, value in data.items():
+        if key not in _UPDATABLE_COLUMNS:
+            raise ValueError(f"Invalid column: {key}")
         set_clauses.append(f"{key} = %({key})s")
         params[key] = value
     if not set_clauses:

--- a/shard_core/database/tours.py
+++ b/shard_core/database/tours.py
@@ -1,0 +1,34 @@
+import logging
+from typing import Optional
+
+from psycopg import AsyncConnection
+from psycopg.rows import dict_row
+
+log = logging.getLogger(__name__)
+
+
+async def get_all(conn: AsyncConnection) -> list[dict]:
+    async with conn.cursor(row_factory=dict_row) as cur:
+        await cur.execute("SELECT * FROM tours")
+        return await cur.fetchall()
+
+
+async def get_by_name(conn: AsyncConnection, name: str) -> Optional[dict]:
+    async with conn.cursor(row_factory=dict_row) as cur:
+        await cur.execute("SELECT * FROM tours WHERE name = %(name)s", {"name": name})
+        return await cur.fetchone()
+
+
+async def upsert(conn: AsyncConnection, tour: dict):
+    async with conn.cursor() as cur:
+        await cur.execute(
+            """INSERT INTO tours (name, status)
+               VALUES (%(name)s, %(status)s)
+               ON CONFLICT (name) DO UPDATE SET status = EXCLUDED.status""",
+            tour,
+        )
+
+
+async def truncate(conn: AsyncConnection):
+    async with conn.cursor() as cur:
+        await cur.execute("DELETE FROM tours")

--- a/shard_core/service/app_installation/worker.py
+++ b/shard_core/service/app_installation/worker.py
@@ -9,9 +9,9 @@ from typing import Literal
 import gconf
 import httpx
 from pydantic import BaseModel
-from tinydb import Query
 
-from shard_core.database.database import installed_apps_table
+from shard_core.database.connection import db_conn
+from shard_core.database import installed_apps as installed_apps_db
 from shard_core.data_model.app_meta import Status
 from shard_core.service.app_tools import (
     get_installed_apps_path,
@@ -94,36 +94,36 @@ installation_worker = InstallationWorker()
 
 
 async def _install_app_from_store(app_name: str):
-    installed_app = get_app_from_db(app_name)
+    installed_app = await get_app_from_db(app_name)
     assert_app_status(installed_app, Status.INSTALLATION_QUEUED)
-    update_app_status(installed_app.name, Status.INSTALLING)
+    await update_app_status(installed_app.name, Status.INSTALLING)
     try:
         zip_file = await _download_app_zip(installed_app.name)
         await _install_app_from_zip(installed_app, zip_file)
-        update_app_status(installed_app.name, Status.STOPPED)
+        await update_app_status(installed_app.name, Status.STOPPED)
     except Exception as e:
-        update_app_status(installed_app.name, Status.ERROR, message=repr(e))
+        await update_app_status(installed_app.name, Status.ERROR, message=repr(e))
         signals.on_app_install_error.send((e, app_name))
 
 
 async def _install_app_from_existing_zip(app_name: str):
-    installed_app = get_app_from_db(app_name)
+    installed_app = await get_app_from_db(app_name)
     assert_app_status(installed_app, Status.INSTALLATION_QUEUED)
-    update_app_status(installed_app.name, Status.INSTALLING)
+    await update_app_status(installed_app.name, Status.INSTALLING)
     try:
         zip_file = (
             get_installed_apps_path() / installed_app.name / f"{installed_app.name}.zip"
         )
         await _install_app_from_zip(installed_app, zip_file)
-        update_app_status(installed_app.name, Status.STOPPED)
+        await update_app_status(installed_app.name, Status.STOPPED)
     except Exception as e:
-        update_app_status(installed_app.name, Status.ERROR, message=repr(e))
+        await update_app_status(installed_app.name, Status.ERROR, message=repr(e))
         signals.on_app_install_error.send((e, app_name))
 
 
 async def _uninstall_app(app_name: str):
     try:
-        update_app_status(app_name, Status.UNINSTALLING)
+        await update_app_status(app_name, Status.UNINSTALLING)
     except KeyError:
         log.warning(f"during uninstallation of {app_name}: app not found in database")
 
@@ -136,17 +136,17 @@ async def _uninstall_app(app_name: str):
     log.debug(f"deleting app data for {app_name}")
     shutil.rmtree(Path(get_installed_apps_path() / app_name), ignore_errors=True)
     log.debug(f"removing app {app_name} from database")
-    with installed_apps_table() as installed_apps:
-        installed_apps.remove(Query().name == app_name)
+    async with db_conn() as conn:
+        await installed_apps_db.remove(conn, app_name)
     await write_traefik_dyn_config()
     signals.on_apps_update.send()
     log.info(f"uninstalled {app_name}")
 
 
 async def _reinstall_app(app_name: str):
-    installed_app = get_app_from_db(app_name)
+    installed_app = await get_app_from_db(app_name)
     assert_app_status(installed_app, Status.REINSTALLATION_QUEUED)
-    update_app_status(installed_app.name, Status.REINSTALLING)
+    await update_app_status(installed_app.name, Status.REINSTALLING)
 
     try:
         await docker_stop_app(app_name, set_status=False)
@@ -160,9 +160,9 @@ async def _reinstall_app(app_name: str):
     try:
         zip_file = await _download_app_zip(installed_app.name)
         await _install_app_from_zip(installed_app, zip_file)
-        update_app_status(installed_app.name, Status.STOPPED)
+        await update_app_status(installed_app.name, Status.STOPPED)
     except Exception as e:
-        update_app_status(installed_app.name, Status.ERROR, message=repr(e))
+        await update_app_status(installed_app.name, Status.ERROR, message=repr(e))
         signals.on_app_install_error.send((e, app_name))
 
 

--- a/shard_core/service/app_tools.py
+++ b/shard_core/service/app_tools.py
@@ -4,10 +4,10 @@ import logging
 from pathlib import Path
 
 import gconf
-from tinydb import Query
 
 import shard_core.data_model.profile
-from shard_core.database.database import installed_apps_table
+from shard_core.database.connection import db_conn
+from shard_core.database import installed_apps as installed_apps_db
 from shard_core.data_model.app_meta import (
     Status,
     AppMeta,
@@ -30,60 +30,62 @@ async def docker_create_app_containers(name: str):
 
 @throttle(5)
 async def docker_start_app(name: str):
-    with installed_apps_table() as installed_apps:
-        # todo: think more about how to handle different states
-        app_status = installed_apps.get(Query().name == name)["status"]
+    async with db_conn() as conn:
+        app_row = await installed_apps_db.get_by_name(conn, name)
+        app_status = app_row["status"] if app_row else None
 
     if app_status in [Status.STOPPED, Status.RUNNING, Status.DOWN]:
         log.debug(f"starting app {name=}")
         await subprocess(
             "docker-compose", "up", "-d", cwd=get_installed_apps_path() / name
         )
-        with installed_apps_table() as installed_apps:
-            installed_apps.update({"status": Status.RUNNING}, Query().name == name)
+        async with db_conn() as conn:
+            await installed_apps_db.update_status(conn, name, Status.RUNNING)
         signals.on_apps_update.send()
     else:
         log.debug(f"app {name=} has status {app_status}, skipping start")
 
 
 async def docker_stop_app(name: str, set_status: bool = True):
-    with installed_apps_table() as installed_apps:
-        # todo: think more about how to handle different states
-        app_status = installed_apps.get(Query().name == name)["status"]
+    async with db_conn() as conn:
+        app_row = await installed_apps_db.get_by_name(conn, name)
+        app_status = app_row["status"] if app_row else None
     if app_status in [Status.RUNNING, Status.UNINSTALLING]:
         await subprocess("docker-compose", "stop", cwd=get_installed_apps_path() / name)
         if set_status:
-            with installed_apps_table() as installed_apps:
-                installed_apps.update({"status": Status.STOPPED}, Query().name == name)
+            async with db_conn() as conn:
+                await installed_apps_db.update_status(conn, name, Status.STOPPED)
         signals.on_apps_update.send()
     else:
         log.debug(f"app {name=} has {app_status=}, skipping stop")
 
 
 async def docker_shutdown_app(name: str, set_status: bool = True, force: bool = False):
-    with installed_apps_table() as installed_apps:
-        # todo: think more about how to handle different states
-        app_status = installed_apps.get(Query().name == name)["status"]
+    async with db_conn() as conn:
+        app_row = await installed_apps_db.get_by_name(conn, name)
+        app_status = app_row["status"] if app_row else None
     if force or app_status in [Status.STOPPED, Status.UNINSTALLING]:
         await subprocess("docker-compose", "down", cwd=get_installed_apps_path() / name)
         if set_status:
-            with installed_apps_table() as installed_apps:
-                installed_apps.update({"status": Status.DOWN}, Query().name == name)
+            async with db_conn() as conn:
+                await installed_apps_db.update_status(conn, name, Status.DOWN)
         signals.on_apps_update.send()
     else:
         log.debug(f"app {name=} has {app_status=}, skipping shutdown")
 
 
 async def docker_stop_all_apps():
-    with installed_apps_table() as installed_apps:
-        apps = [InstalledApp.parse_obj(a) for a in installed_apps.all()]
+    async with db_conn() as conn:
+        all_apps_rows = await installed_apps_db.get_all(conn)
+    apps = [InstalledApp.parse_obj(a) for a in all_apps_rows]
     tasks = [docker_stop_app(app.name) for app in apps]
     await asyncio.gather(*tasks)
 
 
 async def docker_shutdown_all_apps(force: bool = False):
-    with installed_apps_table() as installed_apps:
-        apps = [InstalledApp.parse_obj(a) for a in installed_apps.all()]
+    async with db_conn() as conn:
+        all_apps_rows = await installed_apps_db.get_all(conn)
+    apps = [InstalledApp.parse_obj(a) for a in all_apps_rows]
     tasks = [docker_shutdown_app(app.name, force=force) for app in apps]
     await asyncio.gather(*tasks)
 
@@ -103,9 +105,9 @@ def get_app_metadata(app_name: str) -> AppMeta:
         raise MetadataNotFound(app_name)
 
 
-def size_is_compatible(app_size) -> bool:
+async def size_is_compatible(app_size) -> bool:
     try:
-        profile = shard_core.data_model.profile.get_profile()
+        profile = await shard_core.data_model.profile.get_profile()
     except KeyError:
         return False
     if profile is None:

--- a/shard_core/service/backup.py
+++ b/shard_core/service/backup.py
@@ -193,7 +193,9 @@ async def get_backup_passphrase(terminal_id: str) -> str:
         time=datetime.datetime.now(datetime.timezone.utc),
         terminal_id=terminal_id,
     )
-    await database.set_value(STORE_KEY_BACKUP_PASSPHRASE_LAST_ACCESS, last_access_info.dict())
+    await database.set_value(
+        STORE_KEY_BACKUP_PASSPHRASE_LAST_ACCESS, last_access_info.dict()
+    )
     return passphrase
 
 

--- a/shard_core/service/backup.py
+++ b/shard_core/service/backup.py
@@ -11,7 +11,8 @@ import gconf
 from requests import HTTPError
 
 from shard_core.database import database
-from shard_core.database.database import backups_table
+from shard_core.database.connection import db_conn
+from shard_core.database import backups as backups_db
 from shard_core.data_model.backup import (
     BackupReport,
     BackupStats,
@@ -27,18 +28,18 @@ STORE_KEY_BACKUP_PASSPHRASE_LAST_ACCESS = "backup_passphrase_last_access"
 BACKUP_IN_PROGESS_LOCK = asyncio.Lock()
 
 COMMAND_TEMPLATE = """
-rclone 
---azureblob-sas-url {sas_token} 
---crypt-password {obscured_password} 
---crypt-remote :azureblob:{container_name} 
-sync {directory} :crypt:{container_name}/{directory} 
+rclone
+--azureblob-sas-url {sas_token}
+--crypt-password {obscured_password}
+--crypt-remote :azureblob:{container_name}
+sync {directory} :crypt:{container_name}/{directory}
 --stats-log-level NOTICE --stats 1000m --use-json-log
 """
 
 CLEARTEXT_COMMAND_TEMPLATE = """
-rclone 
+rclone
 --azureblob-sas-url {sas_token}
-sync {directory} :azureblob:{container_name}/{directory} 
+sync {directory} :azureblob:{container_name}/{directory}
 --stats-log-level NOTICE --stats 1000m --use-json-log
 """
 
@@ -120,8 +121,8 @@ async def backup_directories(
             startTime=overall_start_time,
             endTime=overall_end_time,
         )
-        with backups_table() as table:
-            table.insert(report.dict())
+        async with db_conn() as conn:
+            await backups_db.insert(conn, report.dict())
         log.info("Backup done")
 
 
@@ -156,7 +157,7 @@ async def _backup_directory(
 
 
 async def _get_obscured_passphrase():
-    passphrase = database.get_value(STORE_KEY_BACKUP_PASSPHRASE)
+    passphrase = await database.get_value(STORE_KEY_BACKUP_PASSPHRASE)
     obscured_passphrase = subprocess.run(
         ["rclone", "obscure", passphrase], capture_output=True, text=True
     ).stdout.strip()
@@ -168,31 +169,31 @@ def _get_relative_directory(directory: Path) -> Path:
     return directory.relative_to(path_root)
 
 
-def get_latest_backup_report() -> BackupReport | None:
-    with backups_table() as table:
-        latest_stats = max(table.all(), key=lambda x: x["endTime"], default=None)
+async def get_latest_backup_report() -> BackupReport | None:
+    async with db_conn() as conn:
+        latest_stats = await backups_db.get_latest(conn)
     return BackupReport.parse_obj(latest_stats) if latest_stats else None
 
 
-def ensure_backup_passphrase():
+async def ensure_backup_passphrase():
     try:
-        database.get_value(STORE_KEY_BACKUP_PASSPHRASE)
+        await database.get_value(STORE_KEY_BACKUP_PASSPHRASE)
     except KeyError:
         passphrase_numbers = passphrase_util.generate_passphrase_numbers(10)
         passphrase = passphrase_util.get_passphrase(passphrase_numbers)
-        database.set_value(STORE_KEY_BACKUP_PASSPHRASE, passphrase)
+        await database.set_value(STORE_KEY_BACKUP_PASSPHRASE, passphrase)
         log.info("Generated new backup passphrase")
     else:
         log.info("Backup passphrase already exists")
 
 
-def get_backup_passphrase(terminal_id: str) -> str:
-    passphrase = database.get_value(STORE_KEY_BACKUP_PASSPHRASE)
+async def get_backup_passphrase(terminal_id: str) -> str:
+    passphrase = await database.get_value(STORE_KEY_BACKUP_PASSPHRASE)
     last_access_info = BackupPassphraseLastAccessInfoDB(
         time=datetime.datetime.now(datetime.timezone.utc),
         terminal_id=terminal_id,
     )
-    database.set_value(STORE_KEY_BACKUP_PASSPHRASE_LAST_ACCESS, last_access_info.dict())
+    await database.set_value(STORE_KEY_BACKUP_PASSPHRASE_LAST_ACCESS, last_access_info.dict())
     return passphrase
 
 

--- a/shard_core/service/freeshard_controller.py
+++ b/shard_core/service/freeshard_controller.py
@@ -22,7 +22,7 @@ async def refresh_shared_secret():
     response = await call_freeshard_controller("api/shards/self")
     shard = ShardDb.validate(response.json())
     shared_secret = shard.shared_secret
-    database.set_value(STORE_KEY_FREESHARD_CONTROLLER_SHARED_KEY, shared_secret)
+    await database.set_value(STORE_KEY_FREESHARD_CONTROLLER_SHARED_KEY, shared_secret)
     return shared_secret
 
 
@@ -31,7 +31,7 @@ async def validate_shared_secret(secret: str):
         raise SharedSecretInvalid
 
     try:
-        expected_shared_secret = database.get_value(
+        expected_shared_secret = await database.get_value(
             STORE_KEY_FREESHARD_CONTROLLER_SHARED_KEY
         )
     except KeyError:

--- a/shard_core/service/identity.py
+++ b/shard_core/service/identity.py
@@ -58,8 +58,12 @@ async def enrich_identity_from_profile(_):
         if profile.owner:
             default_row = await identities_db.get_default(conn)
             if default_row:
-                await identities_db.update(conn, default_row["id"], {"name": profile.owner})
+                await identities_db.update(
+                    conn, default_row["id"], {"name": profile.owner}
+                )
         if profile.owner_email:
             default_row = await identities_db.get_default(conn)
             if default_row:
-                await identities_db.update(conn, default_row["id"], {"email": profile.owner_email})
+                await identities_db.update(
+                    conn, default_row["id"], {"email": profile.owner_email}
+                )

--- a/shard_core/service/migration.py
+++ b/shard_core/service/migration.py
@@ -1,33 +1,9 @@
 import logging
 
-from shard_core.database.database import get_db
-from shard_core.service.app_installation import install_app_from_store, AppDoesNotExist
-
 log = logging.getLogger(__name__)
 
 
 async def migrate():
-    with get_db() as db:
-        if "apps" not in db.tables():
-            log.debug("no migration needed")
-            return
-
-        if "apps" in db.tables() and "installed_apps" in db.tables():
-            log.warning(
-                "incomplete migration detected, dropping apps table and skipping migration"
-            )
-            db.drop_table("apps")
-            return
-
-        previously_installed_apps = db.table("apps").all()
-
-    log.info(f'found apps to migrate: {[a["name"] for a in previously_installed_apps]}')
-
-    for app in previously_installed_apps:
-        try:
-            await install_app_from_store(app["name"], app["installation_reason"])
-        except AppDoesNotExist:
-            log.warning(f'app {app["name"]} does not exist in store, skipping')
-
-    with get_db() as db:
-        db.drop_table("apps")
+    # The old TinyDB "apps" -> "installed_apps" table migration is no longer needed
+    # since we now use PostgreSQL with yoyo migrations for schema management.
+    log.debug("no legacy migration needed")

--- a/shard_core/service/pairing.py
+++ b/shard_core/service/pairing.py
@@ -7,10 +7,10 @@ from datetime import datetime, timedelta, timezone
 import gconf
 import jwt
 from pydantic import BaseModel
-from tinydb import Query
 
 from shard_core.database import database
-from shard_core.database.database import terminals_table
+from shard_core.database.connection import db_conn
+from shard_core.database import terminals as terminals_db
 from shard_core.data_model.terminal import Terminal
 
 STORE_KEY_JWT_SECRET = "terminal_jwt_secret"
@@ -25,7 +25,7 @@ class PairingCode(BaseModel):
     valid_until: datetime
 
 
-def make_pairing_code(deadline: int = None):
+async def make_pairing_code(deadline: int = None):
     now = datetime.now(timezone.utc)
     pairing_code = PairingCode(
         code=("".join(random.choices(string.digits, k=6))),
@@ -35,14 +35,14 @@ def make_pairing_code(deadline: int = None):
             seconds=deadline or gconf.get("terminal.pairing code deadline", default=600)
         ),
     )
-    database.set_value(STORE_KEY_PAIRING_CODE, pairing_code.dict())
+    await database.set_value(STORE_KEY_PAIRING_CODE, pairing_code.dict())
     return pairing_code
 
 
-def redeem_pairing_code(incoming_code: str):
+async def redeem_pairing_code(incoming_code: str):
     try:
         existing_pairing_code = PairingCode(
-            **database.get_value(STORE_KEY_PAIRING_CODE)
+            **await database.get_value(STORE_KEY_PAIRING_CODE)
         )
     except KeyError:
         raise InvalidPairingCode("no pairing code was issued yet")
@@ -55,11 +55,11 @@ def redeem_pairing_code(incoming_code: str):
             f"issued code ({existing_pairing_code.code}) is expired"
         )
     else:
-        database.remove_value(STORE_KEY_PAIRING_CODE)
+        await database.remove_value(STORE_KEY_PAIRING_CODE)
 
 
-def create_terminal_jwt(terminal_id, **kwargs) -> str:
-    jwt_secret = _ensure_jwt_secret()
+async def create_terminal_jwt(terminal_id, **kwargs) -> str:
+    jwt_secret = await _ensure_jwt_secret()
     payload = {
         "sub": terminal_id,
         "iat": int(datetime.now(timezone.utc).timestamp()),
@@ -68,37 +68,38 @@ def create_terminal_jwt(terminal_id, **kwargs) -> str:
     return jwt.encode(payload, jwt_secret, algorithm="HS256")
 
 
-def verify_terminal_jwt(token: str = None):
+async def verify_terminal_jwt(token: str = None):
     if not token:
         raise InvalidJwt("Missing JWT")
 
-    jwt_secret = _ensure_jwt_secret()
+    jwt_secret = await _ensure_jwt_secret()
 
     bearer = "Bearer "
     if token.startswith(bearer):
-        token = token[len(bearer) :]
+        token = token[len(bearer):]
 
     try:
         decoded_token = jwt.decode(token, jwt_secret, algorithms=["HS256"])
     except jwt.InvalidTokenError as e:
         raise InvalidJwt from e
 
-    with terminals_table() as terminals:  # type: Table
-        if terminal := terminals.get(Query().id == decoded_token["sub"]):
+    async with db_conn() as conn:
+        terminal = await terminals_db.get_by_id(conn, decoded_token["sub"])
+        if terminal:
             return Terminal(**terminal)
         else:
             raise InvalidJwt
 
 
-def _ensure_jwt_secret():
+async def _ensure_jwt_secret():
     try:
-        database.get_value(STORE_KEY_JWT_SECRET)
+        await database.get_value(STORE_KEY_JWT_SECRET)
     except KeyError:
         jwt_secret = secrets.token_urlsafe(
             gconf.get("terminal.jwt secret length", default=64)
         )
-        database.set_value(STORE_KEY_JWT_SECRET, jwt_secret)
-    return database.get_value(STORE_KEY_JWT_SECRET)
+        await database.set_value(STORE_KEY_JWT_SECRET, jwt_secret)
+    return await database.get_value(STORE_KEY_JWT_SECRET)
 
 
 class InvalidPairingCode(Exception):

--- a/shard_core/service/pairing.py
+++ b/shard_core/service/pairing.py
@@ -76,7 +76,7 @@ async def verify_terminal_jwt(token: str = None):
 
     bearer = "Bearer "
     if token.startswith(bearer):
-        token = token[len(bearer):]
+        token = token[len(bearer) :]
 
     try:
         decoded_token = jwt.decode(token, jwt_secret, algorithms=["HS256"])

--- a/shard_core/service/portal_controller.py
+++ b/shard_core/service/portal_controller.py
@@ -26,13 +26,13 @@ async def refresh_profile() -> profile.Profile | None:
     except HTTPError:
         if response.status_code == 401:
             log.warning("profile not found, setting to None")
-            profile.set_profile(None)
+            await profile.set_profile(None)
             return None
         else:
             raise
     shard = ShardBase.parse_obj(response.json())
     profile_ = profile.Profile.from_shard(shard)
-    profile.set_profile(profile_)
+    await profile.set_profile(profile_)
     log.debug("refreshed profile")
     return profile_
 

--- a/shard_core/service/websocket.py
+++ b/shard_core/service/websocket.py
@@ -138,7 +138,8 @@ async def _send_apps_update_async():
     async with db_conn() as conn:
         all_apps_rows = await installed_apps_db.get_all(conn)
     enriched_apps = [
-        enrich_installed_app_with_meta(InstalledApp.parse_obj(app)) for app in all_apps_rows
+        enrich_installed_app_with_meta(InstalledApp.parse_obj(app))
+        for app in all_apps_rows
     ]
     ws_worker.broadcast_message("apps_update", enriched_apps)
 

--- a/shard_core/web/internal/app_error.py
+++ b/shard_core/web/internal/app_error.py
@@ -24,8 +24,8 @@ router = APIRouter()
 
 
 @router.get("/app_error/{status}")
-def app_error(status: int, request: Request):
-    behaviour = get_splash_behaviour(request)
+async def app_error(status: int, request: Request):
+    behaviour = await get_splash_behaviour(request)
     template = get_template_splash()
     return HTMLResponse(content=template.render(**behaviour.dict()), status_code=status)
 
@@ -39,7 +39,7 @@ class SplashBehaviour(BaseModel):
     do_reload: bool
 
 
-def get_splash_behaviour(request: Request):
+async def get_splash_behaviour(request: Request):
     # todo: add special splash screen for app that is not size compatible
     status_code = int(request.path_params["status"])
     app_name = get_app_name(request)
@@ -57,7 +57,7 @@ def get_splash_behaviour(request: Request):
     if disk.current_disk_usage.disk_space_low:
         behaviour.display_status = "Low Disk Space"
         behaviour.do_reload = False
-    if not size_is_compatible(app_meta.minimum_portal_size):
+    if not await size_is_compatible(app_meta.minimum_portal_size):
         display_size = app_meta.minimum_portal_size.value.upper()
         behaviour.display_status = f"VM too small, need at least {display_size}"
         behaviour.do_reload = False

--- a/shard_core/web/protected/apps.py
+++ b/shard_core/web/protected/apps.py
@@ -6,9 +6,9 @@ from typing import List
 import aiofiles
 from fastapi import APIRouter, status, HTTPException, UploadFile
 from fastapi.responses import Response, StreamingResponse
-from tinydb import Query
 
-from shard_core.database.database import installed_apps_table
+from shard_core.database.connection import db_conn
+from shard_core.database import installed_apps as installed_apps_db
 from shard_core.data_model.app_meta import InstalledAppWithMeta, InstalledApp
 from shard_core.service import app_installation
 from shard_core.service.app_installation.exceptions import (
@@ -30,16 +30,17 @@ router = APIRouter(
 
 
 @router.get("", response_model=List[InstalledAppWithMeta])
-def list_all_apps():
-    with installed_apps_table() as installed_apps:
-        apps = [InstalledApp.parse_obj(app) for app in installed_apps.all()]
+async def list_all_apps():
+    async with db_conn() as conn:
+        all_apps_rows = await installed_apps_db.get_all(conn)
+    apps = [InstalledApp.parse_obj(app) for app in all_apps_rows]
     return [enrich_installed_app_with_meta(app) for app in apps]
 
 
 @router.get("/{name}", response_model=InstalledAppWithMeta)
-def get_app(name: str):
-    with installed_apps_table() as installed_apps:
-        installed_app = installed_apps.get(Query().name == name)
+async def get_app(name: str):
+    async with db_conn() as conn:
+        installed_app = await installed_apps_db.get_by_name(conn, name)
     if installed_app:
         return enrich_installed_app_with_meta(InstalledApp.parse_obj(installed_app))
     raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
@@ -63,9 +64,9 @@ def get_app_icon(name: str):
 @router.delete(
     "/{name}", status_code=status.HTTP_204_NO_CONTENT, response_class=Response
 )
-def uninstall_app(name: str):
+async def uninstall_app(name: str):
     try:
-        app_installation.uninstall_app(name)
+        await app_installation.uninstall_app(name)
     except AppNotInstalled:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail=f"App {name} is not installed"

--- a/shard_core/web/protected/backup.py
+++ b/shard_core/web/protected/backup.py
@@ -31,7 +31,9 @@ async def get_backup_info():
         last_access_info_response = None
     else:
         async with db_conn() as conn:
-            terminal_db = await terminals_db.get_by_id(conn, last_access_info_db.terminal_id)
+            terminal_db = await terminals_db.get_by_id(
+                conn, last_access_info_db.terminal_id
+            )
         terminal_name = (
             Terminal.parse_obj(terminal_db).name if terminal_db else "Unknown"
         )

--- a/shard_core/web/protected/backup.py
+++ b/shard_core/web/protected/backup.py
@@ -1,10 +1,10 @@
 import logging
 
 from fastapi import Header, HTTPException, APIRouter, status
-from tinydb import Query
 
 from shard_core.database import database
-from shard_core.database.database import terminals_table
+from shard_core.database.connection import db_conn
+from shard_core.database import terminals as terminals_db
 from shard_core.data_model.backup import (
     BackupPassphraseResponse,
     BackupInfoResponse,
@@ -25,13 +25,13 @@ router = APIRouter(
 async def get_backup_info():
     try:
         last_access_info_db = BackupPassphraseLastAccessInfoDB.parse_obj(
-            database.get_value(backup.STORE_KEY_BACKUP_PASSPHRASE_LAST_ACCESS)
+            await database.get_value(backup.STORE_KEY_BACKUP_PASSPHRASE_LAST_ACCESS)
         )
     except KeyError:
         last_access_info_response = None
     else:
-        with terminals_table() as terminals:
-            terminal_db = terminals.get(Query().id == last_access_info_db.terminal_id)
+        async with db_conn() as conn:
+            terminal_db = await terminals_db.get_by_id(conn, last_access_info_db.terminal_id)
         terminal_name = (
             Terminal.parse_obj(terminal_db).name if terminal_db else "Unknown"
         )
@@ -40,7 +40,7 @@ async def get_backup_info():
         )
 
     return BackupInfoResponse(
-        last_report=backup.get_latest_backup_report(),
+        last_report=await backup.get_latest_backup_report(),
         last_passphrase_access_info=last_access_info_response,
     )
 
@@ -49,7 +49,7 @@ async def get_backup_info():
 async def get_backup_passphrase(x_ptl_client_id: str = Header(None)):
     if not x_ptl_client_id:
         raise HTTPException(status_code=400, detail="Missing X-Ptl-Client-Id header")
-    passphrase = backup.get_backup_passphrase(x_ptl_client_id)
+    passphrase = await backup.get_backup_passphrase(x_ptl_client_id)
     return BackupPassphraseResponse(passphrase=passphrase)
 
 

--- a/shard_core/web/protected/identities.py
+++ b/shard_core/web/protected/identities.py
@@ -8,9 +8,9 @@ from typing import List
 from fastapi import APIRouter, HTTPException, status
 from fastapi.datastructures import UploadFile
 from fastapi.responses import Response, StreamingResponse
-from tinydb import Query
 
-from shard_core.database.database import identities_table
+from shard_core.database.connection import db_conn
+from shard_core.database import identities as identities_db
 from shard_core.data_model.identity import Identity, OutputIdentity, InputIdentity
 from shard_core.service import identity as identity_service, identity
 from shard_core.service.assets import put_asset
@@ -24,37 +24,39 @@ router = APIRouter(
 
 
 @router.get("", response_model=List[OutputIdentity])
-def list_all_identities(name: str = None):
-    with identities_table() as identities:  # type: Table
+async def list_all_identities(name: str = None):
+    async with db_conn() as conn:
         if name:
-            return identities.search(Query().name.search(name))
+            return await identities_db.search_by_name(conn, name)
         else:
-            return identities.all()
+            return await identities_db.get_all(conn)
 
 
 @router.get("/default", response_model=OutputIdentity)
-def get_default_identity():
-    return identity.get_default_identity()
+async def get_default_identity():
+    return await identity.get_default_identity()
 
 
 @router.get("/{id}", response_model=OutputIdentity)
-def get_identity_by_id(id):
-    with identities_table() as identities:
-        if i := identities.get(Query().id == id):
-            return i
-        else:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+async def get_identity_by_id(id):
+    async with db_conn() as conn:
+        i = await identities_db.get_by_id(conn, id)
+    if i:
+        return i
+    else:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
 
 
 @router.get("/default/avatar")
-def get_default_avatar():
-    default_id = identity.get_default_identity()
-    return get_avatar_by_identity(default_id.id)
+async def get_default_avatar():
+    default_id = await identity.get_default_identity()
+    return await get_avatar_by_identity(default_id.id)
 
 
 @router.get("/{id}/avatar")
-def get_avatar_by_identity(id):
-    i = OutputIdentity.parse_obj(get_identity_by_id(id))
+async def get_avatar_by_identity(id):
+    i_row = await get_identity_by_id(id)
+    i = OutputIdentity.parse_obj(i_row)
 
     try:
         avatar_file = find_avatar_file(i.id)
@@ -67,24 +69,26 @@ def get_avatar_by_identity(id):
 
 
 @router.put("", response_model=OutputIdentity, status_code=status.HTTP_201_CREATED)
-def put_identity(i: InputIdentity):
-    with identities_table() as identities:  # type: Table
+async def put_identity(i: InputIdentity):
+    async with db_conn() as conn:
         if i.id:
-            if identities.get(Query().id == i.id):
-                identities.update(i.dict(exclude_unset=True), Query().id == i.id)
-                return OutputIdentity(**identities.get(Query().id == i.id))
+            existing = await identities_db.get_by_id(conn, i.id)
+            if existing:
+                await identities_db.update(conn, i.id, i.dict(exclude_unset=True))
+                updated = await identities_db.get_by_id(conn, i.id)
+                return OutputIdentity(**updated)
             else:
                 raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
         else:
             new_identity = Identity.create(**i.dict(exclude_unset=True))
-            identities.insert(new_identity.dict())
+            await identities_db.insert(conn, new_identity.dict())
             log.info(f"added {new_identity}")
             return new_identity
 
 
 @router.put("/default/avatar")
 async def put_default_avatar(file: UploadFile):
-    default_id = identity.get_default_identity()
+    default_id = await identity.get_default_identity()
     await put_avatar(default_id.id, file)
 
 
@@ -103,7 +107,8 @@ async def put_avatar(id: str, file: UploadFile):
     else:
         existing_file.unlink()
 
-    i = OutputIdentity.parse_obj(get_identity_by_id(id))
+    i_row = await get_identity_by_id(id)
+    i = OutputIdentity.parse_obj(i_row)
     file_extension = file.filename.split(".")[-1]
     file_path = Path("avatars") / f"{i.id}.{file_extension}"
     put_asset(await file.read(), file_path, overwrite=True)
@@ -111,13 +116,14 @@ async def put_avatar(id: str, file: UploadFile):
 
 @router.delete("/default/avatar", status_code=status.HTTP_200_OK)
 async def delete_default_avatar():
-    default_id = identity.get_default_identity()
+    default_id = await identity.get_default_identity()
     await delete_avatar(default_id.id)
 
 
 @router.delete("/{id}/avatar", status_code=status.HTTP_200_OK)
 async def delete_avatar(id: str):
-    i = OutputIdentity.parse_obj(get_identity_by_id(id))
+    i_row = await get_identity_by_id(id)
+    i = OutputIdentity.parse_obj(i_row)
 
     try:
         avatar_file = find_avatar_file(i.id)
@@ -132,8 +138,8 @@ async def delete_avatar(id: str):
     status_code=status.HTTP_204_NO_CONTENT,
     response_class=Response,
 )
-def make_identity_default(id):
+async def make_identity_default(id):
     try:
-        identity_service.make_default(id)
+        await identity_service.make_default(id)
     except KeyError:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)

--- a/shard_core/web/protected/peers.py
+++ b/shard_core/web/protected/peers.py
@@ -46,7 +46,5 @@ async def delete_peer(id):
     async with db_conn() as conn:
         deleted = await peers_db.remove_by_id_prefix(conn, id)
     if deleted > 1:
-        log.critical(
-            f"during deleting of peer {id}, {deleted} peers were deleted"
-        )
+        log.critical(f"during deleting of peer {id}, {deleted} peers were deleted")
     log.info(f"removed peer {id}")

--- a/shard_core/web/protected/terminals.py
+++ b/shard_core/web/protected/terminals.py
@@ -3,9 +3,9 @@ from typing import List
 
 from fastapi import APIRouter, status, HTTPException
 from fastapi.responses import Response
-from tinydb import Query
 
-from shard_core.database.database import terminals_table
+from shard_core.database.connection import db_conn
+from shard_core.database import terminals as terminals_db
 from shard_core.data_model.terminal import Terminal, InputTerminal
 from shard_core.service import pairing
 from shard_core.service.pairing import PairingCode
@@ -19,37 +19,40 @@ router = APIRouter(
 
 
 @router.get("", response_model=List[Terminal])
-def list_all_terminals():
-    with terminals_table() as terminals:  # type: Table
-        return terminals.all()
+async def list_all_terminals():
+    async with db_conn() as conn:
+        return await terminals_db.get_all(conn)
 
 
 @router.get("/id/{id_}")
-def get_terminal_by_id(id_: str):
-    with terminals_table() as terminals:
-        if t := terminals.get(Query().id == id_):
-            return t
-        else:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+async def get_terminal_by_id(id_: str):
+    async with db_conn() as conn:
+        t = await terminals_db.get_by_id(conn, id_)
+    if t:
+        return t
+    else:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
 
 
 @router.get("/name/{name}", response_model=Terminal)
-def get_terminal_by_name(name: str):
-    with terminals_table() as terminals:
-        if t := terminals.get(Query().name == name):
-            return t
-        else:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+async def get_terminal_by_name(name: str):
+    async with db_conn() as conn:
+        t = await terminals_db.get_by_name(conn, name)
+    if t:
+        return t
+    else:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
 
 
 @router.put("/id/{id_}")
-def edit_terminal(id_: str, terminal: InputTerminal):
-    with terminals_table() as terminals:  # type: Table
-        if t := terminals.get(Query().id == id_):
+async def edit_terminal(id_: str, terminal: InputTerminal):
+    async with db_conn() as conn:
+        t = await terminals_db.get_by_id(conn, id_)
+        if t:
             existing_terminal = Terminal(**t)
             existing_terminal.name = terminal.name
             existing_terminal.icon = terminal.icon
-            terminals.update(existing_terminal.dict(), Query().id == id_)
+            await terminals_db.update(conn, id_, existing_terminal.dict())
             on_terminals_update.send()
         else:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
@@ -58,16 +61,16 @@ def edit_terminal(id_: str, terminal: InputTerminal):
 @router.delete(
     "/id/{id_}", status_code=status.HTTP_204_NO_CONTENT, response_class=Response
 )
-def delete_terminal_by_id(id_: str):
-    with terminals_table() as terminals:  # type: Table
-        terminals.remove(Query().id == id_)
+async def delete_terminal_by_id(id_: str):
+    async with db_conn() as conn:
+        await terminals_db.remove(conn, id_)
     on_terminals_update.send()
 
 
 @router.get(
     "/pairing-code", response_model=PairingCode, status_code=status.HTTP_201_CREATED
 )
-def new_pairing_code(deadline: int = None):
-    pairing_code = pairing.make_pairing_code(deadline=deadline)
+async def new_pairing_code(deadline: int = None):
+    pairing_code = await pairing.make_pairing_code(deadline=deadline)
     log.info("created new terminal pairing code")
     return pairing_code

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  postgres:
+    image: postgres:17
+    environment:
+      - POSTGRES_DB=shard_core_test
+      - POSTGRES_USER=shard_core_test
+      - POSTGRES_PASSWORD=shard_core_test
+    ports:
+      - "5433:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U shard_core_test"]
+      interval: 2s
+      timeout: 5s
+      retries: 10

--- a/tests/test_app_reporting.py
+++ b/tests/test_app_reporting.py
@@ -3,7 +3,8 @@ from datetime import date, timedelta, datetime, time
 
 import responses
 
-from shard_core.database.database import app_usage_track_table
+from shard_core.database.connection import db_conn
+from shard_core.database import app_usage as app_usage_db
 from shard_core.data_model.app_usage import AppUsageTrack, AppUsageReport
 from tests.conftest import requires_test_env
 
@@ -31,12 +32,14 @@ async def test_app_reporting(api_client, requests_mock: responses.RequestsMock):
         installed_apps=["late"],
     )
 
-    with app_usage_track_table() as tracks:
-        tracks.truncate()
-        tracks.insert(included_track_1.dict())
-        tracks.insert(included_track_2.dict())
-        tracks.insert(excluded_track_early.dict())
-        tracks.insert(excluded_track_late.dict())
+    async with db_conn() as conn:
+        # Clear existing tracks
+        async with conn.cursor() as cur:
+            await cur.execute("DELETE FROM app_usage_tracks")
+        await app_usage_db.insert(conn, included_track_1.dict())
+        await app_usage_db.insert(conn, included_track_2.dict())
+        await app_usage_db.insert(conn, excluded_track_early.dict())
+        await app_usage_db.insert(conn, excluded_track_late.dict())
 
     await asyncio.sleep(3.5)  # to trigger reporting
     assert len(requests_mock.calls) >= 1

--- a/tests/test_management_auth.py
+++ b/tests/test_management_auth.py
@@ -12,11 +12,11 @@ from tests.conftest import requires_test_env
 @requires_test_env("full")
 async def test_refresh_shared_secret(api_client: AsyncClient, requests_mock):
     with pytest.raises(KeyError):
-        database.get_value(STORE_KEY_FREESHARD_CONTROLLER_SHARED_KEY)
+        await database.get_value(STORE_KEY_FREESHARD_CONTROLLER_SHARED_KEY)
 
     await freeshard_controller.refresh_shared_secret()
 
-    assert database.get_value(STORE_KEY_FREESHARD_CONTROLLER_SHARED_KEY)
+    assert await database.get_value(STORE_KEY_FREESHARD_CONTROLLER_SHARED_KEY)
 
 
 @requires_test_env("full")

--- a/tests/test_service_init_apps.py
+++ b/tests/test_service_init_apps.py
@@ -24,7 +24,7 @@ async def test_refresh_init_apps_skipped_if_flag_set(db, mocker):
     mock_install.assert_not_called()
 
 
-async def test_refresh_init_apps_installs_on_first_startup(mocker):
+async def test_refresh_init_apps_installs_on_first_startup(db, mocker):
     await database.remove_value(STORE_KEY_INITIAL_APPS_INSTALLED)
     mock_install = mocker.patch(
         "shard_core.service.app_installation.install_app_from_store",

--- a/tests/test_service_init_apps.py
+++ b/tests/test_service_init_apps.py
@@ -11,8 +11,8 @@ from tests.util import wait_until_all_apps_installed
 init_app_conf = {"apps": {"initial_apps": ["filebrowser", "mock_app"]}}
 
 
-async def test_refresh_init_apps_skipped_if_flag_set(mocker):
-    database.set_value(STORE_KEY_INITIAL_APPS_INSTALLED, True)
+async def test_refresh_init_apps_skipped_if_flag_set(db, mocker):
+    await database.set_value(STORE_KEY_INITIAL_APPS_INSTALLED, True)
     mock_install = mocker.patch(
         "shard_core.service.app_installation.install_app_from_store",
         new_callable=AsyncMock,
@@ -25,7 +25,7 @@ async def test_refresh_init_apps_skipped_if_flag_set(mocker):
 
 
 async def test_refresh_init_apps_installs_on_first_startup(mocker):
-    database.remove_value(STORE_KEY_INITIAL_APPS_INSTALLED)
+    await database.remove_value(STORE_KEY_INITIAL_APPS_INSTALLED)
     mock_install = mocker.patch(
         "shard_core.service.app_installation.install_app_from_store",
         new_callable=AsyncMock,
@@ -35,7 +35,7 @@ async def test_refresh_init_apps_installs_on_first_startup(mocker):
         await shard_core.service.app_installation.refresh_init_apps()
 
     assert mock_install.call_count == len(init_app_conf["apps"]["initial_apps"])
-    assert database.get_value(STORE_KEY_INITIAL_APPS_INSTALLED) is True
+    assert await database.get_value(STORE_KEY_INITIAL_APPS_INSTALLED) is True
 
 
 @requires_test_env("full")
@@ -49,7 +49,7 @@ async def test_add_init_app(api_client: AsyncClient):
     }
 
     # Clear the flag so refresh_init_apps() runs again (it was set during startup)
-    database.remove_value(STORE_KEY_INITIAL_APPS_INSTALLED)
+    await database.remove_value(STORE_KEY_INITIAL_APPS_INSTALLED)
 
     with gconf.override_conf(init_app_conf):
         await shard_core.service.app_installation.refresh_init_apps()

--- a/tests/test_terminals.py
+++ b/tests/test_terminals.py
@@ -5,7 +5,6 @@ from starlette import status
 
 from shard_core.data_model.backend.shard_model import ShardDb
 from shard_core.database.connection import db_conn
-from shard_core.database import terminals as terminals_db
 from shard_core.data_model.terminal import Terminal, Icon
 from tests.conftest import requests_mock_context, mock_shard, requires_test_env
 from tests.util import get_pairing_code, add_terminal, pair_new_terminal

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 
 [[package]]
@@ -627,6 +627,18 @@ wheels = [
 ]
 
 [[package]]
+name = "importlib-metadata"
+version = "8.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", size = 27865, upload-time = "2025-12-21T10:00:18.329Z" },
+]
+
+[[package]]
 name = "inflect"
 version = "7.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -900,6 +912,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1c/cd/9b5583936515d085a1bec32b45289ceb53b80d9ce1cea0fef4c782dc41a7/psycopg_binary-3.2.9-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:778588ca9897b6c6bab39b0d3034efff4c5438f5e3bd52fda3914175498202f9", size = 3411439, upload-time = "2025-05-13T16:08:47.321Z" },
     { url = "https://files.pythonhosted.org/packages/45/6b/6f1164ea1634c87956cdb6db759e0b8c5827f989ee3cdff0f5c70e8331f2/psycopg_binary-3.2.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f0d5b3af045a187aedbd7ed5fc513bd933a97aaff78e61c3745b330792c4345b", size = 3477477, upload-time = "2025-05-13T16:08:51.166Z" },
     { url = "https://files.pythonhosted.org/packages/7b/1d/bf54cfec79377929da600c16114f0da77a5f1670f45e0c3af9fcd36879bc/psycopg_binary-3.2.9-cp313-cp313-win_amd64.whl", hash = "sha256:2290bc146a1b6a9730350f695e8b670e1d1feb8446597bed0bbe7c3c30e0abcb", size = 2928009, upload-time = "2025-05-13T16:08:53.67Z" },
+]
+
+[[package]]
+name = "psycopg-pool"
+version = "3.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/56/9a/9470d013d0d50af0da9c4251614aeb3c1823635cab3edc211e3839db0bcf/psycopg_pool-3.3.0.tar.gz", hash = "sha256:fa115eb2860bd88fce1717d75611f41490dec6135efb619611142b24da3f6db5", size = 31606, upload-time = "2025-12-01T11:34:33.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c3/26b8a0908a9db249de3b4169692e1c7c19048a9bc41a4d3209cee7dbb758/psycopg_pool-3.3.0-py3-none-any.whl", hash = "sha256:2e44329155c410b5e8666372db44276a8b1ebd8c90f1c3026ebba40d4bc81063", size = 39995, upload-time = "2025-12-01T11:34:29.761Z" },
 ]
 
 [[package]]
@@ -1246,7 +1270,7 @@ wheels = [
 
 [[package]]
 name = "shard-core"
-version = "0.33.0.dev0"
+version = "0.36.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
@@ -1266,6 +1290,7 @@ dependencies = [
     { name = "httpx" },
     { name = "jinja2" },
     { name = "psycopg", extra = ["binary"] },
+    { name = "psycopg-pool" },
     { name = "pydantic" },
     { name = "pyjwt" },
     { name = "python-gitlab" },
@@ -1273,15 +1298,15 @@ dependencies = [
     { name = "pyyaml" },
     { name = "requests" },
     { name = "requests-http-signature" },
-    { name = "tinydb" },
-    { name = "tinydb-serialization" },
     { name = "uvicorn" },
     { name = "websockets" },
+    { name = "yoyo-migrations" },
 ]
 
 [package.optional-dependencies]
 dev = [
     { name = "aioresponses" },
+    { name = "black" },
     { name = "datamodel-code-generator", extra = ["http"] },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -1302,6 +1327,7 @@ requires-dist = [
     { name = "asgi-lifespan", specifier = "==2.*" },
     { name = "azure-storage-blob" },
     { name = "bitstring" },
+    { name = "black", marker = "extra == 'dev'" },
     { name = "blinker" },
     { name = "cachetools" },
     { name = "croniter" },
@@ -1314,6 +1340,7 @@ requires-dist = [
     { name = "httpx" },
     { name = "jinja2" },
     { name = "psycopg", extras = ["binary"] },
+    { name = "psycopg-pool" },
     { name = "pydantic", specifier = "==1.*" },
     { name = "pyjwt" },
     { name = "pytest", marker = "extra == 'dev'" },
@@ -1328,11 +1355,10 @@ requires-dist = [
     { name = "responses", marker = "extra == 'dev'" },
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "setuptools", marker = "extra == 'dev'" },
-    { name = "tinydb" },
-    { name = "tinydb-serialization" },
     { name = "uvicorn" },
     { name = "websockets" },
     { name = "yappi", marker = "extra == 'dev'" },
+    { name = "yoyo-migrations", extras = ["postgresql-psycopg"] },
 ]
 provides-extras = ["dev"]
 
@@ -1364,6 +1390,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sqlparse"
+version = "0.5.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815, upload-time = "2025-12-19T07:17:45.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138, upload-time = "2025-12-19T07:17:46.573Z" },
+]
+
+[[package]]
 name = "starlette"
 version = "0.46.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1376,24 +1411,12 @@ wheels = [
 ]
 
 [[package]]
-name = "tinydb"
-version = "4.8.2"
+name = "tabulate"
+version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a0/79/4af51e2bb214b6ea58f857c51183d92beba85b23f7ba61c983ab3de56c33/tinydb-4.8.2.tar.gz", hash = "sha256:f7dfc39b8d7fda7a1ca62a8dbb449ffd340a117c1206b68c50b1a481fb95181d", size = 32566, upload-time = "2024-10-12T15:24:01.13Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/fe/802052aecb21e3797b8f7902564ab6ea0d60ff8ca23952079064155d1ae1/tabulate-0.9.0.tar.gz", hash = "sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c", size = 81090, upload-time = "2022-10-06T17:21:48.54Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/17/853354204e1ca022d6b7d011ca7f3206c4f8faa3cc743e92609b49c1d83f/tinydb-4.8.2-py3-none-any.whl", hash = "sha256:f97030ee5cbc91eeadd1d7af07ab0e48ceb04aa63d4a983adbaca4cba16e86c3", size = 24888, upload-time = "2024-10-12T15:23:59.833Z" },
-]
-
-[[package]]
-name = "tinydb-serialization"
-version = "2.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "tinydb" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/87/af/d6bc960eadee5fb4406eaeceec4b7be6ef82676a5f3cf638fd56ecf39448/tinydb_serialization-2.2.0.tar.gz", hash = "sha256:b7e7f2b0cc17350438ba070eeb2f5fcb3a9949c5ff38476379450422de3f935f", size = 4912, upload-time = "2024-10-05T18:50:19.813Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/cd/7e44162c9d3288517b7f19d13932112b6ecef079eec28f8d23997ebbe2c6/tinydb_serialization-2.2.0-py3-none-any.whl", hash = "sha256:02edeafd6560b811c8df3e39792a37dee68ac63978659c214eab593316c58253", size = 5736, upload-time = "2024-10-05T18:50:18.206Z" },
+    { url = "https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl", hash = "sha256:024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f", size = 35252, upload-time = "2022-10-06T17:21:44.262Z" },
 ]
 
 [[package]]
@@ -1623,4 +1646,26 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/24/fd/725b8e73ac2a50e78a4534ac43c6addf5c1c2d65380dd48a9169cc6739a9/yarl-1.20.1-cp313-cp313t-win32.whl", hash = "sha256:b121ff6a7cbd4abc28985b6028235491941b9fe8fe226e6fdc539c977ea1739d", size = 86591, upload-time = "2025-06-10T00:45:25.793Z" },
     { url = "https://files.pythonhosted.org/packages/94/c3/b2e9f38bc3e11191981d57ea08cab2166e74ea770024a646617c9cddd9f6/yarl-1.20.1-cp313-cp313t-win_amd64.whl", hash = "sha256:541d050a355bbbc27e55d906bc91cb6fe42f96c01413dd0f4ed5a5240513874f", size = 93003, upload-time = "2025-06-10T00:45:27.752Z" },
     { url = "https://files.pythonhosted.org/packages/b4/2d/2345fce04cfd4bee161bf1e7d9cdc702e3e16109021035dbb24db654a622/yarl-1.20.1-py3-none-any.whl", hash = "sha256:83b8eb083fe4683c6115795d9fc1cfaf2cbbefb19b3a1cb68f6527460f483a77", size = 46542, upload-time = "2025-06-10T00:46:07.521Z" },
+]
+
+[[package]]
+name = "yoyo-migrations"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "sqlparse" },
+    { name = "tabulate" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/5d/9ef7f808ea955eca9f08043c65bdc81a4694e784c978b24ad72022974a97/yoyo_migrations-9.0.0-py3-none-any.whl", hash = "sha256:fc65d3a6d9449c1c54d64ff2ff98e32a27da356057c60e3471010bfb19ede081", size = 49002, upload-time = "2024-08-10T09:43:50.388Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "3.23.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547, upload-time = "2025-06-08T17:06:39.4Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276, upload-time = "2025-06-08T17:06:38.034Z" },
 ]


### PR DESCRIPTION
## Summary
- Replace TinyDB (JSON file-based) with PostgreSQL using psycopg3 async for all database operations
- Add yoyo-migrations for schema management with a single initial migration creating all 8 tables (installed_apps, identities, terminals, peers, backups, tours, app_usage_tracks, kv_store)
- Convert all service, data model, and web endpoint files from sync TinyDB to async Postgres with per-entity DB modules
- Add Docker Compose postgres service for both production and test environments
- Bridge sync blinker signal handlers to async DB via `asyncio.create_task()`

Closes #25

## Test plan
- [x] All existing tests pass (14 passed, 105 skipped due to TEST_ENV=full requirement)
- [ ] Run full test suite with `TEST_ENV=full` in Docker environment
- [ ] Verify yoyo migration applies cleanly on fresh Postgres
- [ ] Test app installation/uninstallation lifecycle end-to-end
- [ ] Test terminal pairing and identity management

🤖 Generated with [Claude Code](https://claude.com/claude-code)