### PR TITLE
fix(profile): propagate billing_enabled + paypal client_id/env to the frontend

### DIFF
--- a/shard_core/data_model/backend/shard_model.py
+++ b/shard_core/data_model/backend/shard_model.py
@@ -136,6 +136,9 @@ class ShardResponse(ShardWithPermissions):
     telemetry_start: datetime
     telemetry_end: datetime
     subscription: ShardSubscriptionSummary | None = None
+    billing_enabled: bool = False
+    paypal_client_id: str | None = None
+    paypal_environment: str | None = None  # "sandbox" | "live"
 
 
 class ShardUpdate(BaseModel):

--- a/shard_core/data_model/backend/subscription_model.py
+++ b/shard_core/data_model/backend/subscription_model.py
@@ -55,6 +55,7 @@ class SubscriptionUpdateDb(BaseModel):
 
 
 class SubscribeResponse(BaseModel):
+    subscription_id: str
     approval_url: str
     expected_price_cents: int
 
@@ -63,3 +64,4 @@ class ResizeResponse(BaseModel):
     approval_url: str | None = None
     expected_price_cents: int | None = None
     current_price_cents: int | None = None
+    subscription_id: str | None = None

--- a/shard_core/data_model/profile.py
+++ b/shard_core/data_model/profile.py
@@ -22,6 +22,9 @@ class Profile(BaseModel):
     max_vm_size: Optional[VMSize] = None
     volume_size_gb: int | None = None
     subscription: Optional[ShardSubscriptionSummary] = None
+    billing_enabled: bool = False
+    paypal_client_id: Optional[str] = None
+    paypal_environment: Optional[str] = None
 
     @classmethod
     def from_shard(cls, shard: ShardBase):
@@ -38,6 +41,9 @@ class Profile(BaseModel):
             ),
             volume_size_gb=getattr(shard, "volume_size_gb", None),
             subscription=getattr(shard, "subscription", None),
+            billing_enabled=getattr(shard, "billing_enabled", False),
+            paypal_client_id=getattr(shard, "paypal_client_id", None),
+            paypal_environment=getattr(shard, "paypal_environment", None),
         )
 
 

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -2,10 +2,38 @@ from datetime import datetime, timezone
 
 from httpx import AsyncClient
 
-from shard_core.data_model.backend.shard_model import ShardSubscriptionSummary
+from shard_core.data_model.backend.shard_model import (
+    ShardResponse,
+    ShardSubscriptionSummary,
+)
 from shard_core.data_model.backend.subscription_model import SubscriptionStatus
 from shard_core.data_model.profile import Profile
 from tests import conftest
+
+
+def test_from_shard_carries_billing_fields():
+    now = datetime.now(timezone.utc)
+    shard = ShardResponse(
+        **conftest.mock_shard.model_dump(),
+        telemetry=[],
+        telemetry_start=now,
+        telemetry_end=now,
+        subscription=None,
+        billing_enabled=True,
+        paypal_client_id="cid",
+        paypal_environment="sandbox",
+    )
+    profile = Profile.from_shard(shard)
+    assert profile.billing_enabled is True
+    assert profile.paypal_client_id == "cid"
+    assert profile.paypal_environment == "sandbox"
+
+
+def test_from_shard_defaults_billing_disabled():
+    # A controller that omits the fields (or has billing off) → safe defaults.
+    profile = Profile.from_shard(conftest.mock_shard)
+    assert profile.billing_enabled is False
+    assert profile.paypal_client_id is None
 
 
 async def test_profile(requests_mock, app_client: AsyncClient):


### PR DESCRIPTION
## Symptom

After deploying the in-window PayPal flow, the web-terminal subscription section doesn't render at all — even for a shard with an active subscription. The profile the frontend receives has no `billing_enabled` / `paypal_client_id` / `paypal_environment`, so the gate `v-if billing_enabled` is undefined → section hidden.

## Cause

shard_core drops the new self-view fields in two places:
1. `refresh_profile` does `ShardResponse.model_validate(controller_json)` against shard_core's **copied** `ShardResponse` (which lacked the three fields → pydantic strips them on parse).
2. The hand-written `Profile` model + `from_shard` (a bespoke remap, not auto-synced) also lacked them.

So even though controller#286 returns the fields, they never reach the web-terminal. (Same stripping class as the earlier subscription-summary fix, compounded by `Profile` being hand-mapped.)

## Fix

- `just get-types`: shard_core's `ShardResponse` copy gains `billing_enabled` / `paypal_client_id` / `paypal_environment` (also reconciles `subscription_model`).
- `Profile` model + `from_shard`: carry the three fields, `getattr`-guarded with safe defaults.
- Tests: `from_shard` carries the fields when set; defaults to disabled when absent.

## Release impact

**core v13 must bump the shard_core image too** (not just web-terminal) — this is the shard_core change that was missed. Sequence: cut shard_core release → v13 bundles new shard_core + new web-terminal → controller release → deploy → re-upgrade the trial shard.

## Recommended reading order

1. `shard_core/data_model/profile.py` — Profile model + from_shard mapping
2. `shard_core/data_model/backend/shard_model.py` — get-types'd ShardResponse fields
3. `tests/test_profile.py` — propagation + default tests

Tracks #265.

🤖 Generated with [Claude Code](https://claude.com/claude-code)