### PR TITLE
ci: install from the lockfile (uv sync --frozen), not pip install latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,13 +18,11 @@ jobs:
           python-version: '3.13'
       - name: Install dependencies
         run: |
-          python -m venv venv
-          source venv/bin/activate
-          pip install ".[dev]"
+          pip install --break-system-packages uv
+          uv sync --frozen --extra dev
       - name: Run Ruff
         run: |
-          source venv/bin/activate
-          ruff check .
+          uv run ruff check .
 
   unittest:
     runs-on: ubuntu-latest
@@ -36,13 +34,11 @@ jobs:
           python-version: '3.13'
       - name: Install dependencies
         run: |
-          python -m venv venv
-          source venv/bin/activate
-          pip install ".[dev]"
+          pip install --break-system-packages uv
+          uv sync --frozen --extra dev
       - name: Run Pytest
         env:
           CONFIG: tests/config.yml
           TEST_ENV: ${{ inputs.full && 'full' || 'sparse' }}
         run: |
-          source venv/bin/activate
-          pytest tests
+          uv run pytest tests


### PR DESCRIPTION
## What

CI (`ruff` + `unittest`) now installs with **`uv sync --frozen --extra dev`** + `uv run`, instead of `pip install ".[dev]"`.

## Why

`pip install ".[dev]"` ignores `uv.lock` and resolves to latest at run time — non-deterministic, and different from what the image ships (`Dockerfile` already builds with `uv sync --frozen --no-dev`). A fresh `azure-mgmt-resource 26.0.0` broke the *controller's* CI this way today; this repo dodged it only because it has no azure dep. Installing from the lock makes CI reproducible and matches the image. Mirrors freeshard-controller's CI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
