### PR TITLE
chore: sync subscription-summary types from controller (get-types)

### DIFF
--- a/shard_core/data_model/backend/shard_model.py
+++ b/shard_core/data_model/backend/shard_model.py
@@ -123,6 +123,8 @@ class ShardSubscriptionSummary(BaseModel):
     price_cents: int
     currency: str
     next_billing_date: datetime | None = None
+    last_payment_failed_at: datetime | None = None
+    ended: datetime | None = None
     payer_email: str | None = None
     pending_vm_size: VmSize | None = None
     pending_price_cents: int | None = None


### PR DESCRIPTION
## What

`just get-types` sync after freeshard-controller#282. Adds `last_payment_failed_at` + `ended` to the copied `ShardSubscriptionSummary`.

## Why

shard_core re-serializes the shard profile through its **own copy** of `ShardSubscriptionSummary` (`profile.py` → `model_dump()`). Without these fields in the copy, they'd be stripped before reaching the web-terminal — so the controller-side addition (#282) is inert until this sync lands.

Generated by `just get-types`; do not hand-edit. **Merge after** controller #282.

Part of the 3-repo subscription-card contract fix (controller → shard_core → web-terminal). Requires a shard_core release so core v12 can bump the shard_core image. Tracks #265.

🤖 Generated with [Claude Code](https://claude.com/claude-code)