### PR TITLE
fix: set shutdown_timeout on LifespanManager to prevent teardown flakiness

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -196,7 +196,7 @@ async def api_client(requests_mock, mocker) -> AsyncGenerator[AsyncClient]:
     async with docker_network_portal():
         app = app_factory.create_app()
         async with (
-            LifespanManager(app, startup_timeout=20),
+            LifespanManager(app, startup_timeout=20, shutdown_timeout=20),
             AsyncClient(
                 transport=ASGITransport(app=app), base_url="https://init", timeout=20
             ) as client,


### PR DESCRIPTION
## Summary

- `test_peer_auth_basic` was erroring in CI with `TimeoutError` **at teardown**, not in the test body
- `LifespanManager` defaults: `startup_timeout=5`, `shutdown_timeout=5`. The fixture overrode `startup_timeout=20` but left `shutdown_timeout` at the 5s default
- On a loaded GitHub runner, the app takes >5s to shut down (background tasks draining), causing `asgi_lifespan` to cancel the shutdown wait and raise `TimeoutError`
- Full traceback: `asyncio.wait_for(AsyncioEvent.wait, timeout=5)` → `CancelledError` → `TimeoutError` in `asgi_lifespan/_concurrency/asyncio.py`

**Note:** PR #64 (increased `wait_until_app_installed` timeout) was a misdiagnosis — that timeout was not in the stack trace. This is the real fix.

## Test plan

- [ ] Trigger CI on this branch and verify `test_peer_auth_basic` passes consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)