### PR TITLE
perf(backup): cut Azure container/list ops in rclone sync

### DIFF
--- a/shard_core/service/backup.py
+++ b/shard_core/service/backup.py
@@ -36,6 +36,7 @@ rclone
 --crypt-remote :azureblob:{container_name}
 sync {directory} :crypt:{container_name}/{directory}
 --create-empty-src-dirs --stats-log-level NOTICE --stats 1000m --use-json-log
+--fast-list --azureblob-no-check-container
 """
 
 CLEARTEXT_COMMAND_TEMPLATE = """
@@ -43,6 +44,7 @@ rclone
 --azureblob-sas-url {sas_token}
 sync {directory} :azureblob:{container_name}/{directory}
 --create-empty-src-dirs --stats-log-level NOTICE --stats 1000m --use-json-log
+--fast-list --azureblob-no-check-container
 """
 
 


### PR DESCRIPTION
## Problem

On the `shardbackupstorage` Azure account, the **"List and Create Container Operations"** meter is the single largest cost line — roughly **3x the actual data-stored cost (~€15/mo)**, ~70% of the account's spend. Nightly-per-shard cadence can't reach that op volume from container creates alone; it's **List Blobs** ops from `rclone sync`.

## Root cause

`shard_core/service/backup.py` runs `rclone sync` once per backup directory (`core`, `user_data`) per shard, nightly (`0 3 * * *`):

1. **No `--fast-list`** → rclone lists the destination **hierarchically**, one List Blobs op *per subdirectory*. `user_data` (app data) is a deep tree, so op count scales with folder-count × shards × 30 nights. This is the bulk of the ~3M ops/month.
2. **No `--azureblob-no-check-container`** → rclone issues a create/check-container op on **every** invocation (2× per shard per night). The controller (`get_backup_sas_url`) already creates the container when minting the SAS — the check is pure waste.

## Fix

Add both flags to `COMMAND_TEMPLATE` and `CLEARTEXT_COMMAND_TEMPLATE`:
- `--fast-list` — single recursive listing (~1 op per 5000 blobs) instead of one-per-directory. Modest extra RAM during listing; blob counts are small.
- `--azureblob-no-check-container` — skip the redundant container check/create.

Read-side / listing change only — `sync` semantics unchanged.

## Expected impact

Drops the dominant cost line by most of its value → total subscription run rate ~€41/mo → **~€26/mo**.

## Test notes

No tests assert the rclone command string. `just cleanup` (ruff/black) could not run — both absent from the env; the change is whitespace inside an existing triple-quoted string, so formatting is unaffected. Verified the new flags tokenize as distinct argv entries under `command.split()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)