### PR TITLE
Fix #58: CronTask silently dies on exception, killing backup permanently

### DIFF
--- a/shard_core/util/async_util.py
+++ b/shard_core/util/async_util.py
@@ -95,4 +95,7 @@ class CronTask(BackgroundTask):
             delta = next_exec - time.time()
             log.debug(f"next execution of cron task {self.name} in {delta:.2f} seconds")
             await asyncio.sleep(delta)
-            await self.func()
+            try:
+                await self.func()
+            except Exception as e:
+                log.error(f"error in cron task {self.name}: {type(e).__name__}({e})")

--- a/tests/test_async_util_periodic.py
+++ b/tests/test_async_util_periodic.py
@@ -38,3 +38,25 @@ async def test_cron():
     await asyncio.sleep(2)
     p.stop()
     assert c.n == 2
+
+
+@requires_test_env("full")
+async def test_cron_continues_after_exception():
+    """CronTask must keep running after the function raises an exception."""
+
+    class FailOnce:
+        def __init__(self):
+            self.n = 0
+
+        async def run(self):
+            self.n += 1
+            if self.n == 1:
+                raise RuntimeError("intentional test error")
+
+    f = FailOnce()
+    p = CronTask(f.run, cron="* * * * * *")
+    p.start()
+    await asyncio.sleep(3)
+    p.stop()
+    # First call raised, but the task should have continued and run at least once more
+    assert f.n >= 2


### PR DESCRIPTION
Closes #58

Wrapped `await self.func()` in `CronTask._run_cron` with a `try/except Exception` block that logs at ERROR level and continues the loop, matching the existing pattern in `PeriodicTask._run_delay`. Also added a test `test_cron_continues_after_exception` verifying the task keeps running after a function raises.