### PR TITLE
set version to 0.39.4 (release #108 readTimeout)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "shard_core"
-version = "0.39.3"
+version = "0.39.4"
 description = "Core software stack that manages all aspects of a Shard"
 readme = "README.md"
 license-files = ["LICENSE.md"]


### PR DESCRIPTION
## What

Bump version `0.39.3 → 0.39.4` to cut a release.

## Why

#108 (`fix(traefik): set finite readTimeout on entrypoints`) merged to main on 2026-06-21 but is in **no released image** — latest tag `0.39.3` (2026-06-05) predates it, so **no shard runs the readTimeout** (#111). This bump is the precursor to publishing the `0.39.4` GitHub Release, which `release.yml` builds into `ghcr.io/freeshardbase/freeshard:0.39.4`.

## Follow-up (not in this PR)

1. **Publish the `0.39.4` GitHub Release** (maintainer action) → triggers the image build.
2. Bump the controller core-version compose to `freeshard:0.39.4` (a small follow-up to core v18 / a v19).

## Note

This is now **defence-in-depth**, not the primary fix: the fd-exhaustion root cause is addressed by the traefik `v2.6 → v2.11` bump (controller #322), since v2.11 (Go 1.25) self-raises the nofile ceiling. readTimeout still usefully reaps abandoned connections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
