### PR TITLE
Fix env var delimiters in self-hosted docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,9 +39,9 @@ services:
     networks:
       - portal
     environment:
-      - FREESHARD_DNS_ZONE=${DNS_ZONE:?}
-      - FREESHARD_TRAEFIK_ACME_EMAIL=user@example.com
-      - FREESHARD_TRAEFIK_DISABLE_SSL=${DISABLE_SSL}
+      - FREESHARD_DNS__ZONE=${DNS_ZONE:?}
+      - FREESHARD_TRAEFIK__ACME_EMAIL=${EMAIL:?}
+      - FREESHARD_TRAEFIK__DISABLE_SSL=${DISABLE_SSL}
       - FREESHARD_PATH_ROOT_HOST=${FREESHARD_DIR:?}
 
   web-terminal:


### PR DESCRIPTION
## Summary

- Fixes broken pydantic-settings env var names in the self-hosted `docker-compose.yml`
- With `env_nested_delimiter="__"`, nested fields require double underscores — single-underscore names were silently ignored, falling back to hardcoded values in `config.toml`
- Also fixes `FREESHARD_TRAEFIK__ACME_EMAIL` which was hardcoded to `user@example.com` instead of reading `${EMAIL}` from `.env`

| Old | Fixed |
|-----|-------|
| `FREESHARD_DNS_ZONE` | `FREESHARD_DNS__ZONE` |
| `FREESHARD_TRAEFIK_ACME_EMAIL=user@example.com` | `FREESHARD_TRAEFIK__ACME_EMAIL=${EMAIL:?}` |
| `FREESHARD_TRAEFIK_DISABLE_SSL` | `FREESHARD_TRAEFIK__DISABLE_SSL` |

The `DNS_ZONE` and `ACME_EMAIL` bugs were particularly impactful for self-hosted setups: a custom domain and email would be silently ignored, with the shard falling back to the `freeshard.cloud` zone and `contact@freeshard.net` email baked into the image's `config.toml`.

## Test plan

- [ ] Self-hosted deployment with a custom `DNS_ZONE` correctly uses the specified domain
- [ ] Self-hosted deployment uses the email from `.env` for SSL certificate requests
- [ ] `DISABLE_SSL=true` works for localhost testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)