### PR TITLE
fix(backup): serialize datetime in directories JSONB

### DIFF
--- a/shard_core/database/backups.py
+++ b/shard_core/database/backups.py
@@ -4,8 +4,10 @@ from psycopg import AsyncConnection
 from psycopg.rows import dict_row
 from psycopg.types.json import Jsonb
 
+from shard_core.data_model.backup import BackupReport
 
-async def insert(conn: AsyncConnection, report: dict) -> dict:
+
+async def insert(conn: AsyncConnection, report: BackupReport) -> dict:
     sql: LiteralString = """INSERT INTO backups (directories, start_time, end_time)
         VALUES (%(directories)s, %(start_time)s, %(end_time)s)
         RETURNING *"""
@@ -13,9 +15,11 @@ async def insert(conn: AsyncConnection, report: dict) -> dict:
         await cur.execute(
             sql,
             {
-                "directories": Jsonb(report["directories"]),
-                "start_time": report["startTime"],
-                "end_time": report["endTime"],
+                "directories": Jsonb(
+                    [d.model_dump(mode="json") for d in report.directories]
+                ),
+                "start_time": report.startTime,
+                "end_time": report.endTime,
             },
         )
         return await cur.fetchone()

--- a/shard_core/service/backup.py
+++ b/shard_core/service/backup.py
@@ -125,7 +125,7 @@ async def backup_directories(
             endTime=overall_end_time,
         )
         async with db_conn() as conn:
-            await db_backups.insert(conn, report.model_dump())
+            await db_backups.insert(conn, report)
         _write_marker_blob(container_name, sas_token)
         log.info("Backup done")
 


### PR DESCRIPTION
## Summary
- Backup job crashed with `TypeError: Object of type datetime is not JSON serializable` when inserting report row.
- Root cause: `Jsonb(...)` uses stdlib `json.dumps`, which can't serialize `datetime`. `BackupStats.startTime`/`endTime` inside `directories` are datetimes.
- Fix: `db_backups.insert` now takes `BackupReport` directly and dumps nested `BackupStats` with `mode="json"` (ISO strings) for the JSONB column, while keeping top-level `startTime`/`endTime` as `datetime` for the timestamp columns.

## Test plan
- [ ] Run daily backup cron, verify row appears in `backups` table with correct `directories` JSON and valid `start_time`/`end_time`.
- [ ] `GET` last backup via existing endpoint — confirm roundtrip parses back into `BackupReport`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)