### PR TITLE
fix(backup): drop unsupported rclone flag breaking v18 backups (#117)

### DIFF
--- a/shard_core/service/backup.py
+++ b/shard_core/service/backup.py
@@ -174,6 +174,10 @@ async def _backup_directory(
         stderr=asyncio.subprocess.PIPE,
     )
     stdout, stderr = await process.communicate()
+    if process.returncode != 0:
+        message = stderr.decode().strip()
+        log.error(f"rclone exited with {process.returncode}: {message}")
+        raise BackupFailedError(message)
     try:
         last_entry = stderr.decode().split("\n")[-2]  # last line ends with newline
         rclone_result = json.loads(last_entry)
@@ -224,6 +228,10 @@ async def get_backup_passphrase(terminal_id: str) -> str:
         STORE_KEY_BACKUP_PASSPHRASE_LAST_ACCESS, last_access_info.model_dump()
     )
     return passphrase
+
+
+class BackupFailedError(Exception):
+    pass
 
 
 class BackupInProgressError(Exception):

--- a/shard_core/service/backup.py
+++ b/shard_core/service/backup.py
@@ -36,7 +36,7 @@ rclone
 --crypt-remote :azureblob:{container_name}
 sync {directory} :crypt:{container_name}/{directory}
 --create-empty-src-dirs --stats-log-level NOTICE --stats 1000m --use-json-log
---fast-list --azureblob-no-check-container
+--fast-list
 """
 
 CLEARTEXT_COMMAND_TEMPLATE = """
@@ -44,7 +44,7 @@ rclone
 --azureblob-sas-url {sas_token}
 sync {directory} :azureblob:{container_name}/{directory}
 --create-empty-src-dirs --stats-log-level NOTICE --stats 1000m --use-json-log
---fast-list --azureblob-no-check-container
+--fast-list
 """
 
 

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -1,0 +1,50 @@
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from shard_core.service import backup
+from shard_core.service.backup import (
+    COMMAND_TEMPLATE,
+    CLEARTEXT_COMMAND_TEMPLATE,
+    BackupFailedError,
+    _backup_directory,
+)
+
+
+def test_command_templates_only_use_supported_flags():
+    """Guard against reintroducing rclone flags missing from the bundled binary.
+
+    The core image ships rclone 1.60.1 (Debian bookworm), which lacks
+    --azureblob-no-check-container (added in 1.61.0). See issue #117.
+    """
+    for template in (COMMAND_TEMPLATE, CLEARTEXT_COMMAND_TEMPLATE):
+        assert "--azureblob-no-check-container" not in template
+        assert "--fast-list" in template
+
+
+def _mock_process(returncode, stderr):
+    process = AsyncMock()
+    process.communicate.return_value = (b"", stderr)
+    process.returncode = returncode
+    return process
+
+
+@pytest.mark.asyncio
+async def test_backup_directory_returns_stats_on_success():
+    stats = {"bytes": 42, "errors": 0}
+    stderr = (json.dumps({"stats": stats}) + "\n").encode()
+    process = _mock_process(0, stderr)
+    with patch.object(backup.asyncio, "create_subprocess_exec", return_value=process):
+        result = await _backup_directory("container", "dir", "obscured", "sas")
+    assert result == stats
+
+
+@pytest.mark.asyncio
+async def test_backup_directory_raises_on_nonzero_exit():
+    stderr = b"Error: unknown flag: --azureblob-no-check-container\n"
+    process = _mock_process(1, stderr)
+    with patch.object(backup.asyncio, "create_subprocess_exec", return_value=process):
+        with pytest.raises(BackupFailedError) as exc_info:
+            await _backup_directory("container", "dir", "obscured", "sas")
+    assert "unknown flag: --azureblob-no-check-container" in str(exc_info.value)


### PR DESCRIPTION
Fixes #117 — v18 release blocker: all backups fail with `Fatal error: unknown flag: --azureblob-no-check-container`.

## What
1. **Unblock backups** — drop `--azureblob-no-check-container` from both `COMMAND_TEMPLATE` and `CLEARTEXT_COMMAND_TEMPLATE`. The flag (rclone `azureblob no_check_container`) only exists in rclone ≥1.61.0; the core image bundles 1.60.1 from Debian bookworm apt. `--fast-list` — which delivers the larger List-ops saving that e2071cf targeted — is global and supported by 1.60.1, so it stays. Per maintainer direction in the issue: drop the flag, do not pin the rclone version.
2. **Stop masking errors** — `_backup_directory` ignored rclone's exit code and unconditionally parsed stderr's last line as JSON, so any rclone failure surfaced as `JSONDecodeError` instead of the real cause. Now checks `process.returncode` and raises `BackupFailedError` carrying the decoded stderr.
3. **Regression guard** — new `tests/test_backup.py`: a static check that neither template reintroduces an unsupported flag (CI has no rclone binary, so a live invocation isn't possible), plus two unit tests for `_backup_directory` (stats on success, `BackupFailedError` with stderr on non-zero exit).

## Verification
- New backup tests pass (`pytest tests/test_backup.py` → 3 passed).
- Full suite: 136 passed. The one failure (`test_app_lifecycle::test_app_starts_and_stops`) is a pre-existing docker-timing flake — reproduced on clean `main` with these changes stashed; `app_lifecycle` does not import `backup`.
- ruff + black clean.

## Recommended reading order
1. `shard_core/service/backup.py` — the two-part fix
2. `tests/test_backup.py` — regression guard + unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
