### PR TITLE
Fix #59: Write a marker blob after each backup so the controller can detect backup recency

### DIFF
--- a/shard_core/service/backup.py
+++ b/shard_core/service/backup.py
@@ -7,6 +7,7 @@ import traceback
 from pathlib import Path
 from typing import List
 
+from azure.storage.blob import BlobClient
 from requests import HTTPError
 
 from shard_core.database import database
@@ -123,7 +124,33 @@ async def backup_directories(
         )
         with backups_table() as table:
             table.insert(report.model_dump())
+        _write_marker_blob(container_name, sas_token)
         log.info("Backup done")
+
+
+def _write_marker_blob(container_name: str, sas_token: str):
+    """Write a marker blob to the backup container to record the time of the last backup.
+
+    The blob's Last-Modified timestamp on Azure is updated on every call, giving the
+    controller a reliable recency signal regardless of whether any data blobs changed.
+    """
+    try:
+        # sas_token is a container-level SAS URL of the form:
+        #   https://account.blob.core.windows.net/container?sv=...&sig=...
+        # BlobClient.from_blob_url expects the blob path inserted before the query:
+        #   https://account.blob.core.windows.net/container/_last_backup?sv=...&sig=...
+        from urllib.parse import urlparse, urlunparse
+
+        parsed = urlparse(sas_token)
+        blob_url = urlunparse(
+            parsed._replace(path=f"/{container_name}/_last_backup")
+        )
+        blob_client = BlobClient.from_blob_url(blob_url)
+        timestamp = datetime.datetime.now(datetime.timezone.utc).isoformat()
+        blob_client.upload_blob(timestamp, overwrite=True)
+        log.debug("Wrote _last_backup marker blob")
+    except Exception:
+        log.warning("Failed to write _last_backup marker blob", exc_info=True)
 
 
 def is_backup_in_progress():

--- a/shard_core/service/backup.py
+++ b/shard_core/service/backup.py
@@ -6,6 +6,7 @@ import subprocess
 import traceback
 from pathlib import Path
 from typing import List
+from urllib.parse import urlparse, urlunparse
 
 from azure.storage.blob import BlobClient
 from requests import HTTPError
@@ -139,8 +140,6 @@ def _write_marker_blob(container_name: str, sas_token: str):
         #   https://account.blob.core.windows.net/container?sv=...&sig=...
         # BlobClient.from_blob_url expects the blob path inserted before the query:
         #   https://account.blob.core.windows.net/container/_last_backup?sv=...&sig=...
-        from urllib.parse import urlparse, urlunparse
-
         parsed = urlparse(sas_token)
         blob_url = urlunparse(
             parsed._replace(path=f"/{container_name}/_last_backup")

--- a/uv.lock
+++ b/uv.lock
@@ -1308,7 +1308,7 @@ wheels = [
 
 [[package]]
 name = "shard-core"
-version = "0.36.0"
+version = "0.37.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
Closes #59

Added `_write_marker_blob()` helper to `shard_core/service/backup.py` that writes a small `_last_backup` blob to the Azure backup container after each successful backup. The blob content is the current UTC ISO timestamp. Azure records a fresh `Last-Modified` on every write, giving the controller a reliable recency signal. The write uses `BlobClient.from_blob_url()` constructed from the existing container-level SAS URL already in scope. Failures are caught and logged as warnings without aborting the backup. The pre-existing `test_disk_space_is_reported` test failure is unrelated to this change.