### PR TITLE
Fix: Handle stale container name conflicts when starting apps

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
     image: ghcr.io/freeshardbase/freeshard:0.37.4
     container_name: shard_core
     restart: always
+    stop_grace_period: 30s
     volumes:
       - ${FREESHARD_DIR:?}/core:/core
       - ${FREESHARD_DIR:?}/user_data:/user_data

--- a/shard_core/app_factory.py
+++ b/shard_core/app_factory.py
@@ -30,7 +30,6 @@ from .service.app_installation.util import (
     render_all_docker_compose_templates,
 )
 from .service.app_tools import (
-    docker_stop_all_apps,
     docker_shutdown_all_apps,
     scheduled_docker_prune_images,
 )
@@ -105,7 +104,6 @@ async def lifespan(_):
         t.stop()
     for t in background_tasks:
         await t.wait()
-    await docker_stop_all_apps()
     await docker_shutdown_all_apps(force=True)
 
 

--- a/shard_core/service/app_tools.py
+++ b/shard_core/service/app_tools.py
@@ -51,6 +51,16 @@ async def docker_start_app(name: str):
                 await subprocess(
                     "docker-compose", "up", "-d", cwd=get_installed_apps_path() / name
                 )
+            elif "Conflict" in str(e) and "already in use" in str(e):
+                log.warning(
+                    f"stale containers for app {name=}, removing and recreating"
+                )
+                await subprocess(
+                    "docker-compose", "down", cwd=get_installed_apps_path() / name
+                )
+                await subprocess(
+                    "docker-compose", "up", "-d", cwd=get_installed_apps_path() / name
+                )
             else:
                 raise
         with installed_apps_table() as installed_apps:


### PR DESCRIPTION
## Summary

Fixes the root cause and adds a runtime recovery for stale Docker containers left behind after an unclean `shard_core` shutdown (e.g. during a core version update).

**Root cause:** when a core update replaces the `shard_core` container, Docker sends SIGTERM and waits 10s (default) before SIGKILLing. The lifespan shutdown was running `docker-compose stop` (per app) *then* `docker-compose down` (per app) — double the work, which regularly exceeded the grace period. The process was killed before `docker-compose down` ran, leaving containers stopped-but-not-removed. On next start, `docker-compose up -d` failed with a name conflict.

**Changes:**

1. **`docker-compose.yml`** — add `stop_grace_period: 30s` to the `shard_core` service so Docker waits long enough for the shutdown sequence to complete
2. **`app_factory.py`** — remove the redundant `docker_stop_all_apps()` call; `docker-compose down` (in `docker_shutdown_all_apps`) stops *and* removes containers in one step, so the prior stop pass was wasted time eating into the grace period
3. **`app_tools.py`** — runtime recovery: if `docker-compose up -d` still hits a name conflict (e.g. from a pre-fix deployment), detect the error and recover with `docker-compose down` + retry, mirroring the existing stale-network-reference recovery

## Test plan

- [ ] Trigger a core version update on a shard with apps running; verify no stale containers remain afterwards
- [ ] Manually leave stopped containers in place and trigger app start; verify the conflict recovery log appears and the app comes up cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)