### PR TITLE
fix(profile): expose volume_size_gb on Profile model

### DIFF
--- a/shard_core/data_model/profile.py
+++ b/shard_core/data_model/profile.py
@@ -20,6 +20,7 @@ class Profile(BaseModel):
     delete_after: Optional[datetime] = None
     vm_size: VMSize
     max_vm_size: Optional[VMSize] = None
+    volume_size_gb: int | None = None
     subscription: Optional[ShardSubscriptionSummary] = None
 
     @classmethod
@@ -35,6 +36,7 @@ class Profile(BaseModel):
             max_vm_size=(
                 VMSize(shard.max_vm_size.value.lower()) if shard.max_vm_size else None
             ),
+            volume_size_gb=getattr(shard, "volume_size_gb", None),
             subscription=getattr(shard, "subscription", None),
         )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -260,6 +260,7 @@ mock_shard = ShardDb(
     status=ShardStatus.ASSIGNED,
     shared_secret="foosecretbar",
     cloud=Cloud.OVHCLOUD,
+    volume_size_gb=30,
 )
 
 

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -39,3 +39,11 @@ async def test_profile_without_subscription_is_none(
     response.raise_for_status()
     profile = Profile.model_validate(response.json())
     assert profile.subscription is None
+
+
+async def test_profile_includes_volume_size_gb(requests_mock, app_client: AsyncClient):
+    response = await app_client.get("protected/management/profile")
+    response.raise_for_status()
+    profile = Profile.model_validate(response.json())
+    assert profile.volume_size_gb == conftest.mock_shard.volume_size_gb
+    assert profile.volume_size_gb == 30


### PR DESCRIPTION
## Summary

- Add `volume_size_gb: int | None` to the `Profile` model and propagate it from `ShardBase` in `Profile.from_shard`.
- Extend `tests/test_profile.py` with a case asserting the field round-trips through `GET /protected/management/profile`.

## Why this matters

This is a prerequisite for web-terminal#20 (Subscription card on the Settings page). The Trial-state "Subscribe — €X/month" button label needs `volume_size_gb` to apply the pricing formula from `landing-page/src/components/Pricing.astro` (disk price per GB × volume size). Without this field, the web terminal can only render a placeholder for the price, producing a degraded UX during the initial billing rollout. `ShardBase` already carries the field, so this is purely a model-surface fix on the shard side.

## Recommended reading order

1. `shard_core/data_model/profile.py` — the model + `from_shard` change.
2. `tests/conftest.py` — `mock_shard` gains `volume_size_gb=30` so the propagation has something to assert against.
3. `tests/test_profile.py` — new `test_profile_includes_volume_size_gb`.

## Test plan

- [x] `test_profile` still passes (existing model-equality assertion).
- [x] `test_profile_includes_subscription` still passes.
- [x] `test_profile_includes_volume_size_gb` — new: asserts `Profile.volume_size_gb == mock_shard.volume_size_gb == 30`.
- [x] `test_signed_call` (uses `Profile.from_shard`) still passes.
- [x] `just cleanup` (ruff + black on `shard_core` and `tests`) clean.
- [ ] Manual: after merging, web-terminal#20 reads `$store.state.profile.volume_size_gb` and renders the Subscribe price label.

Notes
- `from_shard` uses `getattr(shard, "volume_size_gb", None)` for safety against runtime subclasses, mirroring the existing `subscription` field.
- No DB migration needed — `Profile` is stored as JSON via `set_value` in `kv_store`, and the field defaults to `None`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)