### PR TITLE
fix: increase app install wait timeout to reduce CI flakiness

### DIFF
--- a/tests/util.py
+++ b/tests/util.py
@@ -43,7 +43,7 @@ async def add_terminal(api_client, pairing_code, t_name):
     )
 
 
-async def wait_until_app_installed(api_client: AsyncClient, app_name, timeout=20):
+async def wait_until_app_installed(api_client: AsyncClient, app_name, timeout=60):
     end = time.time() + timeout
     while True:
         if time.time() > end:


### PR DESCRIPTION
## Summary

- `test_peer_auth_basic` failed in the 0.38.0 release pipeline with `TimeoutError` while the PR pipeline passed — same code, different runner load
- Root cause: `wait_until_app_installed` had a 20s timeout with 2s sleep intervals; on a loaded runner, `mock_app` installation exceeded this
- Fix: raise default timeout from 20s to 60s

## Test plan

- [ ] Re-run the failing release pipeline job or trigger CI on this branch
- [ ] Verify `test_peer_auth_basic` passes consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)