### PR TITLE
Recover from stale Docker network references on app start

### DIFF
--- a/shard_core/service/app_tools.py
+++ b/shard_core/service/app_tools.py
@@ -36,9 +36,23 @@ async def docker_start_app(name: str):
 
     if app_status in [Status.STOPPED, Status.RUNNING, Status.DOWN]:
         log.debug(f"starting app {name=}")
-        await subprocess(
-            "docker-compose", "up", "-d", cwd=get_installed_apps_path() / name
-        )
+        try:
+            await subprocess(
+                "docker-compose", "up", "-d", cwd=get_installed_apps_path() / name
+            )
+        except SubprocessError as e:
+            if "network" in str(e) and "not found" in str(e):
+                log.warning(
+                    f"stale network reference for app {name=}, recreating containers"
+                )
+                await subprocess(
+                    "docker-compose", "down", cwd=get_installed_apps_path() / name
+                )
+                await subprocess(
+                    "docker-compose", "up", "-d", cwd=get_installed_apps_path() / name
+                )
+            else:
+                raise
         with installed_apps_table() as installed_apps:
             installed_apps.update({"status": Status.RUNNING}, Query().name == name)
         signals.on_apps_update.send()


### PR DESCRIPTION
## Summary

- After a VM reboot (e.g. during a resize), installed app containers can reference a now-deleted portal network ID, causing `docker-compose up -d` to fail with `network ... not found`
- `docker_start_app` now catches this specific error, runs `docker-compose down` to clear stale container state, then retries `up -d`

## Test plan

- [ ] Install an app, simulate a hard reboot (stop Docker daemon, recreate the portal network, restart Docker), verify the app starts cleanly on the next `control_apps` cycle without manual intervention
- [ ] Verify non-network `SubprocessError`s are still re-raised normally