### PR TITLE
Fix zombie processes from healthcheck curl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     curl \
     docker-compose \
     rclone \
+    tini \
     && apt-get clean
 
 # Install Docker
@@ -48,4 +49,5 @@ HEALTHCHECK --start-period=5s --interval=30s --timeout=5s CMD curl -f http://loc
 
 #ENV FLASK_APP=shard_core
 EXPOSE 80
+ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD ["fastapi", "run", "--port", "80", "shard_core/app.py"]


### PR DESCRIPTION
## Summary

- Install `tini` in the Docker image and set it as `ENTRYPOINT`
- `tini` acts as a proper init process (PID 1), reaping zombie child processes automatically

## Background

Docker's `HEALTHCHECK` runs `curl -f http://localhost/public/health` every 30 seconds as a child of PID 1. In the container, PID 1 is the Python FastAPI process, which doesn't call `waitpid()` on its children. Each completed curl exits but isn't reaped, leaving a zombie process. On a live shard this produces ~25 zombies/12.5 minutes, accumulating indefinitely.

## Test plan

- [ ] Build image and run container
- [ ] After a few minutes, verify `docker exec shard_core ps aux | awk '$8=="Z"'` shows no zombies

🤖 Generated with [Claude Code](https://claude.com/claude-code)