### PR TITLE
Fix #93: forward Content-Type in call_backend proxied writes

### DIFF
--- a/shard_core/web/internal/call_backend.py
+++ b/shard_core/web/internal/call_backend.py
@@ -27,8 +27,17 @@ async def call_backend(rest: str, request: Request):
     url = f"{base_url}/{rest}"
 
     body = await request.body()
+    # Forward only the Content-Type so proxied writes reach the controller with
+    # the original media type. Host/Content-Length/signature headers are managed
+    # by requests and the signer. Content-Type is not a signed component, so
+    # forwarding it does not invalidate the signature.
+    content_type = request.headers.get("content-type")
     response = await signed_request(
-        request.method, url, data=body, params=dict(request.query_params)
+        request.method,
+        url,
+        data=body,
+        params=dict(request.query_params),
+        headers={"content-type": content_type} if content_type else None,
     )
 
     log.debug(f"called backend: {url} -> {response.status_code}")

--- a/tests/test_call_backend.py
+++ b/tests/test_call_backend.py
@@ -31,3 +31,19 @@ async def test_call_backend_with_query_strings(requests_mock, app_client):
         if call.request.path_url.startswith(path)
     ][0]
     assert received_request.params == params
+
+
+async def test_call_backend_forwards_content_type(requests_mock, app_client):
+    path = "/api/feedback"
+    response = await app_client.post(
+        f"internal/call_backend{path}",
+        json={"hello": "world"},
+    )
+    response.raise_for_status()
+
+    received_request = [
+        call.request
+        for call in requests_mock.calls
+        if call.request.path_url.startswith(path)
+    ][0]
+    assert received_request.headers["Content-Type"] == "application/json"


### PR DESCRIPTION
## Summary

`shard_core/web/internal/call_backend.py` forwarded the request body to the controller but **dropped the `Content-Type` header**. Because `requests` adds no `Content-Type` for a bytes `data` payload, signed writes reached the controller with no `Content-Type`, and the controller's strict FastAPI parsing (`strict_content_type=True`) then refused to JSON-parse the body → pydantic received raw bytes → HTTP 422. GETs (no body) were unaffected; only POST/PUT writes broke.

## Changes

- `call_backend` now reads the incoming request's `Content-Type` and forwards it via the `headers=` kwarg to `signed_request`. Only `Content-Type` is forwarded — `Host`/`Content-Length`/signature headers remain managed by `requests` and the signer.
- `Content-Type` is **not** a covered signature component (`@method`, `@authority`, `@target-uri`, `date`, `content-digest`), so forwarding it does not invalidate the signature.
- Added `test_call_backend_forwards_content_type`: POSTs JSON through `/internal/call_backend/...` and asserts the on-the-wire request to the controller carries `Content-Type: application/json`.

## Testing

`ruff check` and `black --check` pass on the changed files. The integration test suite requires a PostgreSQL container via Docker, which is unavailable in this environment, so the suite could not be executed here (the two pre-existing `call_backend` tests error identically due to the missing Docker dependency).

Closes #93