### PR TITLE
Add project skill library under .claude/skills/ (16 skills)

### DIFF
--- a/.claude/skills/freeshard-architecture-contract/SKILL.md
+++ b/.claude/skills/freeshard-architecture-contract/SKILL.md
@@ -1,0 +1,289 @@
+---
+name: freeshard-architecture-contract
+description: Load-bearing design decisions, invariants, and honest weak points of shard_core. Use BEFORE changing anything that touches auth, routing, startup/shutdown order, app status handling, signals, caching, or paths. TRIGGER on "why is there no auth on this route", "add an endpoint", "add a status", "app not starting", edits to app_factory.py, web/internal/auth.py, traefik_dynamic_config.py, app_tools.py, app_lifecycle.py, signals.py, or any question about path_root vs path_root_host, JWT, forwardAuth, or what survives a restart. SKIP for step-by-step how-to-run instructions (use freeshard-run-and-operate), config option catalogs (use freeshard-config-and-flags), protocol theory (use freeshard-domain-reference), or debugging a live symptom (use freeshard-debugging-playbook).
+---
+
+# Freeshard Architecture Contract
+
+The invariants that hold shard_core together, and the places where it is honestly weak.
+shard_core is the FastAPI app that runs on every "shard" (a personal cloud VM). It sits
+behind a Traefik reverse proxy, drives sibling Docker containers ("apps") through the
+mounted docker socket, and stores state in PostgreSQL. Everything below is verified
+against the repo as of 2026-07-03 (branch state: v0.39.2 era).
+
+## 1. The auth model: FastAPI has ZERO auth — Traefik is the gate
+
+**No route handler in `shard_core/web/` carries any auth dependency.** There is no
+`Depends(get_current_user)` anywhere. Enforcement is 100% (a) Traefik forwardAuth
+middlewares and (b) Docker network topology. This is the single most important fact
+about this codebase: an endpoint's security is defined by the Traefik router that fronts
+it, not by its code.
+
+`create_app()` mounts exactly four routers (shard_core/app_factory.py:59-62), with
+prefixes from each package's `__init__.py`: `/internal`, `/public`, `/protected`,
+`/management`. Traefik's dynamic config is compiled in Python
+(shard_core/service/traefik_dynamic_config.py) — external paths `/core/<level>/...`
+have the `/core/` prefix stripped by the `strip` middleware
+(traefik_dynamic_config.py:82-85) before reaching FastAPI.
+
+### The four auth levels
+
+| External route | FastAPI prefix | Traefik middlewares | Enforcement |
+|---|---|---|---|
+| `/core/public/...` | `/public` | `strip`, `auth-public` | NONE. `auth-public` only injects request headers `X-Ptl-Client-Type: public` (+ empty Id/Name) (traefik_dynamic_config.py:106-116) |
+| `/core/protected/...` | `/protected` | `strip`, `auth-private` | forwardAuth → `http://shard_core/internal/authenticate_terminal`: verifies the `authorization` cookie JWT, sets `X-Ptl-Client-{Type,Id,Name}` response headers which Traefik copies onto the request (traefik_dynamic_config.py:87-98; web/internal/auth.py:47-60) |
+| `/core/management/...` | `/management` | `strip`, `auth-management` | forwardAuth → `http://shard_core/internal/authenticate_management`: `authorization` header must equal the controller shared secret in kv_store key `freeshard_controller_shared_key` (min length 8; on miss/mismatch it re-fetches once from the controller via signed `GET api/shards/self`) (web/internal/auth.py:63-71; service/freeshard_controller.py:28-44) |
+| `https://<app>.<domain>/...` (app subdomains) | n/a (proxied to app container) | `app-error`, `auth` | forwardAuth → `http://shard_core/internal/auth` with `authResponseHeadersRegex: ^X-Ptl-.*` (traefik_dynamic_config.py:117-124) — see AuthState below |
+| (not routed) | `/internal` | — | **Unauthenticated by design.** Never routed by Traefik; reachable only inside the `portal` docker network |
+
+### App-subdomain auth (`GET /internal/auth`, web/internal/auth.py:74-179)
+
+Per request to any app, Traefik asks shard_core:
+
+1. Match app by first label of `X-Forwarded-Host` against `installed_apps` (cached, see §6). Unknown app → 404.
+2. Longest-prefix match of `X-Forwarded-Uri` against the app's `app_meta.json` paths.
+3. Compute `AuthState`: valid terminal JWT cookie → `TERMINAL`; else valid RSA HTTP Message Signature (reconstructed from `X-Forwarded-Method/Proto/Host/Uri` headers, service/peer.py:79-106) → `PEER`; else `ANONYMOUS`.
+4. Deny 401 if path access is `private` without TERMINAL, or `peer` without PEER (auth.py:88-100).
+5. Render the path's per-header jinja2 templates with `auth` + `portal` values into response headers; fire `on_request_to_app` (auth.py:102-111) — this signal is what starts idle apps.
+
+Known sharp edge: `_match_path` returns `None` when no path prefix matches, and the
+caller immediately does `path_object.access` → `AttributeError` → 500 from the
+forwardAuth endpoint (auth.py:82-83, 141-147).
+
+### KNOWN WEAKNESS — state it plainly, design around it
+
+Every installed app container joins the same external docker network `portal` as
+shard_core (see tests/mock_app_store/mock_app/docker-compose.yml.template:1-3,16-17).
+shard_core serves plain HTTP on container port 80 with no in-app auth, so **any app
+container can `curl http://shard_core/protected/...` or `/management/...` or
+`/internal/...` directly, bypassing all auth**. Consequences you must respect:
+
+- **Never publish shard_core's port** in docker-compose.yml (it currently has no `ports:` — keep it that way; only Traefik publishes 80/443/8883).
+- **Treat every new endpoint — any router — as app-reachable.** Do not put secrets or destructive operations behind "protected" and assume only the owner can call them; a malicious app can.
+- Header-trusting endpoints inherit this: e.g. `GET /protected/backup/passphrase` trusts the `X-Ptl-Client-Id` request header (web/protected/backup.py), which is only trustworthy when injected by Traefik.
+- The Traefik dashboard runs with `api.insecure: true` (data/traefik.yml) and is likewise reachable unauthenticated from inside the network; its external route `traefik.<domain>` is gated by `auth-private` (traefik_dynamic_config.py:72-78).
+
+This is a known accepted-for-now risk, not an invitation. Nothing in the repo mitigates
+it as of 2026-07-03; if your change widens the blast radius (new secret-returning
+endpoint, new mutating internal route), flag it in the PR.
+
+## 2. Identity and session crypto
+
+**The signing scheme is RSA, not Ed25519.** agents.md claims Ed25519 — that is wrong;
+do not propagate it.
+
+- Keys: RSA-4096, exponent 65537 (shard_core/service/crypto.py:52-57). Raw sign/verify uses PSS padding with MGF1(SHA256)+SHA256 (crypto.py:34-46,79-86).
+- Identity id = human-encoded SHA512 of the public key PEM (crypto.py:29-32). The encoding is 5-bits-per-char over the 32-char alphabet `abcdefghjklnpqrstvwxyz0123456789` (shard_core/service/human_encoding.py:102), giving a **103-char id** (512 bits / 5, zero-padded — verified by computation; some docs say 96, that is wrong).
+- `short_id` = first 6 chars of id (data_model/identity.py:46-47). Shard domain = `id[:dns.prefix_length].lower() + "." + dns.zone` with `prefix_length = 6` (identity.py:58-64) — so the domain is derived from the key hash.
+- Outgoing signed calls: IETF HTTP Message Signatures, `RSA_PSS_SHA512`, `key_id = short_id`, executed via `asyncio.to_thread(requests.request, ...)` (service/signed_call.py:14-30). Incoming peer verification resolves the signer by `keyid` = peer short_id prefix (peer.py:101-106).
+
+**Terminal JWTs (the browser session): HS256, and there is NO `exp` claim.** Payload is
+`{sub: terminal_id, iat}` only (service/pairing.py:59-66). The secret is auto-generated
+(`secrets.token_urlsafe(64)`) and stored in kv_store key `terminal_jwt_secret`
+(pairing.py:92-98). **Revocation = deleting the terminal row**: `verify_terminal_jwt`
+looks up the terminal by `sub` and rejects if the row is gone (pairing.py:84-89). The
+cookie is named `authorization`, httponly+secure, scoped to the shard domain, expiry
+~10 years (web/public/pair.py:42-49 — note the `356`-day typo, harmless). Invariant: if
+you ever add a second way to mint terminal JWTs, it must keep the row-existence check as
+the revocation mechanism, or add `exp` properly.
+
+## 3. Startup and shutdown order (app_factory.py) — a real contract
+
+Two phases. Phase 0 runs at import/`create_app()` time, BEFORE the lifespan:
+
+- `_copy_traefik_static_config()` renders `data/traefik.yml` (or `traefik_no_ssl.yml`) to `{path_root}/core/traefik.yml` (app_factory.py:46-49, 140-157). This resolves the traefik↔shard_core dependency cycle: Traefik's compose service has `depends_on: shard_core: service_healthy`, so the static config exists before Traefik boots (docker-compose.yml:48-50).
+
+Phase 1, the lifespan (app_factory.py:78-108), in order — each step depends on the previous:
+
+| # | Step | Why it must come here |
+|---|---|---|
+| 1 | `database.init_database()` — sync yoyo `migrate()`, open psycopg pool (max_size=20), one-time TinyDB→Postgres import (database/database.py:26-34) | Everything else reads the DB |
+| 2 | `identity.init_default_identity()` — create RSA-4096 default identity if table empty | Steps 3-4 render identity values |
+| 3 | `write_traefik_dyn_config()` — compile per-app routers to `{path_root}/core/traefik_dyn/traefik_dyn.yml` (app_installation/util.py:103-124) | Needs DB + identity |
+| 4 | `render_all_docker_compose_templates()` — re-render every installed app's compose file from its `.template` (util.py:65-75) | Needs identity; must precede any app start |
+| 5 | `login_docker_registries()` (app_installation/__init__.py:123-133, errors logged not raised) | Before any image pull |
+| 6 | `migration.migrate()` — legacy no-op stub (service/migration.py) | — |
+| 7 | `refresh_init_apps()` — first-boot-only ENQUEUE of `apps.initial_apps`, guarded by kv flag `initial_apps_installed` (__init__.py:102-120) | Enqueue only — see deadlock warning |
+| 8 | `ensure_backup_passphrase()` — generate + store passphrase if absent (backup.py:203-212) | — |
+| 9 | `portal_controller.refresh_profile()` wrapped in `try/except (ConnectionError, HTTPError, ValidationError)` (app_factory.py:89-92) | Failure tolerated so self-hosted shards (no controller) still boot. The caught types are `requests` exceptions — swapping the HTTP client under `signed_request` would turn controller outages into boot loops |
+| 10 | Start background tasks (app_factory.py:94-96) — **the InstallationWorker starts only HERE** | See deadlock warning |
+| 11 | `print_welcome_log()` — prints shard URL + first-boot pairing link | — |
+
+**DEADLOCK WARNING:** between steps 7 and 10, installation tasks are queued but nothing
+consumes them. Code inserted in the lifespan must never await installation
+completion before step 10 — it will hang forever. Enqueue is fine; awaiting results is not.
+
+Shutdown (app_factory.py:101-108): stop all background tasks → await them →
+`docker_shutdown_all_apps(force=True)` (compose `down` for every app, status → DOWN) →
+close the DB pool. The compose file's `stop_grace_period: 30s` on shard_core
+(docker-compose.yml:56) exists to let this finish; long-running additions to shutdown
+must fit inside that budget or raise it.
+
+## 4. App Status state machine — "adding a status? audit all six"
+
+`Status` enum (data_model/app_meta.py:29-40): UNKNOWN, INSTALLATION_QUEUED, INSTALLING,
+STOPPED, RUNNING, UNINSTALLATION_QUEUED, UNINSTALLING, REINSTALLATION_QUEUED,
+REINSTALLING, DOWN, ERROR. (`InstalledApp.status` is typed plain `str`, app_meta.py:147
+— the DB column holds the string values.)
+
+Transitions as implemented (single serial in-memory queue, one worker,
+app_installation/worker.py):
+
+- install: row inserted as INSTALLATION_QUEUED → worker asserts it (worker.py:98,111) → INSTALLING → STOPPED on success | ERROR on failure
+- reinstall: any → REINSTALLATION_QUEUED (no precondition) → worker asserts (worker.py:148) → REINSTALLING → STOPPED | ERROR
+- uninstall: any → UNINSTALLATION_QUEUED → UNINSTALLING (**no status assertion**, worker.py:124-128) → row deleted
+- ERROR is escaped only via uninstall or reinstall
+
+The four status **allow-lists** live in shard_core/service/app_tools.py:
+
+| Function | Acts only when status in | Line |
+|---|---|---|
+| `docker_start_app` | STOPPED, RUNNING, DOWN | app_tools.py:36 |
+| `docker_stop_app` | RUNNING, UNINSTALLING | app_tools.py:76 |
+| `docker_shutdown_app` | STOPPED, UNINSTALLING (or `force=True`) | app_tools.py:92 |
+| worker asserts | INSTALLATION_QUEUED / REINSTALLATION_QUEUED | worker.py:98,111,148 |
+
+Plus two **exclusion filters**:
+
+- `write_traefik_dyn_config` skips INSTALLATION_QUEUED and ERROR apps (app_installation/util.py:108,113)
+- `control_apps` (idle lifecycle) skips INSTALLATION_QUEUED and INSTALLING (service/app_lifecycle.py:45)
+
+**RULE: when adding or repurposing a status, audit all six sites above.** A status
+missing from an allow-list silently no-ops (`log.debug` + skip); a status missing from
+the exclusion filters gets routed/lifecycled while half-installed —
+`write_traefik_dyn_config` calling `get_app_metadata()` on an app with missing files
+raises `MetadataNotFound` inside the lifespan (app_factory.py:83) → potential boot loop.
+
+## 5. Signals discipline (shard_core/util/signals.py, blinker)
+
+Two invariants, both currently honored — preserve them:
+
+1. **Sync/async pairing.** Signals fired with `.send()` (`on_backup_update`, `on_disk_usage_update`, `on_terminal_add`, `on_app_install_error`, `on_peer_auth`) have only sync receivers; signals fired with `await ....send_async()` (`on_apps_update`, `on_terminals_update`, `on_terminal_auth`, `on_request_to_app`, `on_identity_update`, `async_on_first_terminal_add`, `async_on_peer_write`) have async receivers. An async receiver on a sync-sent signal produces a silently un-awaited coroutine — no error, no effect.
+2. **Every `installed_apps` status write must be followed by `await signals.on_apps_update.send_async()`.** Its two receivers are `websocket.send_apps_update` (UI push, service/websocket.py:131) and `auth._invalidate_app_cache` (web/internal/auth.py:42-44). Forgetting it means the forwardAuth endpoint serves **stale auth decisions** (including cached negative lookups → 404s for a freshly installed app) until an unrelated update fires. All existing write paths comply (app_tools.py:67,83,99; app_installation/util.py:54; worker.py:142,172; __init__.py:41,64,80).
+
+Note `on_peer_auth` (auth.py:170) has zero listeners as of 2026-07-03 — dead signal,
+don't build on it without wiring a receiver.
+
+## 6. Auth-path caches exist for a reason (#89)
+
+Traefik forwardAuth fires on **every single request** to every app. When the auth
+endpoint did per-request DB lookups, request bursts exhausted the pool and produced
+batches of 500s — https://github.com/FreeshardBase/freeshard/issues/89 (closed). The
+fix: module-global `_identity_cache` and `_app_cache` in web/internal/auth.py:32-44
+(the app cache also caches `None` for unknown names), invalidated by the
+`on_identity_update` / `on_apps_update` signals, plus pool max_size=20
+(database/connection.py).
+
+**RULE: any new per-request work on the auth path (`/internal/auth`,
+`/internal/authenticate_terminal`) needs a cache with signal-driven invalidation, or it
+recreates #89.** Exceptions that already exist and are tolerated: `on_terminal_auth`
+triggers a `terminals.last_connection` DB write per auth (data_model/terminal.py:42-50),
+and `on_request_to_app` triggers a debounced `last_access` write at most every 60s
+(data_model/app_meta.py:155-168). Don't add more without measuring.
+
+## 7. Path duality: path_root vs path_root_host
+
+Two settings that look interchangeable and are not (mixing them breaks apps):
+
+| Setting | Meaning | Prod value | Use for |
+|---|---|---|---|
+| `path_root` | Path **inside the shard_core container** | `/` (so `/core`, `/user_data`) | Everything shard_core itself reads/writes: installed_apps dir, traefik configs, backup dirs, disk stats |
+| `path_root_host` | Path **on the host VM** | `${FREESHARD_DIR}` via env (docker-compose.yml:67) | ONLY the `fs.*` volume paths rendered into app docker-compose templates (app_installation/util.py:80-86) |
+
+Why: app containers are started by the **host** docker daemon (shard_core drives the
+mounted docker socket), so volume paths in app compose files must be host paths, while
+shard_core sees the same directories through its own bind mounts. In local dev,
+`path_root = "run/"` (local_config.toml). A template rendered with `path_root` mounts a
+path that doesn't exist on the host — the app starts with empty volumes.
+
+## 8. In-memory-only state and what a restart costs
+
+None of the following survives a process restart. Know the consequences before relying
+on any of them:
+
+| State | Location | Restart consequence |
+|---|---|---|
+| Installation queue | `asyncio.Queue` in `InstallationWorker` (worker.py:47) | Queued/in-flight tasks vanish; DB rows stay stranded in *_QUEUED/INSTALLING — **there is no startup reconciliation** (see §10) |
+| App last-access times | `last_access_dict` (app_lifecycle.py:20) | Defaults to 0.0 → **on the first `control_apps` tick after boot, every non-always-on RUNNING app is stopped** (app_lifecycle.py:63-66). The DB `last_access` column is written (debounced) but never consulted by idle-stop — two divergent notions of last access |
+| Telemetry counters | module globals `no_of_requests`, `last_send` (telemetry.py:12-13) | Counts lost (feature default-off anyway) |
+| Disk usage snapshot | `disk.current_disk_usage` module global (disk.py:20) | Starts as `disk_space_low=False` until the first 30s tick |
+| Backup-in-progress lock | `BACKUP_IN_PROGESS_LOCK` (backup.py:30) | A backup interrupted by restart leaves no lock — but also no record of the partial sync |
+| Auth caches | `_identity_cache`, `_app_cache` (auth.py:32-33) | Cold; repopulated on demand — harmless |
+
+If your feature needs restart-surviving state, put it in Postgres (kv_store for
+scalars); do not extend these in-memory structures and assume durability.
+
+## 9. Everything is CWD-relative — run from repo/image root only
+
+- Config files: literal `"config.toml"` / `"local_config.toml"` paths (settings.py:139-152). Wrong CWD = all TOML config silently missing; only required-field ValidationErrors surface.
+- Migrations: `Path.cwd() / "migrations"` (database/migration.py:22). Wrong CWD = yoyo finds **zero** migrations and reports success.
+- `data/` assets: traefik static config template and welcome log read `Path.cwd() / "data" / ...` (app_factory.py:147,177).
+
+In the image, WORKDIR is `/app` and this all works; in dev, `just run-dev` runs from
+repo root. Never `cd` elsewhere before starting shard_core, and never "fix" a path by
+absolutizing just one of these three — they move together.
+
+## 10. Known-weak list — real, current, with receipts
+
+State these plainly in reviews; do not paper over them, and do not silently "fix" them
+inside an unrelated PR (each is its own change, gated by freeshard-change-control).
+All verified 2026-07-03:
+
+| Weakness | Evidence | Status |
+|---|---|---|
+| No startup reconciliation of stranded *_QUEUED / INSTALLING rows; a crash mid-install strands the row forever (manual uninstall works because `_uninstall_app` asserts nothing) | lifespan app_factory.py:78-108 has no such step; worker.py:124-128 | Open, no issue filed |
+| Stranded INSTALLING/UNINSTALLING row + missing files → `MetadataNotFound` raised uncaught in lifespan step 3 → boot loop | app_installation/util.py:110-114 filters only INSTALLATION_QUEUED and ERROR | Open |
+| backup.py blocks the event loop: sync `subprocess.run(["rclone","obscure",...])` (backup.py:186-188) and sync Azure `BlobClient.upload_blob` marker write (backup.py:133-151); rclone command built via `str.split()` breaks on whitespace in SAS URL/paths (backup.py:169) | file:lines cited | Open |
+| Backup task is fire-and-forget with no strong reference — `task` is a local var and the done-callback spawns another unreferenced task (asyncio weak-ref GC footgun); contrast the correct `background_tasks` set pattern in app_lifecycle.py:32-36 | backup.py:62-78 | Open |
+| rclone exit code never checked — success inferred from parsing the last stderr line as JSON; a failure ending in valid JSON records as success, a non-JSON last line raises `JSONDecodeError` | backup.py:168-181 | Open; known trouble spot (repeated churn: commits b9dfcfd, 935250b, d6560a0) |
+| Terminal JWTs have no expiry; revocation is solely row deletion | pairing.py:59-66 | Accepted design as of 2026-07-03 (see §2) |
+| Backup passphrase stored PLAINTEXT in Postgres kv_store, returned by `GET /protected/backup/passphrase` — which is app-reachable per §1 | backup.py:28,184-189,215-224 | Open |
+| **Postgres data is NOT in the backup set** — backup syncs only `core/` and `user_data/` while identities (private keys!), terminals, installed_apps, kv_store live in `${FREESHARD_DIR}/postgres_data`; a restored shard loses its identity | config.toml `[services.backup] directories`; docker-compose.yml:19; https://github.com/FreeshardBase/freeshard/issues/122 (filed 2026-07-03) | Open issue |
+| `@throttle(5)` on `docker_start_app` is **global across all apps**, not per-app, and silently returns None when throttled — a request to app B within 5s of app A's start doesn't start B; recovery waits for the next request or lifecycle tick | app_tools.py:30; util/misc.py:5-27 | Open |
+| `peer.update_peer_meta` catches `httpx.HTTPStatusError` around a **requests** response's `raise_for_status()` — requests raises `requests.exceptions.HTTPError`, so any non-2xx peer reply escapes, propagates through `asyncio.gather` (no `return_exceptions`) and aborts the whole 60s peer-refresh cycle (saved only by PeriodicTask's catch-all) | peer.py:39-56, 29-33 | Live bug as of 2026-07-03; no open issue found |
+| `update_app_status(..., message=...)` does not persist the message — ERROR reasons reach the UI only via a transient websocket event; after reload the UI shows ERROR with no cause | app_installation/util.py:45-54 | Open |
+| `/internal/auth` 500s (AttributeError) when no app_meta path prefix matches the URI | web/internal/auth.py:82-83,141-147 | Open |
+| Live-looking Azure Container Registry credentials committed in config.toml `[[apps.registries]]`, docker-logged-in at every boot | config.toml; app_installation/__init__.py:123-133 | Known; do not copy the pattern |
+
+## When NOT to use this skill
+
+- Recreating the dev environment, uv, worktrees → **freeshard-build-and-env**
+- Running the stack, deploy, release, backup/restore procedure → **freeshard-run-and-operate**
+- Config option catalog, env-override rules, dead config → **freeshard-config-and-flags**
+- Crypto/protocol theory (HTTP Message Signatures, rclone crypt, JWT pairing in depth) → **freeshard-domain-reference**
+- A live symptom to triage → **freeshard-debugging-playbook**; its history → **freeshard-failure-archaeology**
+- Whether/how a change may ship at all → **freeshard-change-control** (this skill describes what IS; that one gates what may CHANGE)
+- Cross-repo contracts with controller/web-terminal → **freeshard-ecosystem-contracts**
+
+## Provenance and maintenance
+
+Written 2026-07-03 by direct verification against the working tree at commit e55ce51
+(branch fix-profile-billing-fields; identical for all files cited here unless noted).
+Primary sources: shard_core/{app_factory.py, settings.py}, shard_core/web/internal/auth.py,
+shard_core/service/{traefik_dynamic_config.py, crypto.py, pairing.py, peer.py, backup.py,
+app_tools.py, app_lifecycle.py, telemetry.py, disk.py, freeshard_controller.py,
+signed_call.py, app_installation/*}, shard_core/util/{signals.py, misc.py, async_util.py},
+shard_core/database/migration.py, shard_core/data_model/{identity.py, app_meta.py},
+docker-compose.yml, config.toml,
+https://github.com/FreeshardBase/freeshard/issues/89,
+https://github.com/FreeshardBase/freeshard/issues/122.
+
+Drift-prone facts — re-verify before relying on them:
+
+| Fact | Re-verification command (from repo root) |
+|---|---|
+| Routes still carry no FastAPI auth dependency | `grep -rn "Depends" shard_core/web/ \| grep -vi "router"` (expect no auth deps) |
+| Four routers / prefixes unchanged | `grep -n "include_router" shard_core/app_factory.py; grep -n "prefix" shard_core/web/*/__init__.py` |
+| forwardAuth targets unchanged | `grep -n "address=" shard_core/service/traefik_dynamic_config.py` |
+| shard_core still publishes no ports; stop_grace_period | `grep -n -A3 "shard_core:" docker-compose.yml \| grep -n "ports\|stop_grace"` |
+| JWT still has no exp claim | `grep -n -A6 "def create_terminal_jwt" shard_core/service/pairing.py` |
+| Crypto still RSA-4096 / RSA_PSS_SHA512 | `grep -rn "generate_private_key\|RSA_PSS" shard_core/service/{crypto,signed_call,peer}.py` |
+| Status allow-lists / exclusion filters | `grep -n "app_status in\|status !=\|status not in" shard_core/service/app_tools.py shard_core/service/app_lifecycle.py shard_core/service/app_installation/util.py` |
+| on_apps_update receivers (websocket + cache invalidation) | `grep -rn "on_apps_update.connect" shard_core/` |
+| Startup order in lifespan | `sed -n '78,108p' shard_core/app_factory.py` |
+| throttle still global, still 5s | `grep -n -B1 "def docker_start_app" shard_core/service/app_tools.py; sed -n '1,30p' shard_core/util/misc.py` |
+| peer.py httpx/requests mismatch still present (or fixed) | `grep -n "httpx.HTTPStatusError" shard_core/service/peer.py` |
+| Backup dirs still exclude postgres_data; issue #122 state | `grep -n -A2 "services.backup" config.toml; gh issue view 122 --json state` |
+| Backup event-loop blockers still present | `grep -n "subprocess.run\|upload_blob\|command.split" shard_core/service/backup.py` |
+| Migrations still CWD-relative | `grep -n "Path.cwd" shard_core/database/migration.py shard_core/app_factory.py` |
+| initial_apps / registries in config | `grep -n "initial_apps\|registries" config.toml` |

--- a/.claude/skills/freeshard-build-and-env/SKILL.md
+++ b/.claude/skills/freeshard-build-and-env/SKILL.md
@@ -1,0 +1,206 @@
+---
+name: freeshard-build-and-env
+description: Set up and verify a working shard_core development environment. Use when starting from a fresh clone or bare machine, creating a git worktree for an issue, running uv sync, wondering what a justfile recipe does (run-dev, cleanup, get-types, set-version, run-from-backup), reading the Dockerfile, or hitting env-shaped failures (import errors, "config.toml not found", pytest can't bind port 5433, docker network 'portal' already exists, black/ruff not found). TRIGGER on: "set up the repo", "uv sync", ".worktrees", "justfile", "just cleanup", "Dockerfile", "CI installs differently than local", fresh-environment smoke test. SKIP when: actually running the shard or the compose stack, dev server usage, backup/restore ops (use freeshard-run-and-operate); writing or debugging tests and fixtures (use freeshard-testing-and-qa); type-sync policy and controller drift details (use freeshard-ecosystem-contracts); config keys and env-override semantics (use freeshard-config-and-flags).
+---
+
+# Freeshard build & environment
+
+Goal: from a bare Linux box (or a fresh worktree) to a state where `pytest` collects, `ruff` passes, and you can trust your results. Repo = **shard_core**, the FastAPI backend that runs on each Freeshard VM ("shard") and orchestrates user apps via Docker Compose behind Traefik.
+
+All commands assume CWD = repo root (`/home/ubuntu/projects/freeshard/freeshard` on the main dev VM; adjust for your clone/worktree).
+
+## When NOT to use this skill
+
+| You want to... | Use instead |
+|---|---|
+| Run the dev server, bring up the compose stack, first-start pairing, backup/restore, release | freeshard-run-and-operate |
+| Understand/extend the test suite, fixtures, flaky tests | freeshard-testing-and-qa |
+| Sync types from the controller, cross-repo contracts, drift checks | freeshard-ecosystem-contracts |
+| Look up a config key, env override rules, dead config | freeshard-config-and-flags |
+| Know what changes are allowed and how they ship | freeshard-change-control |
+
+## Prerequisites
+
+| Tool | Required | On the main dev VM as of 2026-07-03 | Check |
+|---|---|---|---|
+| Python | >= 3.13 (`pyproject.toml:15`) | 3.13.3 | `python3 --version` |
+| uv | any recent | 0.10.7 | `uv --version` |
+| just | any recent | 1.40.0 | `just --version` |
+| Docker daemon | running, socket accessible | 29.2.1 | `docker info >/dev/null && echo ok` |
+| Docker Compose | **v2 plugin** (`docker compose`, not `docker-compose`) | v5.0.2 | `docker compose version` |
+| gh | authenticated | 2.46.0 | `gh auth status` |
+| Internet | yes — tests do a real `docker login` + real image pulls | — | — |
+
+uv can provision Python itself (`uv python install 3.13`) if the system Python is too old. Docker + internet are needed even for "just running the tests": the test suite starts a real postgres:17 container and logs into a real container registry (see traps below).
+
+## From bare Linux to productive
+
+```bash
+git clone https://github.com/FreeshardBase/freeshard.git
+cd freeshard
+uv sync --extra dev            # creates .venv from uv.lock; --extra dev pulls pytest, ruff, etc.
+.venv/bin/pytest tests --collect-only -q   # expect "137 tests collected" (origin/main as of 2026-07-03; 134 on the older e55ce51 checkout — count drifts, cross-check freeshard-testing-and-qa), zero errors
+.venv/bin/ruff check .         # expect no findings on a clean main
+```
+
+Notes:
+
+- `uv sync` installs from **uv.lock** — the single source of truth for dependency versions. Never `pip install .` into this venv.
+- Dev tools live in the optional extra `[project.optional-dependencies].dev` (pyproject.toml:47-59). Without `--extra dev` you get no pytest/ruff.
+- `black` is **not** listed in the dev extra, but `just cleanup` calls `.venv/bin/black`. It works anyway because black is a transitive dependency of `datamodel-code-generator` (see uv.lock). If `just cleanup` ever reports black missing, you ran `uv sync` without `--extra dev`.
+- The `shard_core.egg-info/` directory you may see at repo root is a setuptools build artifact, gitignored — ignore it.
+
+## Worktree discipline (mandatory for new work)
+
+Convention in this repo: every feature/bugfix gets its own worktree under `.worktrees/<slug>` on its own branch, cut from **freshly pulled** `origin/main`. The overnight agent loop assumes this; parallel sessions must not share a checkout.
+
+```bash
+git fetch origin main
+git worktree add .worktrees/<slug> -b <branch-name> origin/main
+cd .worktrees/<slug>
+uv sync --extra dev            # ALWAYS, before anything else
+.venv/bin/pytest tests --collect-only -q   # sanity: env works
+```
+
+Rules:
+
+- **ALWAYS run `uv sync --extra dev` inside the new worktree.** Never symlink or share `.venv` from the main checkout: branches can diverge on `pyproject.toml`/`uv.lock`, and a borrowed venv gives silently wrong test results and pollutes the other checkout with `__pycache__` writes.
+- `.worktrees/` is ignored via `.git/info/exclude` (local-only; **not** committed in `.gitignore`). In a fresh clone, add it yourself: `echo '.worktrees/' >> .git/info/exclude`.
+- Two worktrees **cannot run the test suite at the same time** — see traps (port 5433, compose project name, docker network `portal` are all host-global).
+- `local_config.toml` is committed, so every worktree has it — but it is resolved relative to CWD (see traps). Run everything from the worktree root.
+
+## Repo layout orientation map
+
+```
+freeshard/                     repo root (package name: shard_core)
+├── shard_core/                the Python package
+│   ├── app.py                 entrypoint (target of `fastapi run/dev`)
+│   ├── app_factory.py         create_app() + lifespan = startup/shutdown order
+│   ├── settings.py            pydantic-settings: config.toml + local_config.toml + FREESHARD_* env
+│   ├── web/                   FastAPI routers by auth level: public/ protected/ internal/ management/
+│   ├── service/               business logic (app_installation/, backup.py, crypto.py, ...)
+│   ├── database/              psycopg3 async access layer (yoyo migrations applied at startup)
+│   ├── data_model/            pydantic models; backend/ = COPIED from controller — never hand-edit
+│   └── util/
+├── data/                      runtime templates: traefik.yml(+_no_ssl), welcome-log jinja, splash.html, EFF wordlist
+├── migrations/                yoyo SQL migrations (shard-core-0001-init.sql)
+├── tests/                     pytest suite; tests/config.toml = overlay; tests/docker-compose.yml = postgres:17 on :5433
+├── scripts/                   generate_traefik_dyn_config_model.py — raises on purpose, do NOT run (hand-patched output)
+├── config.toml                base config, committed (contains live ACR pull credentials — do not "clean up")
+├── local_config.toml          dev overlay: path_root="run/", dns.zone="localhost" (CWD-relative, dockerignored)
+├── docker-compose.yml         production stack: postgres + traefik + shard_core + web-terminal on network 'portal'
+├── Dockerfile                 two-stage uv image build (see anatomy below)
+├── justfile                   task recipes (see anatomy below)
+├── uv.lock                    dependency source of truth (CI and image both build --frozen from it)
+└── .worktrees/                per-task worktrees (ignored via .git/info/exclude)
+```
+
+## justfile recipe anatomy
+
+Verified against `justfile` as of 2026-07-03. `just` (no args) lists recipes.
+
+| Recipe | What it actually does | Gotchas |
+|---|---|---|
+| `just run-dev` | `fastapi dev --port 8080 shard_core/app.py` via `.venv/bin/fastapi`, with `PYTHONUNBUFFERED=1` | The `CONFIG=config.yml,local_config.yml` it also sets is **dead** — nothing reads `CONFIG`, and those `.yml` files don't exist (real files are `.toml`, picked up by settings.py automatically). Usage details: freeshard-run-and-operate. |
+| `just run-dev-for-freeshard-controller` | second dev instance on port 8081, *intended* to point at a local controller on 8080 | Dead-CONFIG caveat PLUS the `FREESHARD_FREESHARD_CONTROLLER_BASE_URL` var it sets is single-underscore-broken (inert) — the instance actually talks to the **production** controller. Working form: `FREESHARD_FREESHARD_CONTROLLER__BASE_URL`. See freeshard-config-and-flags. |
+| `just cleanup` | `ruff check . --fix` then `black shard_core` and `black tests` | **Run after every code change** — it is the house formatting gate. Requires the dev extra installed (black is transitive). |
+| `just get-types` | **DESTRUCTIVE**: `rm -rf shard_core/data_model/backend`, then `cp -r` from the **LOCAL** sibling checkout `../freeshard-controller/freeshard-controller-backend/freeshard_controller/data_model`, prepending `# DO NOT MODIFY` to every file | Syncs from whatever your local controller checkout happens to be at. **You MUST `git -C ../freeshard-controller checkout main && git -C ../freeshard-controller pull` first.** A stale checkout has caused real bugs before (silently dropped billing fields — commits 6d4b101, e55ce51). As of 2026-07-03 the local controller checkout on the dev VM was verified BEHIND origin/main. Full procedure and drift checks: freeshard-ecosystem-contracts. |
+| `just set-version X.Y.Z` | rewrites `version` in pyproject.toml and the `ghcr.io/freeshardbase/freeshard:` tag in docker-compose.yml, then **`git add .` and `git commit`** | It stages EVERYTHING (`git add .`) — never run with a dirty tree. Release procedure: freeshard-change-control / freeshard-run-and-operate. |
+| `just run-from-backup <zip>` | **DESTRUCTIVE**: `rm -rf run/` then unzips the backup into `run/` (the dev `path_root`) | Wipes local dev state without asking. Restore workflow: freeshard-run-and-operate. |
+
+## Dockerfile anatomy (why the image looks like that)
+
+Two-stage build, verified against `Dockerfile` as of 2026-07-03:
+
+1. **Build stage** — `ghcr.io/astral-sh/uv:python3.13-bookworm-slim`. Runs `uv sync --frozen --no-install-project --no-dev` first (dependencies only, cached layer), then `ADD . .` + `uv sync --frozen --no-dev` (project itself). `UV_COMPILE_BYTECODE=1`, uv cache mounts. `--frozen` = build exactly from uv.lock.
+2. **Runtime stage** — `python:3.13-slim-bookworm` plus:
+   - `curl` — used by the container HEALTHCHECK (`curl -f http://localhost/public/health`).
+   - `rclone` — the backup engine (rclone crypt → Azure Blob).
+   - `tini` as PID 1 (`ENTRYPOINT ["/usr/bin/tini","--"]`) — reaps the zombie processes the healthcheck curl otherwise leaves behind (https://github.com/FreeshardBase/freeshard/pull/55).
+   - **Full Docker install via get.docker.com** — shard_core drives its sibling app containers by shelling out to `docker`/`docker compose` against the docker.sock mounted from the host (docker-compose.yml mounts `/var/run/docker.sock`). Only the CLI + compose plugin are used; the daemon inside the image never runs.
+   - `CMD ["fastapi","run","--port","80","shard_core/app.py"]`.
+
+## CI parity rule
+
+**Install from the lockfile, exactly like CI and the image do.** As of 2026-07-03, `.github/workflows/test.yml` on origin/main installs with `uv sync --frozen --extra dev` and runs `uv run ruff check .` / `uv run pytest tests` (changed in https://github.com/FreeshardBase/freeshard/pull/114). Before that, CI used `pip install ".[dev]"`, which ignores uv.lock and resolves latest-at-runtime — a fresh upstream release broke the controller's CI that way with zero code changes, and this repo switched preemptively. If you see red CI with no plausible connection to the diff, first check whether the install step still honors the lock.
+
+Match CI locally:
+
+```bash
+uv sync --frozen --extra dev   # exactly what CI installs
+uv run ruff check .            # CI lint job
+uv run pytest tests            # CI test job (needs Docker + internet)
+```
+
+`uv sync` without `--frozen` will also *update* uv.lock if pyproject.toml changed — fine during development, but a lockfile diff you didn't intend belongs out of your PR.
+
+Two workflow variables are dead but still present (do not cargo-cult them): `TEST_ENV=full/sparse` (its consumer was removed; push and PR runs are identical) and `CONFIG=tests/config.yml` (nothing reads `CONFIG`; the file doesn't even exist).
+
+## Known traps
+
+| Trap | Reality | Evidence |
+|---|---|---|
+| `CONFIG` env var looks load-bearing | It is dead — justfile, CI, tests, and the README all set it; nothing reads it (config is hardcoded: `config.toml` + `local_config.toml` if present + `FREESHARD_*` env). Full evidence and history: freeshard-config-and-flags. | `grep -rn '"CONFIG"' shard_core/` → no hits |
+| `local_config.toml` silently not applied | It is resolved via `Path("local_config.toml").exists()` — **relative to CWD**. Run the server/tests from the repo (or worktree) root, or your dev overlay (path_root=`run/`, dns.zone=localhost) vanishes and the app tries production paths. Also listed in `.dockerignore`, so it can never leak into the image — don't try to configure the container with it. | settings.py:148-152; .dockerignore |
+| Tests "just need pytest" | They need a running Docker daemon, compose v2, and internet: a session fixture does a **real `docker login`** to `portalapps.azurecr.io` using credentials committed in `config.toml:30-33`, and app-installation tests really pull images from that registry. If those credentials are ever rotated, api_client-based tests fail on pulls — that is an infra failure, not your bug. | tests/conftest.py:129-131 |
+| Concurrent test runs collide | tests/docker-compose.yml pins host port **5433** and conftest pins compose project name **`shard-core-test`**. Two worktrees running pytest simultaneously fight over both. Run suites serially across worktrees. | tests/docker-compose.yml:9; tests/conftest.py:96-98 |
+| Docker network `portal` and container names are host-global | The production compose stack, a locally running dev shard, and the test suite all use the network name `portal` and fixed container names (`postgres`, `traefik`, `shard_core`, app names like `filebrowser`). Test teardown force-removes the `portal` network — it will rip it out from under a dev shard running on the same host. | docker-compose.yml:1-3; tests/util.py:139-147 |
+| agents.md crypto claim | agents.md says Ed25519. The code is **RSA-4096 with PSS padding** (`shard_core/service/crypto.py`), and HTTP Message Signatures use `RSA_PSS_SHA512` (`shard_core/service/signed_call.py:27`). Trust the code. | crypto.py:54-56; signed_call.py:27 |
+| `scripts/generate_traefik_dyn_config_model.py` | Raises `Exception("Do no use! ...")` at import, deliberately: its output model was hand-patched (`authResponseHeadersRegex`) and regenerating would drop that field. Do not "fix" the script. | scripts/generate_traefik_dyn_config_model.py |
+| Leftover test infra after a crash | A killed pytest run leaves the test postgres and/or `portal` network behind; the next run fails on port/name conflicts. | Cleanup: `docker compose -p shard-core-test -f tests/docker-compose.yml down -v` and `docker network rm portal` |
+
+## 15-minute smoke checklist (fresh environment)
+
+Run top to bottom; each step has a pass condition. Stop and fix at the first failure.
+
+```bash
+# 1. Toolchain present (~1 min)
+python3 --version && uv --version && just --version && gh auth status
+docker info >/dev/null && docker compose version        # daemon up, compose v2
+
+# 2. Clean, current source (~1 min)
+git fetch origin main && git status                      # expect: clean tree
+git log --oneline -1 origin/main                         # note the tip you're building against
+
+# 3. Env from lockfile (~2 min)
+uv sync --frozen --extra dev                             # pass: exits 0, no resolver output
+
+# 4. Package imports (~10 s)
+.venv/bin/python -c "import shard_core.app_factory; print('import ok')"
+# pass: prints "import ok" (a CryptographyDeprecationWarning about OFB is known noise as of 2026-07-03)
+
+# 5. Test collection (~30 s, no Docker yet)
+.venv/bin/pytest tests --collect-only -q | tail -1       # pass: "N tests collected", zero errors (137 on origin/main as of 2026-07-03; the count drifts — what matters is zero collection errors)
+
+# 6. Lint (~10 s)
+.venv/bin/ruff check .                                   # pass: "All checks passed!"
+
+# 7. One real test — exercises pytest-docker, postgres:17 spin-up on :5433,
+#    internet, and the committed ACR docker login (~3-5 min)
+.venv/bin/pytest tests/test_crypto.py -q                 # pass: all green
+
+# 8. Formatting gate works (~30 s)
+just cleanup && git status                               # pass: exits 0; tree still clean on untouched main
+```
+
+If step 7 fails at container startup: check for a leftover `shard-core-test` compose project or occupied port 5433 (traps table). If it fails at `docker login` or image pull: the committed ACR credential may be rotated — escalate rather than debug your own change.
+
+## Provenance and maintenance
+
+Written 2026-07-03 against branch state `origin/main` @ 0a40684 (local checkout on `fix-profile-billing-fields` @ e55ce51). Primary sources: `justfile`, `Dockerfile`, `pyproject.toml`, `uv.lock`, `shard_core/settings.py`, `tests/conftest.py`, `tests/docker-compose.yml`, `docker-compose.yml`, `.github/workflows/test.yml` (origin/main), `README.md`, https://github.com/FreeshardBase/freeshard/pull/114, https://github.com/FreeshardBase/freeshard/pull/55. Tool versions quoted are the main dev VM's on the same date.
+
+Drift-prone facts — re-verify before trusting:
+
+| Fact (as of 2026-07-03) | Re-verify with |
+|---|---|
+| Version 0.39.2 / image tag in compose | `grep '^version' pyproject.toml && grep 'freeshardbase/freeshard:' docker-compose.yml` |
+| 137 tests collected (origin/main; 134 at e55ce51) | `.venv/bin/pytest tests --collect-only -q \| tail -1` |
+| CI installs via `uv sync --frozen --extra dev` | `git fetch origin && git show origin/main:.github/workflows/test.yml \| grep -A3 'Install dependencies'` |
+| `CONFIG` env var still dead | `grep -rn '"CONFIG"' shard_core/` (expect no hits) |
+| dev extra contents / black still transitive | `grep -A12 'dev = \[' pyproject.toml` |
+| Test postgres port 5433 / project `shard-core-test` | `grep 5433 tests/docker-compose.yml && grep -n 'shard-core-test' tests/conftest.py` |
+| ACR creds still committed & logged into | `grep -n 'azurecr' config.toml && grep -n 'login_docker_registries' tests/conftest.py shard_core/service/app_installation/__init__.py` |
+| Local controller checkout current before get-types | `git -C ../freeshard-controller rev-parse HEAD && git -C ../freeshard-controller ls-remote origin main` (hashes must match) |
+| `.worktrees/` excluded locally | `grep worktrees .git/info/exclude` |
+| Crypto still RSA-4096/PSS, not Ed25519 | `grep -n 'generate_private_key\|key_size\|RSA_PSS' shard_core/service/crypto.py shard_core/service/signed_call.py` |
+| tini/docker/rclone still in runtime image | `grep -n 'tini\|get.docker.com\|rclone' Dockerfile` |

--- a/.claude/skills/freeshard-change-control/SKILL.md
+++ b/.claude/skills/freeshard-change-control/SKILL.md
@@ -1,0 +1,314 @@
+---
+name: freeshard-change-control
+description: "How changes get accepted into the Freeshard shard_core repo: issue triage on the Dev Board, agent pickup/handback signals, branch & PR conventions, the non-negotiables (Max-merge-only, stay on Traefik v2, no shell on shards, DO-NOT-MODIFY synced types), and release discipline (merged is NOT shipped). Use when starting work on a GitHub issue, opening a PR, deciding whether something needs an issue/spec/sign-off, or asking 'is this fix actually released?'. TRIGGER on: picking up an assigned issue, 'open a PR', 'is this shipped', 'bump the version', 'release this', 'Needs Intent', Dev Board / project board queries, Traefik version questions, edits under shard_core/data_model/backend/. SKIP when you need the mechanical release/run commands themselves (freeshard-run-and-operate), test-writing rules (freeshard-testing-and-qa), cross-repo type-sync mechanics (freeshard-ecosystem-contracts), or the history of why a past fix was rejected (freeshard-failure-archaeology)."
+---
+
+# Freeshard change control
+
+How a change goes from idea to running-on-shards in this repo, and the rules that are
+not yours to bend. Written 2026-07-03; re-verify volatile facts (last section) before
+relying on them.
+
+**Terms used throughout** (defined once):
+
+| Term | Meaning |
+|---|---|
+| shard | A customer VM running the Freeshard stack (this repo's software + Traefik + Postgres + web-terminal) |
+| shard_core | This repo's Python package — the per-shard control plane |
+| controller | freeshard-controller (separate, **private** repo): central cloud management. Decides which shard_core image version the fleet runs |
+| Max / max-tet | Owner and sole maintainer. His PR merge is the only ship gate |
+| ClaydeCode | The AI agent's GitHub account. Most development happens through it |
+| Dev Board | Org-level GitHub Projects v2 board where all triage lives (labels are NOT used for triage) |
+| grind | Overnight loop: one fresh headless agent session per assigned issue, each in its own worktree/branch |
+| core version (vN) | Controller-side host/deploy version (v17, v18, ...). Distinct from shard_core's own 0.x version |
+
+---
+
+## 1. The one-paragraph model
+
+Issues are triaged by Max on the Dev Board. An issue assigned to **ClaydeCode** is the
+pickup signal for agent work. The agent branches from a **freshly fetched**
+`origin/main`, works in a worktree, opens a PR, and hands back by **requesting review
+from max-tet**. Nothing auto-merges. Nothing merged is shipped until a version bump +
+GitHub Release + controller-side rollout happen. Vague issues are never guessed at —
+they get flagged for intent capture and skipped.
+
+---
+
+## 2. Work intake: the Dev Board
+
+Triage lives on the org Projects v2 board **"Freeshard Dev Board"** — project **3**,
+owner **FreeshardBase** (https://github.com/orgs/FreeshardBase/projects/3, org-private).
+Project 2 is the separate "Freeshard Roadmap". Repo labels are irrelevant for triage:
+the only custom label is `high-priority`, rarely used; the board fields are the system.
+
+Board fields (verified 2026-07-03 via `gh project item-list 3 --owner FreeshardBase --format json`):
+
+| Field | Values | Meaning |
+|---|---|---|
+| `stage` | Backlog / Refined / Done | Refined = spec is good enough to work on |
+| `priority` | P0 / P1 / P2 / P3 | P0 = actively blocking users; P3 = someday |
+| `needs Intent` | `yes` / null | `yes` = issue is too vague to execute; requires a spec from Max first |
+| `status` | Todo / In Progress / Done | Kanban position |
+| `blocked By`, `linked pull requests` | free text / links | Dependencies |
+
+Query the board:
+
+```bash
+gh project item-list 3 --owner FreeshardBase --format json --limit 200
+```
+
+**gh traps (both verified 2026-07-03):**
+
+- `gh issue view N --repo FreeshardBase/freeshard --comments` FAILS on this org
+  ("GraphQL: Projects (classic) is being deprecated"). Use
+  `gh issue view N --repo FreeshardBase/freeshard --json body,comments` instead.
+- When filtering board items by repo, do NOT substring-match on
+  `freeshard` — controller items leak in (the board carries items from
+  `FreeshardBase/freeshard-controller` too). Match the exact URL prefix
+  `https://github.com/FreeshardBase/freeshard/issues/` or use
+  `.content.repository == "FreeshardBase/freeshard"`.
+
+### Pickup and handback signals
+
+| Signal | Meaning |
+|---|---|
+| Issue assigned to `ClaydeCode` | Agent should pick it up (grind loop uses exactly this) |
+| PR opened + review requested from `max-tet` | Work handed back for review (e.g. PR #119 carries `reviewRequests: max-tet`) |
+| `needs Intent = yes` on the board | Do NOT work it. See below |
+
+### Needs Intent: never guess
+
+If an issue is vague, underspecified, or flagged `needs Intent` on the board:
+**stop**. Do not fill the gaps with plausible-sounding design decisions. The correct
+move is to leave a comment stating what is unclear and skip the issue. Intent capture
+(turning a vague issue into an approved spec) is a Max-driven process; the spec lands
+as an issue comment before the issue becomes workable. Working a vague issue produces
+PRs that stall for weeks — see PR #92
+(https://github.com/FreeshardBase/freeshard/pull/92), stuck since 2026-05-27 on an
+architectural disagreement that a spec would have settled up front.
+
+---
+
+## 3. Branch and PR conventions
+
+### Always fetch first — local checkouts are routinely stale
+
+The single most common agent mistake in this repo. Two documented instances:
+
+- PR #113 (https://github.com/FreeshardBase/freeshard/pull/113): agent opened a
+  0.39.3→0.39.4 version-bump PR that was already redundant — main had been bumped
+  directly. Closed unmerged.
+- As of 2026-07-03 this very checkout sat on a merged feature branch at version
+  0.39.2 while `origin/main` was at 0.39.4 with a different CI workflow.
+
+```bash
+git fetch origin
+git log -1 --oneline origin/main          # reason from THIS, never from local main
+git ls-remote origin refs/tags/ | tail    # never infer latest release from local tags
+```
+
+Branch from `origin/main`, one branch per issue, in its own worktree for parallel
+agent sessions.
+
+### Branch names
+
+Current agent convention: `feature/clayde/<slug>` or `fix/clayde/<slug>`
+(e.g. `fix/clayde/drop-azureblob-no-check-container` → PR #119). Older agent branches
+used `clayde/issue-<N>`; human branches use plain `fix/…`, `feature/…`, `chore/…`.
+Match the current convention for new agent work.
+
+### PR content
+
+- The description must cover **all** commits on the branch, not just the last one.
+- State what was tested and how; CI (`snapshot.yml`) runs ruff + pytest on every
+  push/PR, and a red PR will not be reviewed.
+- Behavior changes and anything touching DB migrations (`migrations/*.sql`, yoyo)
+  ship with tests in the same PR. Evidence of the house norm: the #117 hotfix
+  PR #119 pairs the one-line fix with `test(backup): guard rclone flags and error
+  surfacing` (commit 0d42299).
+- Narrative commit messages; the reasoning for a change belongs in the commit
+  message, not in code comments.
+
+### Nothing auto-merges
+
+There is no auto-merge, no merge bot, no "trivial change" exception. Max's review and
+merge click is the only ship gate. This is a deliberate design principle of the
+autonomous-agent workflow, not a missing feature: the agent loop is allowed to be
+aggressive precisely because a human gate sits between it and production. Do not
+propose auto-merge, do not merge your own PRs, do not push to main.
+
+---
+
+## 4. Non-negotiables
+
+Each of these was paid for with an incident. Do not route around them; if a task seems
+to require it, stop and flag on the issue.
+
+### 4.1 Max-merge-only (see §3)
+
+### 4.2 Stay on Traefik v2 (v2.11) — do not resurrect v3 prep
+
+**Decision record:** closed PR #112
+(https://github.com/FreeshardBase/freeshard/pull/112) — closing comment: "we're
+staying on Traefik 2 (bumping to v2.11, which is Go 1.25 and self-raises nofile — the
+actual root cause)."
+
+**Why:** the June-2026 fd-exhaustion outage (shards "up but not serving",
+`accept4: too many open files`) was root-caused to the fleet's Traefik v2.6 being
+built with a pre-1.19 Go (measured go1.17.10 — see freeshard-proof-and-analysis-toolkit
+Recipe 1), which cannot self-raise `RLIMIT_NOFILE`. The fix was v2.11
+(Go 1.25) plus a finite `readTimeout` in shard_core (PR #108,
+https://github.com/FreeshardBase/freeshard/pull/108, released in 0.39.4) — NOT a
+risky v3 migration under outage pressure.
+
+**Status:** Traefik v2→v3 is a backlog item — freeshard-controller#321
+(https://github.com/FreeshardBase/freeshard-controller/issues/321, private repo,
+readable with ClaydeCode's gh auth), P3, `needs Intent: yes` on the Dev Board. It
+lists exactly what a future migration entails (HostRegexp→Host in
+`shard_core/service/traefik_dynamic_config.py`, ACME provider `azure`→`azuredns` in
+`data/traefik.yml`). Until that item is Refined and picked, any `Host()`/rule-syntax
+or ACME-provider change "for v3 readiness" is out of scope.
+
+**Known wrinkle (as of 2026-07-03):** this repo's own `docker-compose.yml` (the
+self-hosted/example stack) has pinned `traefik:v3.6` since 2025-12-16 (commit
+e78862d), and `agents.md` says "Traefik v3". The *fleet* decision (v2.11) is enforced
+controller-side in core-version compose files, not here. Treat the repo compose as an
+unresolved inconsistency — do not "fix" it in either direction without an issue.
+
+### 4.3 No shell on shards
+
+There is no user- or app-facing shell/`docker exec` path onto a shard, by design.
+Pairing is the auth boundary; an app whose first-user bootstrap requires
+`docker exec` is incompatible with the platform. Diagnostics on customer shards
+happen ONLY through the controller's operator-activated, time-boxed, read-only
+diagnostic system with an argv-allowlisted command catalogue and append-only audit
+trail (merged as freeshard-controller PR #303,
+https://github.com/FreeshardBase/freeshard-controller/pull/303, private repo). Never
+add an endpoint, feature, or debug pathway that executes arbitrary commands on a
+shard or exposes a shell — that includes "temporary" debug endpoints in a PR.
+
+### 4.4 `shard_core/data_model/backend/` is DO-NOT-MODIFY
+
+Every file there is stamped `# DO NOT MODIFY - copied from freeshard-controller`.
+The directory is wiped and re-copied by `just get-types` (requires
+`../freeshard-controller` checked out — see the `justfile`). Hand-edits are silently
+destroyed on the next sync and create type drift between repos. If a backend model is
+wrong, the fix goes in freeshard-controller first, then a sync commit here (recent
+example: commit 6d4b101 "chore: sync data_model types from freeshard-controller").
+Full procedure: **freeshard-ecosystem-contracts**.
+
+### 4.5 Migrations and behavior changes need tests
+
+Any change to `migrations/` (yoyo SQL, e.g. `migrations/shard-core-0001-init.sql`)
+or to observable behavior needs a test in the same PR. The test suite runs a real
+PostgreSQL via pytest-docker; "hard to test" is rarely true here. How to write them:
+**freeshard-testing-and-qa**.
+
+---
+
+## 5. Release discipline: merged is NOT shipped
+
+A fix that is merged to main does **not** run on any shard. Shipping requires all
+three steps, in order:
+
+1. **Version bump commit** on main: `just set-version X.Y.Z` — rewrites
+   `pyproject.toml` and the image tag in `docker-compose.yml`, and commits
+   "set version to X.Y.Z" (see `justfile`).
+2. **GitHub Release** with tag exactly `X.Y.Z`. `release.yml` first runs a
+   `version-check` job that fails if tag ≠ pyproject version, then full tests, then
+   builds and pushes `ghcr.io/freeshardbase/freeshard:X.Y.Z`.
+3. **Controller-side rollout**: a controller core-version compose bump pins the new
+   image tag for the fleet. This lives in the private freeshard-controller repo and
+   is Max's/controller-side work — flag it in your PR's follow-up section; you cannot
+   do it from this repo.
+
+Steps 2 and 3 are manual maintainer actions. **Evidence this gap is real:** issue
+#111 (https://github.com/FreeshardBase/freeshard/issues/111) — the fd-leak fix
+(PR #108) was merged 2026-06-21 but sat in no released tag until 0.39.4 on
+2026-06-24; no shard ran it in between. As of 2026-07-03 the gap is live again:
+PRs #114 (https://github.com/FreeshardBase/freeshard/pull/114) and #119
+(https://github.com/FreeshardBase/freeshard/pull/119) are merged after the 0.39.4
+release, so the fix for release-blocker issue #117
+(https://github.com/FreeshardBase/freeshard/issues/117, "v18: all backups fail")
+is on main but in no released image (unless shipped since — re-verify).
+
+**Practical consequences:**
+
+- When asked "is X fixed?", answer in two parts: merged? (git) AND released +
+  rolled out? (`gh release list`, then controller state). Never conflate them.
+- Before opening a version-bump PR, fetch and check whether main was already bumped
+  (the PR #113 trap, §3).
+- After any infra-level minor release, expect a hotfix burst: 0.28.0→0.28.6 was
+  7 tags in 3 days (2024-04-20..22, rclone rollout); 0.38.0→0.38.4 was 5 tags in a
+  week (2026-04-17..23, Postgres migration rollout). Budget review capacity for it;
+  don't treat a .0 as done.
+- **In-flight (as of 2026-07-03):** moving shard_core to semantic versioning is
+  agreed in principle — issue #118
+  (https://github.com/FreeshardBase/freeshard/issues/118), P2, Stage=Backlog — but
+  the mechanics (RC scheme, mapping to controller core versions vN) are unspecified.
+  Do not invent semver mechanics in a PR; the current scheme (0.MINOR.PATCH, linear)
+  stays until #118 is refined and executed.
+
+Release *commands* and deploy mechanics: **freeshard-run-and-operate**.
+
+---
+
+## 6. Change classification: what needs what
+
+| Change | Needs |
+|---|---|
+| Typo/docs-only fix, dead-link fix | Direct PR is fine; still reviewer-gated |
+| Bug fix with clear repro | Issue (so triage sees it) → PR with test |
+| Behavior change, new endpoint, config option | Refined issue on the board first |
+| Anything vague / architectural / multi-repo | Issue + `needs Intent` spec from Max before any code |
+| DB migration | Issue → PR with migration + test; see freeshard-testing-and-qa |
+| Touching Traefik version, rule syntax, ACME provider | Blocked by §4.2 — needs the controller#321 backlog item refined first |
+| Touching `data_model/backend/` | Change in freeshard-controller first, then sync (§4.4) |
+| Version bump / release | Maintainer-driven; agents only open a bump PR when explicitly asked, after fetching (§5) |
+| Anything with financial, legal, reputational, or security-posture consequences (billing/PayPal, licenses, public claims, auth boundaries, secrets handling) | Max's explicit sign-off BEFORE implementation, not just merge-time review. Propose on the issue; wait |
+
+When in doubt between two rows, take the heavier one and say so on the issue —
+a wasted comment is cheaper than a stalled PR.
+
+---
+
+## 7. When NOT to use this skill
+
+| You actually need | Use |
+|---|---|
+| Commands to run/deploy the stack, do a release, restore a backup | **freeshard-run-and-operate** |
+| Setting up the dev env, worktrees, uv, type-sync mechanics | **freeshard-build-and-env** |
+| How to write/structure tests, fixtures, flaky-test playbook | **freeshard-testing-and-qa** |
+| Cross-repo contracts and the `just get-types` procedure in detail | **freeshard-ecosystem-contracts** |
+| Why a past fix was rejected/reverted; incident histories in depth | **freeshard-failure-archaeology** |
+| Symptom→triage for a live failure | **freeshard-debugging-playbook** |
+| Load-bearing design invariants (auth model, path conventions) | **freeshard-architecture-contract** |
+| Config axes and env-override rules | **freeshard-config-and-flags** |
+
+---
+
+## Provenance and maintenance
+
+Written 2026-07-03 by repo-archaeology against the live repo and GitHub state.
+Primary sources: git history of https://github.com/FreeshardBase/freeshard;
+PR #112, #113, #119; issues #108, #111, #117, #118; freeshard-controller#321,
+PR controller#303 (private repo); `justfile`, `.github/workflows/{release,snapshot,test}.yml`;
+Dev Board (org project 3) field dump via `gh project item-list`.
+
+Drift-prone facts — re-verify before repeating:
+
+| Fact (as of 2026-07-03) | Re-verify with |
+|---|---|
+| Latest release = 0.39.4; PRs #114/#119 merged but unreleased | `gh release list --repo FreeshardBase/freeshard --limit 3` + `git fetch && git log --oneline 0.39.4..origin/main` |
+| origin/main tip = 0a40684 (merge of PR #119) | `git fetch && git log -1 --oneline origin/main` |
+| Dev Board fields: stage/priority/needs Intent/status | `gh project item-list 3 --owner FreeshardBase --format json --limit 200 \| python3 -c "import json,sys; print(sorted(json.load(sys.stdin)['items'][0].keys()))"` |
+| No open freeshard issues assigned to ClaydeCode | `gh issue list --repo FreeshardBase/freeshard --assignee ClaydeCode --state open` |
+| Traefik v3 migration still backlogged, needs-Intent P3 | `gh issue view 321 --repo FreeshardBase/freeshard-controller --json state,title` + board item |
+| Semver migration (#118) still unrefined | `gh issue view 118 --repo FreeshardBase/freeshard --json state` + board `stage` |
+| Repo compose still pins `traefik:v3.6` / agents.md still says "Traefik v3" | `git show origin/main:docker-compose.yml \| grep 'image: traefik'` |
+| `data_model/backend/` files still stamped DO NOT MODIFY | `head -1 shard_core/data_model/backend/shard_model.py` |
+| `just set-version` still rewrites pyproject + compose tag and commits | `sed -n '/set-version/,/^$/p' justfile` |
+| release.yml still gates on tag==pyproject version | `git show origin/main:.github/workflows/release.yml \| head -25` |
+| Agent branch convention still `fix\|feature/clayde/<slug>` | `gh pr list --repo FreeshardBase/freeshard --state merged --limit 10 --json headRefName,author` |
+| `gh issue view --comments` still broken on this org | `gh issue view 24 --repo FreeshardBase/freeshard --comments` (expect GraphQL projectCards error) |

--- a/.claude/skills/freeshard-config-and-flags/SKILL.md
+++ b/.claude/skills/freeshard-config-and-flags/SKILL.md
@@ -1,0 +1,300 @@
+---
+name: freeshard-config-and-flags
+description: "Catalog of every shard_core configuration axis and how overrides actually work. Use when adding/changing/reading a config option, wiring a FREESHARD_* env var, editing config.toml / local_config.toml / tests/config.toml / .env.template / docker-compose.yml environment mappings, checking whether a feature flag exists, or debugging 'my override does nothing' / 'Settings() crashes at boot'. TRIGGER on shard_core/settings.py, pydantic-settings, env_nested_delimiter, FREESHARD_ env vars, DISABLE_SSL, telemetry.enabled, apps.pruning, CONFIG env var, settings_override, config_override. SKIP when the question is about running/deploying the stack (use freeshard-run-and-operate), test fixture design beyond config overrides (use freeshard-testing-and-qa), or why a config decision was made (use freeshard-architecture-contract)."
+---
+
+# Freeshard config and flags
+
+**shard_core** is the FastAPI backend of a Freeshard shard (a personal cloud VM). All of its
+configuration flows through one pydantic-settings class: `Settings` in
+`shard_core/settings.py:109`. This skill is the complete catalog of every option, the override
+rules, the dead config you must not trust, and the checklist for adding an option.
+
+All file:line references and command outputs verified against the repo on 2026-07-03
+(branch state at commit e55ce51).
+
+## Precedence chain and file map
+
+Highest priority first (`settings_customise_sources`, `shard_core/settings.py:129-152`):
+
+| Priority | Source | When active | Notes |
+|---|---|---|---|
+| 1 | `Settings(...)` init kwargs | tests only (`tests/conftest.py:147-150`) | |
+| 2 | Env vars `FREESHARD_*` | always | see override rules below |
+| 3 | `local_config.toml` | only if the file exists in CWD | dev overlay; excluded from the Docker image via `.dockerignore` (commit 773f736) |
+| 4 | `config.toml` | always | prod baseline, baked into the image (`Dockerfile:21` `ADD . .`) |
+
+Key semantics:
+
+- **Per-field overlay**: each TOML file gets its own `TomlConfigSettingsSource`, so an override
+  file replaces individual fields, not whole nested sections. `local_config.toml` setting only
+  `[dns] zone` keeps `dns.prefix_length` from `config.toml`.
+- **CWD-relative paths**: the file names are literal strings `"config.toml"` /
+  `"local_config.toml"` (`settings.py:143,150`). Start shard_core from the repo root (Docker
+  WORKDIR is `/app`). Started elsewhere, ALL TOML config is silently lost and you get
+  required-field `ValidationError`s.
+- **Lazy singleton**: code reads config via `settings()` (`settings.py:155-159`); tests swap it
+  with `set_settings()` / `reset_settings()`. Never instantiate `Settings()` in product code.
+- Tests replace the `local_config.toml` overlay with `tests/config.toml` via a `_TestSettings`
+  subclass (`tests/conftest.py:54-59`) — see "How tests override config" below.
+
+## Env-var override rules
+
+- Prefix `FREESHARD_`, nested delimiter `__` (double underscore) — `settings.py:110-113`.
+- Correct forms: `FREESHARD_DNS__ZONE`, `FREESHARD_TRAEFIK__ACME_EMAIL`,
+  `FREESHARD_TRAEFIK__DISABLE_SSL`, `FREESHARD_FREESHARD_CONTROLLER__BASE_URL`,
+  `FREESHARD_DB__HOST`. Top-level scalars take a single level: `FREESHARD_PATH_ROOT`,
+  `FREESHARD_PATH_ROOT_HOST`.
+
+### Trap: single-underscore nesting is SILENTLY ignored
+
+pydantic-settings raises no error for `FREESHARD_DNS_ZONE` — it just doesn't match, and the
+value falls back to the TOML files. This caused a production incident: commit 5de2998
+(2026-04-13) fixed `docker-compose.yml`, where single-underscore names made every self-hosted
+shard silently fall back to the hardcoded zone `freeshard.cloud` and hardcoded ACME email.
+
+**The same bug class is still live as of 2026-07-03**: the justfile recipe
+`run-dev-for-freeshard-controller` (`justfile:51`) sets
+`FREESHARD_FREESHARD_CONTROLLER_BASE_URL=http://127.0.0.1:8080` — one underscore short before
+`BASE_URL`. Verified inert: with that var set, `Settings().freeshard_controller.base_url` is
+still `https://controller.freeshard.net`. That recipe silently talks to the **production**
+controller. The working form is `FREESHARD_FREESHARD_CONTROLLER__BASE_URL`.
+
+### Verify-an-override one-liner
+
+Whenever you add or touch a `FREESHARD_*` var (compose, justfile, CI), prove it lands. From
+repo root:
+
+```bash
+FREESHARD_DNS__ZONE=probe.test .venv/bin/python -c \
+  "from shard_core.settings import Settings; print(Settings().dns.zone)"
+# must print: probe.test
+```
+
+Substitute your section/field. If it prints the TOML value instead, the var name is wrong.
+
+## Full option catalog
+
+Legend: **prod** = `config.toml` (baked into image), **dev** = `local_config.toml`,
+**test** = `tests/config.toml`. Blank cell = not set there (default/prod value applies).
+Model definitions all in `shard_core/settings.py`.
+
+### Top level
+
+| Option | Type | Default | Prod | Dev | Consumer | Notes |
+|---|---|---|---|---|---|---|
+| `path_root` | str | `/` | `/` | `run/` | `service/disk.py:24`, `service/backup.py:51`, `service/assets.py:8`, `app_installation/util.py`, `database/tinydb_migration.py`, `app_factory.py` | Container-internal root for `core/` and `user_data/`. Tests set it per-test to `tmp_path` (`tests/conftest.py:148`). |
+| `path_root_host` | str | `/home/shard` | `/home/shard` | | `app_installation/util.py:80-85` | HOST-side path, used ONLY to render volume mounts into app docker-compose templates (host docker daemon resolves them). Prod compose overrides via `FREESHARD_PATH_ROOT_HOST=${FREESHARD_DIR:?}` (`docker-compose.yml:67`). |
+
+### [db] — DatabaseSettings (settings.py:92-97)
+
+| Option | Type | Default | Prod | Consumer |
+|---|---|---|---|---|
+| `host` | str | `postgres` | `postgres` | `database/connection.py:19` (async pool conninfo), `database/migration.py:13` (yoyo) |
+| `port` | int | `5432` | `5432` | same |
+| `dbname` / `user` / `password` | str | `shard_core` each | same | same — matches hardcoded `POSTGRES_*` env on the postgres compose service (`docker-compose.yml:14-17`) |
+
+Tests inject a different DB (`shard_core_test` on host port from pytest-docker) as an init
+kwarg (`tests/conftest.py:149`).
+
+### [dns] — DnsSettings (settings.py:10-12)
+
+| Option | Type | Default | Prod | Dev | Consumer |
+|---|---|---|---|---|---|
+| `zone` | str | REQUIRED | `freeshard.cloud` | `localhost` | `data_model/identity.py:63` — shard domain = `identity.id[:prefix_length].lower() + "." + zone`. Self-hosted: `FREESHARD_DNS__ZONE=${DNS_ZONE:?}` (`docker-compose.yml:64`). |
+| `prefix_length` | int | `6` | `6` | | `data_model/identity.py:62` |
+
+### [services.backup] — BackupSettings (settings.py:15-23)
+
+| Option | Type | Default | Prod | Consumer |
+|---|---|---|---|---|
+| `directories` | list[str] | REQUIRED | `["core", "user_data"]` | `service/backup.py:52` — the rclone-crypt sync set. Note: Postgres data is NOT in it. |
+| `included_globs` | list[str] | `[]` | set in config.toml | **DEAD — no consumer** (see Dead config) |
+| `timing.base_schedule` | cron str | REQUIRED | `0 3 * * *` | `app_factory.py:131` (CronTask start_backup) |
+| `timing.max_random_delay` | int (s) | REQUIRED | `3600` | `app_factory.py:132`, jitter applied `util/async_util.py:93-94` |
+
+### [traefik] — TraefikSettings (settings.py:30-32)
+
+| Option | Type | Default | Prod | Consumer |
+|---|---|---|---|---|
+| `acme_email` | str | REQUIRED | `contact@freeshard.net` | rendered into Traefik static config (`app_factory.py:140-157`). Self-hosted: `FREESHARD_TRAEFIK__ACME_EMAIL=${EMAIL:?}`. |
+| `disable_ssl` | bool | `False` | | feature flag — see Feature-flag inventory |
+
+### [apps] — AppsSettings (settings.py:65-72)
+
+| Option | Type | Default | Prod | Test | Consumer |
+|---|---|---|---|---|---|
+| `app_store.base_url` | str | REQUIRED | `https://storageaccountportab0da.blob.core.windows.net` | | `app_installation/worker.py:181-182`, `app_installation/util.py:58-59` — app-zip download URLs |
+| `app_store.container_name` | str | REQUIRED | `app-store` | | same |
+| `registries` | list[{uri,username,password}] | `[]` | one entry: `portalapps.azurecr.io` + **plaintext credentials** | | `app_installation/__init__.py:123-133` — `docker login` at startup. See "Committed registry credentials". |
+| `lifecycle.refresh_interval` | int (s) | `30` | `10` | `2` | `app_factory.py:115` — period of `control_apps` |
+| `initial_apps` | list[str] | `[]` | `["filebrowser", "immich", "paperless-ngx"]` | | `app_installation/__init__.py:110` — first-start install queue, guarded by kv flag `initial_apps_installed` |
+| `last_access.max_update_frequency` | int (s) | `60` | `60` | `3` | `data_model/app_meta.py:158-161` — debounce on app last-access writes |
+| `usage_reporting.tracking_schedule` | cron | REQUIRED | `0 2 * * *` | `* * * * * *` | `app_factory.py:117-120` |
+| `usage_reporting.reporting_schedule` | cron | REQUIRED | `0 3 1 * *` | `* * * * * */3` | `app_factory.py:121-124`; posts to `{management.api_url}/app_usage` (`service/app_usage_reporting.py:54-55`) |
+| `pruning.schedule` | cron | REQUIRED | `0 4 * * *` | | `app_factory.py:125-128` |
+| `pruning.max_age` | int (h) | `24` | `24` | | `service/app_tools.py:163` — `docker image prune --filter until=<n>h` |
+| `pruning.enabled` | bool | `False` | `false` | `true` | feature flag — see inventory |
+
+### [telemetry] — TelemetrySettings (settings.py:75-77)
+
+| Option | Type | Default | Prod | Test | Consumer |
+|---|---|---|---|---|---|
+| `enabled` | bool | `False` | `false` | `true` | `service/telemetry.py:19,27` — gates both request counting and sending |
+| `send_interval_seconds` | int | `300` | `300` | | `app_factory.py:136`; sends to controller `api/telemetry` (`telemetry.py:38-39`) |
+
+### [management], [portal_controller], [freeshard_controller]
+
+| Section.option | Default | Prod | Consumer |
+|---|---|---|---|
+| `management.api_url` | REQUIRED | `https://ptlfunctionapp.azurewebsites.net/api/management` (legacy Azure function app) | ONLY `service/app_usage_reporting.py:54` (monthly `/app_usage` POST). `management_mock.py` mocks this API for local dev — point at it with `FREESHARD_MANAGEMENT__API_URL`. |
+| `portal_controller.base_url` | Optional (settings.py:124) | Azure Container Apps URL in config.toml | **DEAD — zero consumers** (see Dead config) |
+| `freeshard_controller.base_url` | REQUIRED | `https://controller.freeshard.net` | `service/freeshard_controller.py:14`, `service/portal_controller.py:15` (yes — the *portal_controller module* reads the *freeshard_controller setting*), `web/protected/feedback.py:23`, `web/internal/call_backend.py:26` |
+
+### [log] and [terminal]
+
+| Option | Type | Default | Dev | Consumer |
+|---|---|---|---|---|
+| `log.levels` | dict[str,str] | `{}` | `shard_core=debug`, quiets `app_usage_reporting` + `websocket`; prod sets `gunicorn=warning` | `app_factory.py:72-75` — per-module log levels; key `root` targets the root logger; dotted keys must be quoted in TOML |
+| `terminal.pairing_code_deadline` | int (s) | `600` | | `service/pairing.py:34` — pairing-code validity |
+| `terminal.jwt_secret_length` | int | `64` | | `service/pairing.py:96` — `secrets.token_urlsafe` length |
+
+`[terminal]` appears in NO TOML file — defaults only. Override via env if ever needed.
+
+## Dead config — parsed but consumed by NOTHING
+
+Do not "fix" behavior by editing these; do not copy them into new code as if live.
+
+| Item | Where it lurks | Evidence it's dead (re-run to confirm) |
+|---|---|---|
+| `CONFIG` env var | `justfile:48,51` (`CONFIG=config.yml,local_config.yml`), CI `.github/workflows/test.yml:41` (`CONFIG: tests/config.yml`), `tests/conftest.py:3`, README "Development" section | No code reads it: `grep -rn "environ" shard_core/ \| grep CONFIG` → empty. Vestige of the old gconf loader, replaced by pydantic-settings in commit e2c06a7. The `.yml` filenames in justfile/CI are doubly wrong (config files are `.toml`); conftest.py:3 points at the real `tests/config.toml` — equally dead, just not a phantom filename. Config loading works anyway because `local_config.toml` auto-loads when present. |
+| `services.backup.included_globs` | `settings.py:23`, populated in `config.toml:17` | `grep -rn included_globs shard_core/` hits only the settings field definition. Never wired into the rclone command. Intent (planned selective backup vs leftover) unverified as of 2026-07-03. |
+| `[portal_controller] base_url` | `settings.py:84-85,124`, `config.toml:60-61` | `grep -rn "settings().portal_controller" shard_core/ tests/` → empty. Legacy of the portal→freeshard-controller migration. `service/portal_controller.py` actually uses `settings().freeshard_controller.base_url`. |
+
+## Feature-flag inventory
+
+| Flag | Default | Prod | What it gates | Bypass / caveat |
+|---|---|---|---|---|
+| `traefik.disable_ssl` | `false` | unset (false) | Static-config template `traefik_no_ssl.yml` vs `traefik.yml` (`app_factory.py:142-145`); http vs https scheme in shard URL and Traefik dynamic config (`app_factory.py:163`, `service/traefik_dynamic_config.py:42,166,216,225,233-234`) | Dev/testing only. Self-hosted exposure: `DISABLE_SSL` in `.env.template:4`. See boot-crash trap below. |
+| `telemetry.enabled` | `false` | `false` | Both request counting and sending (`service/telemetry.py:19,27`) | `true` in tests. Sends request counts to the freeshard controller. |
+| `apps.pruning.enabled` | `false` | `false` | The *scheduled* docker image prune short-circuits when disabled (`service/app_tools.py:175-176`) | Manual `POST /protected/settings/prune-images` (`web/protected/settings.py:14-19`) calls `docker_prune_images(apply_filter=False)` — it runs regardless of the flag AND ignores `max_age`. |
+| Peer-to-peer | **NO FLAG EXISTS** | always active | Nothing — peers router included unconditionally (`web/protected/__init__.py:26`), `update_all_peer_pubkeys` PeriodicTask runs every 60 s (`app_factory.py:116`) | README's "peer-to-peer is disabled" means "no app uses it / not surfaced in UI", not config-gated. Don't search for a flag; there isn't one. |
+
+## Compose / .env mapping (self-hosted surface)
+
+`.env.template` → `docker-compose.yml:63-67` env mapping on the `shard_core` service:
+
+| .env var | Compose mapping | Guard |
+|---|---|---|
+| `DNS_ZONE` | `FREESHARD_DNS__ZONE=${DNS_ZONE:?}` | fail-fast if unset |
+| `EMAIL` | `FREESHARD_TRAEFIK__ACME_EMAIL=${EMAIL:?}` | fail-fast |
+| `FREESHARD_DIR` | `FREESHARD_PATH_ROOT_HOST=${FREESHARD_DIR:?}` (also raw in volume mounts) | fail-fast |
+| `DISABLE_SSL` | `FREESHARD_TRAEFIK__DISABLE_SSL=${DISABLE_SSL}` | **NO guard, no default** |
+
+### Trap: empty DISABLE_SSL crashes boot
+
+Because `${DISABLE_SSL}` has no `:?` guard and no default, a self-hoster who omits the line
+from `.env` gets an **empty string** passed as `FREESHARD_TRAEFIK__DISABLE_SSL`, and
+`Settings()` raises at startup:
+
+```
+pydantic_core._pydantic_core.ValidationError: 1 validation error for Settings
+traefik.disable_ssl
+  Input should be a valid boolean, unable to interpret input [type=bool_parsing, input_value='', ...]
+```
+
+(Reproduced 2026-07-03 with `FREESHARD_TRAEFIK__DISABLE_SSL= python -c "...Settings()"`.)
+If you touch this mapping, either add a default (`${DISABLE_SSL:-false}`) or a `:?` guard —
+and use `${VAR:?}` guards for any NEW compose env mapping you add.
+
+## Committed registry credentials
+
+`config.toml:30-33` contains a real Azure Container Registry login (`portalapps.azurecr.io`,
+service-principal GUID username, plaintext password) committed to the repo. It is
+`docker login`-ed at every startup (`app_installation/__init__.py:123-133`) **and at test-session
+start** (`tests/conftest.py:129-131` `setup_all` fixture) — rotating or revoking these
+credentials breaks the test suite. Whether committing them is intentional (scoped pull-only
+token) or an oversight is unverified as of 2026-07-03. Do not copy this pattern for new
+registries; do not "helpfully" delete them either — that is a change-control question
+(see freeshard-change-control).
+
+## How tests override config
+
+Three layers, all in `tests/conftest.py`:
+
+1. **Base**: autouse fixture `config_override` (`tests/conftest.py:134-156`) builds a
+   `_TestSettings` instance per test — `config.toml` + `tests/config.toml` overlay (instead of
+   `local_config.toml`), with `path_root=tmp_path/...` and the pytest-docker Postgres as init
+   kwargs — and installs it via `set_settings()`; teardown calls `reset_settings()`.
+2. **Per-module**: define a module-level dict named `config_override` in the test file — the
+   fixture picks it up by name (`conftest.py:139`).
+3. **Per-test**: `@pytest.mark.config_override({...nested dict...})` (`conftest.py:142-143`),
+   or the `settings_override({...})` context manager (`conftest.py:78-88`) for a scoped block
+   inside a test.
+
+Rules: never mutate `settings()` fields directly; never instantiate plain `Settings()` in a
+test. `tests/config.toml` exists to make background tasks fast (refresh_interval=2,
+every-second crons) and to enable flags that default off (pruning, telemetry) so they're
+exercised.
+
+## Add-a-config-option checklist
+
+0. **Gate**: a new config option is a behavior change — it needs a Refined issue on the Dev
+   Board first (freeshard-change-control §6).
+1. **Field**: add it to the right `BaseModel` in `shard_core/settings.py` with a sane default.
+   Make it required (no default) only if prod MUST set it explicitly in `config.toml`.
+2. **Prod value**: set in `config.toml` (required fields always; defaulted fields when prod
+   differs from the default).
+3. **Dev/test overlays**: `local_config.toml` if dev needs a different value; `tests/config.toml`
+   if a background task consumes it (tests need fast intervals / enabled flags).
+4. **Self-hosted exposure** (only if self-hosters must set it): add a documented line to
+   `.env.template` and a `FREESHARD_<SECTION>__<FIELD>=${VAR:?}` mapping in `docker-compose.yml`.
+   Double underscore between section and field. `:?` guard always — a boolean passed as an
+   unguarded `${VAR}` crashes `Settings()` on empty string (see trap above).
+5. **Verify the env path** with the one-liner (see "Verify-an-override one-liner").
+6. **Wire a consumer** via `settings().<section>.<field>` and grep to confirm it's actually
+   read — this repo already has two parsed-but-dead options; don't add a third.
+7. **Before trusting an EXISTING option**, grep for its consumer first: `included_globs` and
+   `portal_controller.base_url` parse fine and do nothing.
+
+## When NOT to use this skill
+
+- Bringing up the compose stack, dev server, releases, backup/restore →
+  **freeshard-run-and-operate**.
+- Recreating the dev environment, uv, worktrees, type-sync → **freeshard-build-and-env**.
+- Test-suite architecture and fixtures beyond the config-override machinery →
+  **freeshard-testing-and-qa**.
+- Why config is designed this way / what invariants must hold →
+  **freeshard-architecture-contract**.
+- Debugging a running shard's misbehavior (beyond "my override doesn't land") →
+  **freeshard-debugging-playbook**.
+- Whether you're allowed to change prod config values or rotate the committed credentials →
+  **freeshard-change-control**.
+
+## Provenance and maintenance
+
+Written 2026-07-03. Primary sources: `shard_core/settings.py`, `config.toml`,
+`local_config.toml`, `tests/config.toml`, `.env.template`, `docker-compose.yml`, `justfile`,
+`tests/conftest.py`, `.github/workflows/test.yml`; commits e2c06a7 (gconf → pydantic-settings),
+5de2998 (env delimiter incident), 773f736 (local_config.toml dockerignore). All catalog
+entries, dead-config claims, and both trap reproductions were verified by running the listed
+commands on 2026-07-03.
+
+Drift-prone facts — re-verify before relying on them:
+
+| Fact (as of 2026-07-03) | Re-verification command (repo root) |
+|---|---|
+| Option set / defaults in the catalog | `cat shard_core/settings.py` |
+| Prod values | `cat config.toml` |
+| Dev / test overlay values | `cat local_config.toml tests/config.toml` |
+| Precedence: init > env > local_config.toml > config.toml | `sed -n '129,152p' shard_core/settings.py` |
+| `CONFIG` env var still dead | `grep -rn "environ" shard_core/ \| grep CONFIG` (expect empty) |
+| `CONFIG` still set in justfile/CI | `grep -n CONFIG justfile .github/workflows/test.yml` |
+| `included_globs` still dead | `grep -rn included_globs shard_core/` (only settings.py) |
+| `[portal_controller]` still dead | `grep -rn "settings().portal_controller" shard_core/ tests/` (expect empty) |
+| justfile controller recipe still single-underscore-broken | `grep -n FREESHARD_FREESHARD_CONTROLLER justfile` (broken if not `__BASE_URL`) |
+| `DISABLE_SSL` compose mapping still unguarded | `grep -n DISABLE_SSL docker-compose.yml` (broken if no `:?` or `:-` ) |
+| ACR credentials still committed / still docker-login'd in tests | `sed -n '30,33p' config.toml; sed -n '129,131p' tests/conftest.py` |
+| Feature-flag consumers unchanged | `grep -rn "disable_ssl\|telemetry.enabled\|pruning.enabled" shard_core/` |
+| Peer-to-peer still unflagged | `grep -rn "peer" shard_core/settings.py` (expect empty) |
+| Env override still lands | the verify-an-override one-liner |

--- a/.claude/skills/freeshard-debugging-playbook/SKILL.md
+++ b/.claude/skills/freeshard-debugging-playbook/SKILL.md
@@ -1,0 +1,287 @@
+---
+name: freeshard-debugging-playbook
+description: Symptom-to-triage playbook for known Freeshard shard_core failure modes. Use when diagnosing a live or reported failure: shard up but unreachable, "too many open files" in traefik logs, all controller writes return 422, app won't start / container name conflict / stale network, backup failures or rclone errors, burst 500s on app access, Immich thumbnails broken or postgres crash-looping, app stuck INSTALLATION_QUEUED, config override silently ignored, OOM kills / restart loops. TRIGGER on incident reports, "shard unreachable", "backups failing", "app stuck", error strings like EMFILE, 422 Unprocessable, "already in use", PANIC, SIGABRT. SKIP when writing new tests or diagnosing test flakiness (use freeshard-testing-and-qa), when you need measurement tooling (use freeshard-diagnostics-and-tooling), or when researching WHY the design is this way (use freeshard-architecture-contract or freeshard-failure-archaeology).
+---
+
+# Freeshard Debugging Playbook
+
+Symptom → discriminating experiment → fix, for every failure mode this project has already paid to learn. Written 2026-07-03. Verify volatile facts (issue states, versions) before acting on them — re-verification commands are in the last section.
+
+**Terms** (used throughout, defined once):
+
+| Term | Meaning |
+|---|---|
+| shard | A customer VM running the shard_core stack: `postgres:17`, `traefik`, `shard_core` (this repo's image), `web-terminal`, plus one Docker Compose project per installed app — all on one Docker network named `portal` (docker-compose.yml). |
+| controller | freeshard-controller, the central cloud service at controller.freeshard.net. Provisions shards, issues backup SAS URLs, receives telemetry. |
+| forwardAuth | Traefik middleware: every request to an app subdomain is first sent to shard_core `GET /internal/auth`; a 200 lets the request through. Auth is enforced by Traefik, NOT inside FastAPI routes. |
+| hosted vs self-hosted | Same image and compose file. Hosted shards are known to the controller (profile, backups, management API work); self-hosted shards get profile=None and no backups. |
+| merged ≠ shipped | A fix on `main` reaches no shard until a version bump + GitHub Release + controller core-version rollout. See freeshard-change-control. Evidence: [#111](https://github.com/FreeshardBase/freeshard/issues/111). |
+
+## First 15 minutes on any incident
+
+Access note: on hosted customer shards there is no ad-hoc SSH; probes run through the controller's operator-activated diagnostics API. Locally (dev compose stack) run these directly.
+
+```bash
+# 1. What is running, what is restarting, what is unhealthy?
+docker ps -a --format 'table {{.Names}}\t{{.Status}}\t{{.RestartCount}}'
+
+# 2. Is shard_core itself alive? (healthcheck endpoint, same one the Dockerfile uses)
+docker exec shard_core curl -sf http://localhost/public/health   # expect {"status":"ok"}
+# From outside, through traefik: curl -sf https://<domain>/core/public/health
+
+# 3. Disk. Two known incidents were "really a full disk" (log spam, backups).
+df -h /   # shard_core also stops ALL apps when free space on user_data < 1 GiB (shard_core/service/disk.py:28)
+
+# 4. Logs, most recent first. shard_core logs to stdout.
+docker logs --tail 300 shard_core
+docker logs --tail 300 traefik      # look for "too many open files", ACME errors
+docker logs --tail 100 <app-container>
+
+# 5. App status as the DB sees it (statuses: INSTALLATION_QUEUED, INSTALLING,
+#    STOPPED, RUNNING, DOWN, ERROR, ... — shard_core/data_model/app_meta.py:29)
+docker exec -it postgres psql -U shard_core -c "select name, status from installed_apps;"
+```
+
+Then match the symptom against this table.
+
+## Symptom → triage index
+
+| # | Symptom | First discriminator | Likely cause |
+|---|---|---|---|
+| 1 | Shard containers all "Up", but nothing reachable from outside | `docker exec traefik sh -c 'ulimit -n'` + traefik log grep "too many open files" | Traefik fd exhaustion |
+| 2 | Every WRITE to the controller (via shard proxy) returns 422; reads fine | tcpdump the internal hop: is Content-Type present? | Proxy dropped Content-Type |
+| 3 | One app won't start; logs say name "already in use" or network "not found" | `docker logs shard_core` grep for auto-recovery warnings | Stale Docker state after core update |
+| 4 | Backups failing / no recent backup marker | rclone exit + last stderr line; does the flag exist in the shipped rclone? | rclone flag/output-parsing class |
+| 5 | Burst of 500s when opening an app (esp. SPA firing many parallel requests) | pool wait timeouts in shard_core logs; were auth caches invalidated? | forwardAuth DB-pool exhaustion (regression of #89) |
+| 6 | Immich thumbnails broken / uploads fail / its postgres crash-looping | THREE distinct modes — discriminate before acting (see §6) | pgvecto.rs corruption vs VectorChord stale index vs upstream regression |
+| 7 | App randomly dies / restarts; user sees bare 502 | `docker inspect` OOMKilled + RestartCount | OOM kill or idle-stop mid-migration (open #120/#121) |
+| 8 | A config/env override silently does nothing | one-liner Settings() probe (see §8) | Single-underscore env var name |
+| 9 | Test passes locally, times out only in CI | — | Known flaky class → freeshard-testing-and-qa |
+| 10 | App stuck in INSTALLATION_QUEUED or INSTALLING forever (esp. after restart) | Was shard_core restarted since the install was queued? | In-memory queue, no startup reconciliation |
+
+---
+
+## 1. Shard "up but unreachable" — Traefik fd exhaustion
+
+**Symptom.** All containers show "Up", shard_core health is green, but HTTP/HTTPS from outside hangs or is refused. Traefik log is a hot loop of `accept4: too many open files` (EMFILE). Bonus damage: that log loop itself can fill the root disk (a 38 GB traefik JSON log in 3 days was part of the June 2026 incident) — check `df -h` too.
+
+**Discriminating experiment.**
+
+```bash
+docker exec traefik sh -c 'ulimit -n'
+# ~1024        -> fd ceiling is the problem (old Go binary + low docker nofile default)
+# ~64000+      -> ceiling fine; look elsewhere (DNS, certs, routing)
+
+docker logs --tail 200 traefik 2>&1 | grep -c 'too many open files'
+# >0 -> confirmed EMFILE; 0 -> not this failure mode
+```
+
+**Root cause (June 2026 incident).** Two factors multiplied: (a) Traefik with `readTimeout=0` leaks one fd per abandoned connection from internet scanners; (b) the hosted fleet's pinned Traefik v2.6 is built with a pre-1.19 Go (measured go1.17.10 — see freeshard-proof-and-analysis-toolkit Recipe 1), which does not self-raise `RLIMIT_NOFILE` (Go 1.19+ does), so on newer Ubuntu base images with a 1024 per-container nofile soft limit the ceiling was hit within days. Older shards survived the identical leak only because their limit was higher — "old shards are fine" was luck, not health.
+
+**Fix.** Both halves shipped: finite `readTimeout: 300s` on http/https entrypoints in the shard-generated static config (commit fd1d05b, PR [#108](https://github.com/FreeshardBase/freeshard/pull/108), released in 0.39.4), and the hosted fleet's Traefik bumped to v2.11 (Go 1.25, self-raises nofile) — the deliberate decision to stay on v2 rather than migrate to v3 is recorded in closed PR [#112](https://github.com/FreeshardBase/freeshard/pull/112)'s comment; v3 migration is a P3 backlog item. Note the hosted-fleet Traefik pin lives in freeshard-controller's core files, NOT in this repo; this repo's docker-compose.yml (self-hosted stack) pins `traefik:v3.6` (as of 2026-07-03, docker-compose.yml:29).
+
+**If you hit it anyway:** restart traefik for immediate relief, then verify `readTimeout` is present in `/core/traefik.yml` on the shard (it comes from `data/traefik.yml` in this repo) and check the shard's core version is ≥ 0.39.4. This is a "merged-but-not-rolled-out" trap — the fix sat unreleased once already ([#111](https://github.com/FreeshardBase/freeshard/issues/111)).
+
+## 2. All controller writes 422, reads fine — proxy dropped Content-Type
+
+**Symptom.** Every POST/PUT proxied from the terminal through shard_core's `/internal/call_backend/...` to the controller returns 422 Unprocessable Entity; every GET works.
+
+**Story.** shard_core's sign-and-forward proxy relayed the body but not the `Content-Type` header — harmless for years, until a controller-side FastAPI upgrade (0.115 → 0.136) started rejecting JSON bodies without a JSON Content-Type. Python `requests` sets no Content-Type for `data=<bytes>`. Issue [#93](https://github.com/FreeshardBase/freeshard/issues/93), fixed in PR [#94](https://github.com/FreeshardBase/freeshard/pull/94); the fix and its rationale are commented in `shard_core/web/internal/call_backend.py:30-40`. A red herring (double-encoding) was chased first.
+
+**Discriminating experiment.** Traefik swallows the detail; look at the actual bytes on the plaintext internal hop with a netshoot sidecar in the target container's network namespace:
+
+```bash
+docker run --rm --net container:shard_core nicolaka/netshoot \
+  tcpdump -i any -A -s0 'tcp port 80'
+# Reproduce one failing write, then read the captured request:
+#   Content-Type header present  -> not this bug; inspect the 422 response body for the real validation error
+#   Content-Type header absent   -> this bug (or a regression of it)
+```
+
+**Fix/escalation.** Ensure the proxy forwards Content-Type (call_backend.py already does; check any NEW proxy path). General rule for any sign-and-forward proxy in this codebase: forward semantically load-bearing headers with the body. Related repeat offenders in the same file family: query strings (#19), streaming instead of buffering (#38/#39).
+
+## 3. App won't start — stale Docker state (name conflict / dead network)
+
+**Symptom.** An app fails to start after a core update or host reboot. `docker logs shard_core` (or the SubprocessError) contains either `Conflict... already in use` (container name) or `network ... not found`.
+
+**Story.** Docker objects (containers, networks) survive core updates and go stale. Fixed three times: [#63](https://github.com/FreeshardBase/freeshard/issues/63) (name conflicts, commit fefd2f4), root cause of stale containers on core update (751678d), and stale network references ([#54](https://github.com/FreeshardBase/freeshard/issues/54), d66d889).
+
+**Current behavior.** `docker_start_app` auto-recovers from both modes by string-matching the error text and running `compose down` + `up -d` (`shard_core/service/app_tools.py:43-61`). This is fragile by design — if Docker changes its error messages, recovery silently stops matching.
+
+**Discriminating experiment.**
+
+```bash
+docker logs shard_core 2>&1 | grep -E 'stale (network reference|containers) for app'
+# Hit  -> auto-recovery fired; if the app STILL fails, the staleness is a new, unmatched variant
+# Miss -> not the known staleness class; read the raw compose error
+```
+
+**Fix/escalation.** Manual recovery: `docker compose down && docker compose up -d` with cwd `<path_root>/core/installed_apps/<app>/`. If you found a NEW staleness variant, extend the string-match in app_tools.py (plus its tests) rather than adding a separate ad-hoc retry path. Also note `docker_start_app` is `@throttle(5)` — global across ALL apps, silently dropping calls within 5s of any other app's start (`shard_core/util/misc.py`); a "second app didn't start" report right after another app started may just be the throttle.
+
+## 4. Backup failures — the rclone class
+
+Backups: daily CronTask 03:00 UTC + ≤1h jitter runs `rclone ... sync` of `core/` and `user_data/` to an Azure blob container via a controller-issued SAS URL, crypt-encrypted with a passphrase from the `kv_store` table (`shard_core/service/backup.py`). Four distinct known failure modes:
+
+**(a) Flag not supported by the shipped rclone.** [#117](https://github.com/FreeshardBase/freeshard/issues/117) (P0 release blocker): ALL v18 backups failed because `--azureblob-no-check-container`, added in the cost optimization PR [#106](https://github.com/FreeshardBase/freeshard/pull/106), did not exist in the rclone version baked into the image (Dockerfile installs rclone from Debian bookworm). Fixed by dropping the flag, PR [#119](https://github.com/FreeshardBase/freeshard/pull/119). **Rule: any new rclone flag must be validated against the image's pinned rclone version** — `docker run --rm ghcr.io/freeshardbase/freeshard:<tag> rclone help flags | grep <flag>`.
+
+**(b) Strict parsing of rclone's stats JSON.** Recurred across two years: 9666db5 (2024, 0.28.x rollout) and b9dfcfd (2026, 0.38.3). **Rule: rclone's JSON log/stats output is an opaque dict; never pydantic-validate its shape.**
+
+**(c) Dead cron task.** CronTask used to die permanently on any exception, silently killing all future backups until restart ([#58](https://github.com/FreeshardBase/freeshard/issues/58)). Fixed: both PeriodicTask and CronTask now catch, log, and keep looping (`shard_core/util/async_util.py:98-101`). If backups stopped and there's no error at 03:00-ish in the logs, suspect this class regressed.
+
+**(d) Exit-code masking.** Historically `_backup_directory` never checked the rclone returncode — an rclone failure whose last stderr line happened to be valid JSON was recorded as a successful backup, and real failures surfaced as confusing `JSONDecodeError`s. Fixed on main (a4a80bc, merged 2026-06-30 via PR #119: `process.returncode != 0` now raises `BackupFailedError`, backup.py:177-180) — **but as of 2026-07-03 that commit is in no released tag** (`git tag --contains a4a80bc` is empty). Deployed shards ≤ 0.39.4 still have the masking behavior.
+
+**Discriminating experiment.**
+
+```bash
+docker logs shard_core 2>&1 | grep -iE 'rclone|backup' | tail -30
+# "Error: unknown flag"            -> mode (a): flag vs pinned rclone version
+# "Failed to parse rclone output"  -> mode (b) or, on <=0.39.4, a masked real failure (d)
+# nothing at all around 03:00 UTC  -> mode (c) or the task never started; check task startup logs
+```
+
+Recency check without logs: the `_last_backup` marker blob's Last-Modified in the Azure container is the controller's recency signal (backup.py:133-151); a `backups` table row is written per run (`select * from backups order by 1 desc limit 3;`).
+
+Self-hosted note: backups REQUIRE a controller SAS URL — on self-hosted shards `start_backup` always fails with `BackupStartFailedError`. Not a bug.
+
+## 5. Burst 500s on app access — forwardAuth pool exhaustion
+
+**Symptom.** Opening an app (especially an SPA that fires ~30 parallel requests, e.g. Actual Budget) yields a batch of 500s; single requests fine.
+
+**Story.** forwardAuth means EVERY app request hits shard_core `/internal/auth`. It used to cost 2-3 DB queries per call; a 4-connection pool exhausted under SPA bursts → 30s pool waits → 500s. Issue [#89](https://github.com/FreeshardBase/freeshard/issues/89) (high-priority), fixed in PR [#90](https://github.com/FreeshardBase/freeshard/pull/90): pool `max_size=20, timeout=10` (`shard_core/database/connection.py:28-29`) plus in-process `_identity_cache`/`_app_cache` making the auth path zero-DB at steady state. Caches have NO TTL — they are invalidated only by the `on_identity_update` / `on_apps_update` signals (`shard_core/web/internal/auth.py:36-44`).
+
+**Discriminating experiment.** If burst 500s reappear, the prime suspect is a cache-invalidation gap, not pool size:
+
+```bash
+# Did some code path change identity/app state WITHOUT emitting the signal?
+git grep -n "send_async" shard_core | grep -E "on_apps_update|on_identity_update"
+# Cross-check: every writer of installed_apps/identities rows must appear here.
+# Meanwhile in logs: psycopg pool timeout errors around the burst -> pool path; auth 401/500 with fresh state -> stale cache.
+```
+
+**Rule.** Any NEW per-request lookup added to the auth path needs a cache with signal-driven invalidation, or it recreates #89. Every DB status change must be followed by `await signals.on_apps_update.send_async()` — forgetting it means stale auth decisions until the next unrelated update.
+
+## 6. Immich broken — THREE distinct failure modes. Discriminate first.
+
+Immich incidents get conflated because all three end in "thumbnails/uploads broken". Acting on the wrong one wastes hours (e.g. doubling RAM for a non-OOM crash). Details below are from the June/July 2026 production incidents; recovery specifics are operational knowledge, not verifiable in this repo — re-check against current Immich/VectorChord docs before running them.
+
+| Mode | Fingerprint | NOT this if... |
+|---|---|---|
+| (A) pgvecto.rs index corruption | Immich's postgres container crash-loops on a ~86s period; its logs show `PANIC` with `ERRORDATA_STACK_SIZE` (signal 6); thumbnails 404 | postgres stays up |
+| (B) VectorChord 0.3→0.4 stale index | Uploads/jobs abort; postgres process dies with **SIGABRT, not SIGKILL** — doubling RAM changes nothing (that is the discriminator vs OOM); happens after an Immich upgrade needing VectorChord 0.4.x while the packaged postgres image ships 0.3.0 | `dmesg`/`docker inspect` shows OOMKilled=true (then it's §7) |
+| (C) Upstream v2.7.x aspect-ratio regression | Thumbnails wrong/broken but DB perfectly healthy, no crashes | any postgres crash present |
+
+**Discriminating experiment.**
+
+```bash
+docker inspect --format 'OOM={{.State.OOMKilled}} Exit={{.State.ExitCode}} Restarts={{.RestartCount}}' <immich-postgres-container>
+docker logs --tail 200 <immich-postgres-container> 2>&1 | grep -E 'PANIC|SIGABRT|vchord|vectors'
+# PANIC + crash loop            -> mode A
+# SIGABRT on REINDEX/insert     -> mode B
+# clean logs, OOM=false         -> mode C (upstream; check Immich version against upstream changelog)
+```
+
+**Recovery sketches.** A: clear the pg_vectors index data and migrate to VectorChord. B (July 2026, recovered with no data loss): create the missing `pg_vectors/indexes` dir, `ALTER EXTENSION vchord UPDATE`, then `REINDEX`. C: wait for/pin an upstream fix; nothing shard-side to do.
+
+**Systemic fixes filed** (open as of 2026-07-03): derive app compose from upstream's version-pinned compose so supporting-image versions can't drift ([app-repository#29](https://github.com/FreeshardBase/app-repository/issues/29)); don't let the lifecycle manager kill in-flight migrations ([#121](https://github.com/FreeshardBase/freeshard/issues/121)); show "updating" instead of a bare 502 ([#120](https://github.com/FreeshardBase/freeshard/issues/120)).
+
+## 7. OOM kills / restart loops invisible to the user
+
+**Symptom.** User reports an app "sometimes doesn't work" or shows a bare 502; nothing in the UI explains why. On size-S shards (2 CPU/4GB) heavyweight apps (Immich) get OOM-killed and restart-loop silently. Open issue: [#120](https://github.com/FreeshardBase/freeshard/issues/120).
+
+**Adjacent trap:** shard_core's idle-stop (apps stopped after `idle_time_for_shutdown`, default 60s, when no authed request arrives) can kill an app mid-database-migration right after an update — the app is "busy", not "idle", but shard_core only counts inbound requests. Open issue: [#121](https://github.com/FreeshardBase/freeshard/issues/121). Also note: idle-stop's last-access state is in-memory only, so after a shard_core restart ALL non-always-on running apps get stopped on the first `control_apps` tick (`shard_core/service/app_lifecycle.py:63-66` area) — a wave of app stops right after a core update is expected behavior, not an incident.
+
+**Discriminating experiment.**
+
+```bash
+docker inspect --format 'OOM={{.State.OOMKilled}} Exit={{.State.ExitCode}} Restarts={{.RestartCount}}' <app-container>
+# OOM=true                    -> genuine OOM: app vs VM size; check app's minimum_portal_size vs shard vm_size
+# OOM=false, app was stopped  -> check shard_core logs for idle-stop ("stopping app") near the failure time
+```
+
+**Escalation.** Both are open product gaps, not code bugs you should hotfix ad hoc — if your task touches them, work the issues, don't invent a side-channel fix.
+
+## 8. Config override silently not applying
+
+**Symptom.** You set an env var (compose file, .env, CI) and shard_core behaves as if it isn't there. No error anywhere.
+
+**Story.** Settings use pydantic-settings with `env_prefix="FREESHARD_"` and `env_nested_delimiter="__"` (`shard_core/settings.py:111-112`). A nested field needs a DOUBLE underscore between section and field: `FREESHARD_DNS__ZONE`, not `FREESHARD_DNS_ZONE`. Single-underscore names are silently ignored and the TOML value wins. This has shipped as a real production bug before — incident narrative and the still-broken justfile recipe: freeshard-config-and-flags.
+
+**Discriminating experiment** (run in repo root, needs `uv sync`; prints the dev-config fallback `localhost` when the var is ignored):
+
+```bash
+FREESHARD_DNS__ZONE=probe.example .venv/bin/python -c \
+  "from shard_core.settings import Settings; print(Settings().dns.zone)"   # -> probe.example
+FREESHARD_DNS_ZONE=probe.example .venv/bin/python -c \
+  "from shard_core.settings import Settings; print(Settings().dns.zone)"   # -> localhost (silently ignored)
+```
+
+Adapt the field path to whatever you're overriding. Precedence: env > `local_config.toml` > `config.toml`. Also: the `CONFIG` env var seen in the justfile and CI is dead — nothing reads it. Full catalog: freeshard-config-and-flags.
+
+## 9. Test fails only in CI (timeout)
+
+Known flaky class with documented precedent fixes (timeout bumps, LifespanManager shutdown_timeout, network teardown, demote-to-unit-test). Do not debug from scratch here — go to **freeshard-testing-and-qa**.
+
+## 10. App stuck INSTALLATION_QUEUED / INSTALLING after a restart
+
+**Symptom.** An app shows INSTALLATION_QUEUED or INSTALLING indefinitely; nothing is happening.
+
+**Root cause.** The installation queue is a single in-memory `asyncio.Queue` drained by one serial worker (`shard_core/service/app_installation/worker.py`). It is NOT persistent and there is NO startup reconciliation: if shard_core restarts between enqueue and completion, the DB row is stranded in its transitional status forever. Apps in INSTALLATION_QUEUED/INSTALLING are also excluded from lifecycle control (`app_lifecycle.py:45`) and from traefik routing, so the app is fully inert. Additional stall cause without a restart: the zip download has no timeout, so a hung app store stalls the whole serial worker (worker is one-at-a-time — one stuck install blocks ALL queued installs).
+
+**Discriminating experiment.**
+
+```bash
+# Was shard_core restarted after the install was queued?
+docker inspect --format '{{.State.StartedAt}}' shard_core
+docker exec -it postgres psql -U shard_core -c \
+  "select name, status from installed_apps where status like '%QUEUED%' or status like '%INSTALLING%';"
+# Rows older than the container start -> stranded; no restart -> check whether the worker is stuck on a download (thread dump / logs)
+```
+
+**Recovery.** Two safe paths, both via the terminal-authed API (or the DB as last resort):
+- Uninstall: `DELETE /protected/apps/{name}` — `_uninstall_app` deliberately asserts NO status precondition (worker.py:124-134), so it works from any stranded state. Then reinstall fresh.
+- Reinstall in place: `POST /protected/apps/{name}/reinstall` — reinstall is also allowed from any status (`app_installation/__init__.py:91`).
+
+Caveat: uninstall swallows shutdown errors and proceeds to delete files + DB row — if containers existed and `compose down` failed, orphaned containers/networks remain; sweep with `docker ps -a` afterwards.
+
+---
+
+## Cross-cutting traps (read once, save hours)
+
+- **Merged is not shipped.** Check `git tag --contains <sha>` before assuming a fix is on any shard. Two incidents (#111, the backup returncode fix) sat merged-but-unreleased. Release gates: freeshard-change-control.
+- **The local checkout lies.** Always `git fetch` and reason from `origin/main`; this repo's worktrees and branches are often behind or divergent.
+- **Traefik swallows error detail.** For anything on the internal plaintext hop, tcpdump via `docker run --rm --net container:<name> nicolaka/netshoot tcpdump -i any -A -s0 'tcp port 80'`.
+- **"Up" is not "serving".** A container can be Up while its process is EMFILE-looping (§1) or its web entrypoint 200s before the backend is ready (split web/backend apps).
+- **Signals discipline.** Sync-emitted blinker signals must have sync receivers; `send_async` for async ones. An async receiver on a sync signal is a silently un-awaited coroutine.
+- **Auth on the docker network is absent by design.** All auth is Traefik forwardAuth; `docker exec`/on-network curl bypasses it. Never conclude "auth is broken" from an on-network probe, and never publish shard_core's port.
+- **ERROR status has no persisted reason.** `update_app_status(..., message=...)` only logs the message; after a UI reload an ERROR app shows no cause. Get the reason from shard_core logs at failure time.
+
+## When NOT to use this skill
+
+- Designing/adding tests, or a test is flaky → **freeshard-testing-and-qa**.
+- You need to measure (profiling, counting queries, load) rather than pattern-match a known symptom → **freeshard-diagnostics-and-tooling**.
+- You want the full history of an investigation, its dead ends and rejected fixes → **freeshard-failure-archaeology**.
+- You're deciding whether/how a fix may ship, or classifying a change → **freeshard-change-control**.
+- The problem is env setup (uv, worktrees, type-sync) → **freeshard-build-and-env**; running/deploying the stack → **freeshard-run-and-operate**.
+- You need theory (crypto, HTTP signatures, forwardAuth mechanics, rclone crypt) → **freeshard-domain-reference**.
+- Config axes and every override rule in detail → **freeshard-config-and-flags**.
+
+## Provenance and maintenance
+
+Written 2026-07-03 against origin/main tip 0a40684 (local checkout: branch fix-profile-billing-fields, 0.39.2). Primary sources: this repo's code and git history; GitHub issues/PRs cited inline (FreeshardBase/freeshard #54 #58 #63 #89 #90 #93 #94 #106 #108 #111 #112 #117 #119 #120 #121; app-repository#29); commits fd1d05b, 5de2998, a4a80bc, 9666db5, b9dfcfd, fefd2f4, d66d889, 1e0e7c1. Immich recovery specifics (§6) come from June/July 2026 production incident operations and are not verifiable in this repo — treat as leads, not gospel.
+
+Drift-prone facts — re-verify before relying on them:
+
+| Fact (as of 2026-07-03) | Re-verify with |
+|---|---|
+| Backup returncode fix (a4a80bc) in no released tag | `git fetch && git tag --contains a4a80bc` |
+| Latest release 0.39.4; local compose pins 0.39.x | `git ls-remote --tags origin \| tail -5` and `git show origin/main:docker-compose.yml \| grep image:` |
+| Self-hosted compose pins traefik:v3.6; hosted fleet on v2.11 (controller-managed) | compose: same command as above; fleet pin lives in freeshard-controller core files — check there |
+| Issues #120, #121, #91, app-repo#29 still OPEN | `gh issue view <n> --repo FreeshardBase/freeshard --json state` |
+| Auth caches + signal invalidation unchanged | `grep -n "_invalidate" shard_core/web/internal/auth.py` |
+| Pool max_size=20, timeout=10 | `grep -n max_size shard_core/database/connection.py` |
+| Docker staleness auto-recovery string-matches unchanged | `sed -n '40,65p' shard_core/service/app_tools.py` |
+| rclone flags in COMMAND_TEMPLATE (currently `--fast-list`, no `--azureblob-no-check-container`) | `git show origin/main:shard_core/service/backup.py \| sed -n '32,48p'` |
+| Env delimiter `__`, prefix FREESHARD_ | `grep -n env_nested_delimiter shard_core/settings.py` |
+| No startup reconciliation of queued statuses | `grep -rn "QUEUED" shard_core/app_factory.py` (expect no hits) |
+| Health endpoint /public/health | `grep -rn 'prefix="/health"' shard_core/web/public/health.py` |
+| readTimeout 300s in traefik static template | `git fetch && git show origin/main:data/traefik.yml \| grep -n readTimeout` (the local checkout can predate the fix) |

--- a/.claude/skills/freeshard-diagnostics-and-tooling/SKILL.md
+++ b/.claude/skills/freeshard-diagnostics-and-tooling/SKILL.md
@@ -1,0 +1,253 @@
+---
+name: freeshard-diagnostics-and-tooling
+description: "How to MEASURE things in the freeshard (shard_core) repo instead of eyeballing them: runnable scripts for type-drift vs the controller, env-override proof, todo scanning, hung-test cleanup, and churn/fix hotspots; plus techniques for fd headroom, OOM-vs-crash discrimination, on-the-wire proxy inspection, disk-space semantics, and GH board/issue queries that actually work. TRIGGER on: 'is the backend type copy stale', 'did my FREESHARD_* env var take effect', 'find todos', 'un-wedge hung test infra' (for the symptom itself — tests won't start — see freeshard-testing-and-qa first), 'which files are bug hotspots', 'measure fd headroom', 'discriminate OOM-kill from self-abort', 'capture what the proxy actually sends', 'disk_space_low semantics', 'query the Dev Board', 'gh issue view fails with projectCards', profiling with yappi. If all you have is a raw symptom string (a 'too many open files' loop, a crashing container), load freeshard-debugging-playbook first. SKIP when: you are diagnosing a specific known failure symptom and want the answer, not a measurement (use freeshard-debugging-playbook); you need config semantics/catalog (freeshard-config-and-flags); you need test-suite architecture or how to add tests (freeshard-testing-and-qa); you need the type-sync PROCEDURE across repos (freeshard-ecosystem-contracts)."
+---
+
+# Freeshard diagnostics and tooling
+
+Purpose: replace "it looks fine" with a number or a diff. Every section gives a command, what it measures, and how to read the output. All commands assume CWD = repo root (`/path/to/freeshard`, the shard_core repo). Verified against the repo on 2026-07-03.
+
+Terms used once: **shard** = a customer VM running this repo's app (shard_core: FastAPI + PostgreSQL + Docker Compose orchestration behind a Traefik reverse proxy). **controller** = the central management service (separate repo, FreeshardBase/freeshard-controller). **Dev Board** = the org-level GitHub Projects v2 board where triage actually lives (labels are not used for triage).
+
+## Script index (in `scripts/` next to this file)
+
+All scripts were run and their output verified on 2026-07-03, except `test-db-cleanup.sh` (inherently mutating; syntax- and logic-verified, component commands tested read-only).
+
+| Script | Measures | Mutates? |
+|---|---|---|
+| `check-type-drift.sh` | Drift of `shard_core/data_model/backend/*` vs controller origin/main | No (gh api reads) |
+| `verify-env-override.sh` | Whether a `FREESHARD_*` env var actually lands in `Settings()` | No |
+| `todo-scan.sh` | Code-debt markers (lowercase-aware, noise-filtered) | No |
+| `test-db-cleanup.sh` | — (teardown of hung test Docker resources) | Yes, test resources only |
+| `churn-hotspots.sh` | Git churn + fix-commit hotspots, rename-corrected | No |
+
+Run them as e.g. `.claude/skills/freeshard-diagnostics-and-tooling/scripts/check-type-drift.sh`. Do not confuse with the repo's own `scripts/` dir (it contains only `generate_traefik_dyn_config_model.py` — see "Repo-native tooling" below).
+
+## 1. Type drift vs the controller — `check-type-drift.sh`
+
+**What it measures:** `shard_core/data_model/backend/` is a verbatim copy of the controller's `data_model/` package, made by `just get-types` (justfile:13-23: `rm -rf` target, `cp -r` from the LOCAL sibling checkout, prepend a 2-line `# DO NOT MODIFY` header to every file). Nothing in CI checks freshness. Stale copies have shipped real bugs: `Profile` re-serialization silently dropped billing fields the controller had added (fixed in commits 6d4b101 and e55ce51 — `Profile.from_shard` now uses `getattr(..., default)` defensively, shard_core/data_model/profile.py).
+
+The script diffs each local file (header stripped) against the controller's **origin/main via `gh api contents`** — it does not need or trust the local sibling checkout, which is exactly the failure mode (`just get-types` from a stale checkout produced bidirectional drift in `subscription_model.py`).
+
+**Expected output** (real output, 2026-07-03 — this drift is currently live):
+
+```
+in sync         : shard_model.py
+MISSING LOCALLY : diagnostic_model.py (exists on controller main, not in shard_core/data_model/backend — next get-types adds it)
+DRIFTED         : permission_model.py
+    23a24,25
+    >     OPEN_DIAGNOSTIC = auto()
+    >     RUN_DIAGNOSTIC = auto()
+DRIFTED         : settings_model.py
+    12a13
+    >     NEW_INSTANCE_IMAGE = auto()
+DRIFTED         : subscription_model.py
+    62d61
+    <     approval_url: str | None = None
+    65a65
+    >     plan_id: str | None = None
+RESULT: DRIFT — ...
+```
+
+**Interpretation:**
+- `MISSING LOCALLY` / lines prefixed `>` = controller is ahead; the next `just get-types` (after pulling the sibling checkout!) picks them up.
+- Lines prefixed `<` on a DRIFTED file = the local copy has content main no longer has — a past sync ran against a diverged checkout. Treat the remote as truth.
+- Drift is only *operationally* urgent if shard_core loads the drifted model. As of 2026-07-03 shard_core imports the backend copy directly in 4 modules: service/telemetry.py, service/portal_controller.py, service/freeshard_controller.py, data_model/profile.py (+ tests) — but only 2 backend files directly (shard_model, telemetry_model), and `shard_model` itself transitively imports permission_model, subscription_model, and telemetry_model (backend/shard_model.py:9-11). So the currently-drifted permission_model/subscription_model ARE loaded at runtime: a controller payload with an enum member the stale copy lacks (e.g. OPEN_DIAGNOSTIC) fails `ShardResponse` validation. `git grep -n "data_model.backend" -- shard_core tests` finds only the direct imports — check shard_model's own import block too.
+- Exit code 0 = in sync, 1 = drift, 2 = setup error. Usable as a CI-style gate.
+
+For the full multi-repo sync procedure and when to run `just get-types`, use **freeshard-ecosystem-contracts**.
+
+## 2. Prove an env override lands — `verify-env-override.sh`
+
+**What it measures:** shard_core settings use pydantic-settings with `env_prefix="FREESHARD_"` and `env_nested_delimiter="__"` (shard_core/settings.py). A nested var written with a SINGLE underscore is **silently ignored** — no warning, no error. This has shipped a production bug, and as of 2026-07-03 the justfile recipe `run-dev-for-freeshard-controller` still carries an inert var of this class — incident narrative and current status: freeshard-config-and-flags.
+
+**Rule:** any time you add a `FREESHARD_*` var to docker-compose.yml, justfile, or CI, prove it lands:
+
+```
+.claude/skills/freeshard-diagnostics-and-tooling/scripts/verify-env-override.sh FREESHARD_DNS__ZONE=example.test dns.zone
+```
+
+**Expected output:**
+
+```
+PASS: FREESHARD_DNS__ZONE=example.test -> Settings().dns.zone == 'example.test'
+```
+
+and for the trap case:
+
+```
+$ .../verify-env-override.sh FREESHARD_DNS_ZONE=example.test dns.zone
+FAIL: FREESHARD_DNS_ZONE=example.test was IGNORED -> Settings().dns.zone == 'localhost'
+```
+
+(the `localhost` comes from local_config.toml — the dev overlay wins when the env var doesn't parse as an override). Top-level scalars take a single level: `FREESHARD_PATH_ROOT_HOST=/srv/x path_root_host`. For the full option catalog and precedence rules, use **freeshard-config-and-flags**.
+
+## 3. Find real code debt — `todo-scan.sh`
+
+**What it measures:** actionable in-code markers. Two traps make naive scans lie here:
+
+1. **All markers are lowercase** (`# todo:`). Scanners that grep `TODO|FIXME` (the common default) return **zero** hits in this repo.
+2. Plain `grep -r` from repo root sweeps `.worktrees/` (stale agent worktrees → duplicate hits) and `data/eff_large_wordlist.txt` (`hacker` matches `hack`). The script uses `git grep -inI` (tracked text files only) and excludes `data/`, `tests/fixtures/`, `*.png`, `*.lock`.
+
+**Expected output** (2026-07-03 — 5 real code todos, all in one subsystem, plus compose placeholders):
+
+```
+docker-compose.yml:38-42        #- AZURE_*=todo          <- self-hoster placeholders, not debt
+shard_core/data_model/app_meta.py:48:# todo: use data_model.backend.shard_model.VmSize ...
+shard_core/web/internal/app_error.py:45:# todo: add special splash screen for app that is not size compatible
+shard_core/web/internal/call_peer.py:34:# todo: test this
+tests/test_app_lifecycle.py:101:# todo: test_large_app_does_not_start
+tests/test_app_lifecycle.py:103:# todo: test app with size comparison
+```
+
+**Interpretation:** four of the five real todos cluster in the app-size-compatibility subsystem (duplicate VMSize enum, missing size-incompatible splash, two missing size tests) — the repo's named code-debt hotspot; the fifth (call_peer.py:34 `todo: test this`) marks the untested `lru_cache`'d peer-proxy path (see freeshard-failure-archaeology §4.3). If your scan returns zero, your scanner is uppercase-only, not the repo clean.
+
+## 4. Un-wedge the test suite — `test-db-cleanup.sh`
+
+**What it fixes:** pytest (pytest-docker) starts postgres:17 under compose project `shard-core-test` with host port **5433 pinned** (tests/docker-compose.yml, tests/conftest.py `docker_compose_project_name`). Heavier `api_client` tests also create the Docker network `portal` and real app containers. A killed pytest leaves these behind; symptoms of leftovers:
+
+| Symptom | Cause |
+|---|---|
+| `bind: address already in use` on 5433 at session start | stale `shard-core-test` postgres |
+| `network with name portal already exists` / teardown hangs | stale `portal` network with containers still attached (incident: commit 28964fd "portal network not torn down between tests") |
+| two worktrees' suites failing each other | both pin port 5433 + project name — suites cannot run concurrently on one host |
+
+**Usage:** `.claude/skills/freeshard-diagnostics-and-tooling/scripts/test-db-cleanup.sh` — runs `docker compose -p shard-core-test -f tests/docker-compose.yml down -v --remove-orphans`, then removes the `portal` network **only if no containers are attached**. `--force` force-disconnects attached containers first (mirrors `tests/util.py:_force_remove_docker_network`). Do NOT `--force` while a dev shard (`just run-dev`) is using the `portal` network on the same host.
+
+**Fast wiring check before/after:** `.venv/bin/pytest tests --collect-only -q` — imports every test module and the app package without starting Docker. Verified 2026-07-03: `134 tests collected in 0.29s` on the e55ce51 checkout (origin/main collects 137 — see freeshard-testing-and-qa). If collection fails, you have an import/syntax problem, not a Docker problem; fix that first. For fixture selection and flaky-test playbooks, use **freeshard-testing-and-qa**.
+
+## 5. Where do bugs live — `churn-hotspots.sh`
+
+**What it measures:** per-file commit counts (churn) and per-file *fix*-commit counts over git history. Naive `git log --name-only | sort | uniq -c` double-counts this repo because of two wholesale renames, which the script normalizes:
+
+- `portal_core/` → `shard_core/` (commit 88e5842, 2025-02-11 — the project was formerly named "Portal")
+- `shard_core/model/` → `shard_core/data_model/` (commit b5b4eda, 2025-08-04)
+
+It also filters to files that still exist (`git ls-files`), so deleted files don't pollute the ranking.
+
+**Usage:** full history, or `--since 2026-01-01` for the recent picture.
+
+**Expected output shape** (real top entries, full history, 2026-07-03):
+
+```
+== top 20 by total churn ==
+    107 tests/conftest.py
+     69 shard_core/__init__.py
+     45 shard_core/web/internal/auth.py
+     38 shard_core/service/app_tools.py
+== top 20 by fix-commit count ==
+     33 tests/conftest.py
+     15 shard_core/service/app_tools.py
+     10 shard_core/app_factory.py
+      9 shard_core/web/internal/auth.py
+```
+
+**Interpretation:** a file high on BOTH lists is a defect hotspot; expect hidden invariants and review scrutiny. Known hotspot families this confirms: the auth path (`web/internal/auth.py`, DB-pool exhaustion incident https://github.com/FreeshardBase/freeshard/issues/89), docker lifecycle (`service/app_tools.py`), and the proxy code (`web/internal/call_backend.py` / `call_peer.py` — repeat offender: Content-Type https://github.com/FreeshardBase/freeshard/issues/93, query strings, streaming). `shard_core/__init__.py` ranks high because version strings lived there historically — not a real hotspot. For the incident narratives, use **freeshard-failure-archaeology**.
+
+## Measurement techniques (no script needed)
+
+### fd headroom in a container (the EMFILE class)
+
+```
+docker exec traefik sh -c 'ulimit -n'
+```
+
+Container names on a shard are fixed by docker-compose.yml (`traefik`, `shard_core`, `postgres`, `web-terminal`). **Interpretation:** `1024` is the Docker per-container default soft limit; a Go binary built with Go < 1.19 does not self-raise RLIMIT_NOFILE, so 1024 is the whole budget for an internet-facing proxy — the June 2026 fleet outage ("up but not serving", `accept4: too many open files` in a hot loop) was exactly this, fixed by finite `readTimeout` (https://github.com/FreeshardBase/freeshard/pull/108) plus a fleet Traefik bump to a modern-Go build (decision comment on closed https://github.com/FreeshardBase/freeshard/pull/112: stay on Traefik v2, bump to v2.11 whose Go 1.25 self-raises nofile; note this repo's own docker-compose.yml — the self-hosted/dev stack — pins `traefik:v3.6` as of 2026-07-03). A value ≥ ~64000 means a modern Go runtime already self-raised it. Watch fd consumption live: `docker exec traefik sh -c 'ls /proc/1/fd | wc -l'` vs the ulimit.
+
+### What a proxy ACTUALLY sends — tcpdump in the container's netns
+
+When a request "should be fine" but the receiver rejects it, stop reasoning about what the code intends and capture the plaintext internal hop:
+
+```
+docker run --rm --net container:shard_core nicolaka/netshoot \
+  tcpdump -i any -A -s0 'tcp port 80'
+```
+
+`--net container:<name>` joins the target's network namespace, so you see its traffic without touching the container. **Interpretation guide:** read the actual header block of the outbound request. This technique found that `call_backend` forwarded bodies but no `Content-Type` header — controller-inbound requests had Host, Content-Length, Content-Digest, Signature, but no Content-Type, so a strict FastAPI 422'd every proxied write while reads worked (https://github.com/FreeshardBase/freeshard/issues/93, root-cause in FreeshardBase/freeshard-controller#267). The red herring chased before capturing: double-encoding.
+
+### OOM kill vs crash — SIGKILL(137) vs SIGABRT(134)
+
+A restart-looping container "looks like OOM". Discriminate before buying RAM:
+
+```
+docker inspect <container> --format 'status={{.State.Status}} exit={{.State.ExitCode}} oom={{.State.OOMKilled}}'
+dmesg -T | grep -iE 'oom|killed process' | tail
+```
+
+| Evidence | Meaning |
+|---|---|
+| exit 137 (=128+9, SIGKILL) + `OOMKilled=true` or dmesg oom-kill lines | real memory exhaustion — resize / limit issue |
+| exit 134 (=128+6, SIGABRT), `OOMKilled=false`, no dmesg oom entries | the process **aborted itself** — a crash/assert; more RAM changes nothing |
+| exit 137, `OOMKilled=false`, but dmesg shows a *child* process oom-killed | cgroup OOM killed a child; the flag on the main container can stay false — trust dmesg |
+
+Real precedent: a shard's Immich postgres restart-loop was assumed OOM (size-S shard); doubling RAM changed nothing because it was SIGABRT from a broken postgres extension. User-visibility of exactly this failure class is open work: https://github.com/FreeshardBase/freeshard/issues/120 and https://github.com/FreeshardBase/freeshard/issues/121.
+
+### disk_space_low — what it actually means
+
+`shard_core/service/disk.py`: a `PeriodicTask` runs `update_disk_space()` every 30 s (app_factory.py:134). It calls `shutil.disk_usage(settings().path_root / "user_data")` and sets `disk_space_low = free < 1 GiB` (disk.py:24-28, GiB = 1024³). Consequences of the flag: app starts are refused (service/app_lifecycle.py:26,55) and the app-error splash reports it (web/internal/app_error.py:59). Read it: `GET /protected/stats/disk` (externally `https://<shard-domain>/core/protected/stats/disk`), or the `disk_usage_update` websocket broadcast (service/websocket.py:114-116). Notes: it measures the **filesystem containing `{path_root}/user_data`**, not the whole disk; on a dev checkout `path_root` is `run/` (local_config.toml), so it measures your dev machine's disk; the module-level value starts as all-zeros/`False` until the first 30 s tick.
+
+### Profiling — yappi (available, usage unproven)
+
+`yappi` is a dev dependency (pyproject.toml `[project.optional-dependencies].dev`; import verified 2026-07-03). There is one opt-in fixture, `profile_with_yappi` (tests/conftest.py:398-403): wall-clock mode, wraps the test in `yappi.run()`, prints func stats after. As of 2026-07-03 **no test requests it** — treat it as a candidate tool, not an established practice. Use: add `profile_with_yappi` to a slow test's signature, run that single test, read the printed `tsub`/`ttot` columns (own time vs cumulative). Precedent for perf work here is the auth-path fix (https://github.com/FreeshardBase/freeshard/issues/89 → PR #90); nothing in the repo shows yappi was the tool used.
+
+### GH issue/board queries that actually work (FreeshardBase specifics)
+
+```
+# Issue with comments — the --comments flag FAILS on this org:
+gh issue view 24 --repo FreeshardBase/freeshard --json body,comments
+# (gh issue view 24 --comments errors: "GraphQL: Projects (classic) is being
+#  deprecated ... (repository.issue.projectCards)")
+
+# Dev Board (org Projects v2: project 3 = Dev Board, project 2 = Roadmap):
+gh project item-list 3 --owner FreeshardBase --format json --limit 200
+```
+
+Board item fields (verified 2026-07-03): `title`, `status`, `stage` (Backlog/Refined/Done), `priority` (P0–P3), `"needs Intent"`, `"blocked By"`, `"linked pull requests"`, `repository`, `content`, `assignees`, `labels` — gh omits fields that are empty on an item, so use `.["needs Intent"] // empty` style jq. **Substring-leak trap:** filtering by `.content.url | contains("FreeshardBase/freeshard")` also matches the 37 freeshard-controller items (2026-07-03: board had 71 items, only 25 from this repo). Filter exactly:
+
+```
+gh project item-list 3 --owner FreeshardBase --format json --limit 200 \
+  --jq '.items[] | select(.repository=="https://github.com/FreeshardBase/freeshard") | "\(.priority // "-") \(.stage // "-") \(.title)"'
+```
+
+Also: labels are NOT the triage system here (only one custom label, `high-priority`); priority lives in the board fields. `--json stateReason` is not a valid issue field via gh.
+
+### Production shards — the controller diagnostics API
+
+You cannot SSH into or `docker exec` on a customer shard from here. The sanctioned path is the controller's **Shard Diagnostics** feature (merged as FreeshardBase/freeshard-controller#303, 2026-06-16): a human operator opens a time-boxed, read-only, **leveled** diagnostic on one shard (L1 system state → L2 +logs → L3 +data reads; promotion is up-only), and hands the diagnostic **id** to the agent. The agent then runs probes from a server-side allowlisted command catalogue via controller endpoints — an agent token is inert until an operator opens a diagnostic, and every probe/note lands in an append-only audit timeline. If you are asked to troubleshoot a production shard: request that an operator open a diagnostic and give you its id; without one there is by design nothing you can do. The API and probe catalogue live in the freeshard-controller repo, not here.
+
+### Repo-native tooling worth knowing
+
+- `scripts/generate_traefik_dyn_config_model.py` — the generator that once produced the 1117-line `shard_core/data_model/traefik_dyn_config.py` from the Traefik v2 JSON schema. It deliberately `raise`s on run ("Do no use! Output file was manually changed by adding authResponseHeadersRegex.") and still points at the pre-rename `portal_core/model/` path. Do not run it; edit the model by hand and keep the manual patch.
+- `justfile` — check it before inventing commands: `just cleanup` (ruff --fix + black), `just run-dev`, `just get-types`, `just set-version X`.
+- `management_mock.py` (repo root) — a mock of the management API for local dev; see **freeshard-build-and-env** / **freeshard-run-and-operate** for how it's used.
+
+## When NOT to use this skill
+
+- You have a **symptom** and want the known cause → **freeshard-debugging-playbook** (this skill gives you instruments; that one gives you diagnoses).
+- You want the story/evidence of a past incident → **freeshard-failure-archaeology**.
+- You're adding/altering a config option or need env-precedence semantics → **freeshard-config-and-flags** (this skill only *proves* an override lands).
+- You're writing or fixing tests, choosing fixtures, or chasing flakes → **freeshard-testing-and-qa** (this skill only un-wedges hung test infra and checks collection).
+- You need the cross-repo type-sync **procedure** or contract map → **freeshard-ecosystem-contracts** (this skill only *measures* drift).
+- You're setting up a dev environment or worktree → **freeshard-build-and-env**.
+- You're deciding whether a change may ship / how to release → **freeshard-change-control**.
+
+## Provenance and maintenance
+
+Written 2026-07-03 against freeshard main-lineage checkout (branch fix-profile-billing-fields, HEAD e55ce51). Primary sources: the repo itself (shard_core/settings.py, shard_core/service/disk.py, tests/conftest.py, tests/util.py, justfile, pyproject.toml, docker-compose.yml), GitHub issues/PRs cited inline (freeshard #89 #93 #108 #111 #112 #120 #121; freeshard-controller #267 #303), and commits 5de2998, 88e5842, b5b4eda, 6d4b101, e55ce51, 28964fd. All five scripts executed 2026-07-03 except test-db-cleanup.sh (mutating; syntax-checked, component reads tested).
+
+Drift-prone facts — re-verify before relying:
+
+| Fact (as of 2026-07-03) | Re-verification command |
+|---|---|
+| Backend type copy drift state (diagnostic_model missing, 3 files drifted) | `.claude/skills/freeshard-diagnostics-and-tooling/scripts/check-type-drift.sh` |
+| shard_core imports backend copy in 4 modules + tests (plus shard_model's transitive imports) | `git grep -n "data_model.backend" -- shard_core tests` and `head -12 shard_core/data_model/backend/shard_model.py` |
+| 5 lowercase code todos, all in app-size subsystem | `.claude/skills/freeshard-diagnostics-and-tooling/scripts/todo-scan.sh` |
+| 134 tests collected at e55ce51 (137 on origin/main), collection needs no Docker | `.venv/bin/pytest tests --collect-only -q` |
+| Test compose project `shard-core-test`, host port 5433 | `grep -n "shard-core-test" tests/conftest.py; grep -n 5433 tests/docker-compose.yml` |
+| disk_space_low threshold = free < 1 GiB on user_data, 30 s period | `sed -n '22,30p' shard_core/service/disk.py; grep -n update_disk_space shard_core/app_factory.py` |
+| justfile run-dev-for-freeshard-controller still has the single-underscore inert env var | `grep -n "FREESHARD_FREESHARD_CONTROLLER" justfile` |
+| yappi fixture exists but no test uses it | `git grep -n profile_with_yappi -- tests` |
+| Dev Board = project 3, 25/71 items from this repo, field names | `gh project item-list 3 --owner FreeshardBase --format json --limit 200 --jq '[.items[] \| keys] \| add \| unique'` |
+| `gh issue view --comments` still broken on this org | `gh issue view 24 --repo FreeshardBase/freeshard --comments` (expect projectCards GraphQL error) |
+| Diagnostics feature shape (levels, operator-gated) | `gh pr view 303 --repo FreeshardBase/freeshard-controller --json body` |
+| Fixed container names traefik/shard_core/postgres/web-terminal | `grep -n container_name docker-compose.yml` |

--- a/.claude/skills/freeshard-diagnostics-and-tooling/scripts/check-type-drift.sh
+++ b/.claude/skills/freeshard-diagnostics-and-tooling/scripts/check-type-drift.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# check-type-drift.sh — report drift between shard_core/data_model/backend/*
+# (the local copy of freeshard-controller's data_model, synced by `just get-types`)
+# and the controller's origin/main, WITHOUT needing the sibling checkout.
+#
+# Read-only: fetches remote files via `gh api contents`, diffs against the local
+# copy with the 2-line "# DO NOT MODIFY" header stripped.
+#
+# Usage (from repo root):  .claude/skills/freeshard-diagnostics-and-tooling/scripts/check-type-drift.sh
+# Exit code: 0 = fully in sync, 1 = drift found, 2 = setup error.
+
+set -u
+
+LOCAL_DIR="shard_core/data_model/backend"
+REMOTE_PATH="freeshard-controller-backend/freeshard_controller/data_model"
+REPO="FreeshardBase/freeshard-controller"
+REF="${1:-main}"
+
+if [ ! -d "$LOCAL_DIR" ]; then
+	echo "ERROR: $LOCAL_DIR not found — run from the freeshard repo root." >&2
+	exit 2
+fi
+if ! command -v gh >/dev/null; then
+	echo "ERROR: gh CLI required." >&2
+	exit 2
+fi
+
+remote_files=$(gh api "repos/$REPO/contents/$REMOTE_PATH?ref=$REF" --jq '.[] | select(.type=="file") | .name') || {
+	echo "ERROR: could not list $REPO:$REMOTE_PATH@$REF via gh api." >&2
+	exit 2
+}
+
+drift=0
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+for f in $remote_files; do
+	gh api "repos/$REPO/contents/$REMOTE_PATH/$f?ref=$REF" --jq '.content' | base64 -d > "$tmp/remote"
+	if [ ! -f "$LOCAL_DIR/$f" ]; then
+		echo "MISSING LOCALLY : $f (exists on controller $REF, not in $LOCAL_DIR — next get-types adds it)"
+		drift=1
+		continue
+	fi
+	# get-types prepends "# DO NOT MODIFY - copied from freeshard-controller\n\n";
+	# empty files (e.g. __init__.py) get no header, so strip conditionally.
+	if head -1 "$LOCAL_DIR/$f" | grep -q '^# DO NOT MODIFY'; then
+		tail -n +3 "$LOCAL_DIR/$f" > "$tmp/local"
+	else
+		cp "$LOCAL_DIR/$f" "$tmp/local"
+	fi
+	if diff -q "$tmp/local" "$tmp/remote" >/dev/null; then
+		echo "in sync         : $f"
+	else
+		echo "DRIFTED         : $f"
+		diff "$tmp/local" "$tmp/remote" | sed 's/^/    /'
+		drift=1
+	fi
+done
+
+# Files that exist locally but not on the controller anymore (removed upstream).
+for lf in "$LOCAL_DIR"/*.py; do
+	name=$(basename "$lf")
+	if ! printf '%s\n' "$remote_files" | grep -qx "$name"; then
+		echo "EXTRA LOCALLY   : $name (gone from controller $REF — next get-types removes it)"
+		drift=1
+	fi
+done
+
+if [ "$drift" -eq 0 ]; then
+	echo "RESULT: backend type copy is in sync with $REPO@$REF"
+else
+	echo "RESULT: DRIFT — before relying on these types: cd ../freeshard-controller && git checkout main && git pull, then 'just get-types' here (destructive rm -rf + copy)."
+fi
+exit $drift

--- a/.claude/skills/freeshard-diagnostics-and-tooling/scripts/churn-hotspots.sh
+++ b/.claude/skills/freeshard-diagnostics-and-tooling/scripts/churn-hotspots.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# churn-hotspots.sh — rank files by change frequency (churn) and by how often
+# they appear in fix-commits. High fix-count files are where the next bug is.
+#
+# Rename handling (this repo has two big ones that break naive counting):
+#   - portal_core/ -> shard_core/            (commit 88e5842, 2025-02-11)
+#   - shard_core/model/ -> shard_core/data_model/  (commit b5b4eda, 2025-08-04)
+# Paths from old commits are normalized to their current names, and only files
+# that still exist (git ls-files) are counted, so dead files don't pollute the list.
+#
+# Usage (from repo root):
+#   .claude/skills/freeshard-diagnostics-and-tooling/scripts/churn-hotspots.sh            # full history
+#   .claude/skills/freeshard-diagnostics-and-tooling/scripts/churn-hotspots.sh --since 2026-01-01
+# Read-only.
+
+set -u
+
+SINCE_ARGS=()
+if [ "${1:-}" = "--since" ] && [ -n "${2:-}" ]; then
+	SINCE_ARGS=(--since "$2")
+fi
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+	echo "ERROR: not inside a git checkout." >&2
+	exit 2
+fi
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+git ls-files > "$tmp/live"
+
+normalize() {
+	sed -e 's|^portal_core/|shard_core/|' -e 's|^shard_core/model/|shard_core/data_model/|'
+}
+
+echo "== top 20 by total churn (commits touching the file) =="
+git log "${SINCE_ARGS[@]}" --format= --name-only \
+	| grep -v '^$' | normalize | grep -Fxf "$tmp/live" \
+	| sort | uniq -c | sort -rn | head -20
+
+echo
+echo "== top 20 by fix-commit count (subject contains fix, case-insensitive) =="
+git log "${SINCE_ARGS[@]}" -i --grep 'fix' --format= --name-only \
+	| grep -v '^$' | normalize | grep -Fxf "$tmp/live" \
+	| sort | uniq -c | sort -rn | head -20
+
+echo
+echo "Interpretation: a file high on BOTH lists is a defect hotspot — read"
+echo "freeshard-failure-archaeology before touching it, and expect review scrutiny."

--- a/.claude/skills/freeshard-diagnostics-and-tooling/scripts/test-db-cleanup.sh
+++ b/.claude/skills/freeshard-diagnostics-and-tooling/scripts/test-db-cleanup.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# test-db-cleanup.sh — tear down leftovers of a hung/aborted pytest run.
+#
+# The test suite (pytest-docker) starts postgres:17 under compose project
+# "shard-core-test" (tests/conftest.py: docker_compose_project_name) with host
+# port 5433 pinned (tests/docker-compose.yml). api_client tests additionally
+# create the docker network "portal" and real app containers. A killed pytest
+# leaves these behind; the next run then fails on the pinned port / stale
+# network. This script removes them. It mutates only test resources.
+#
+# Usage (from repo root): .claude/skills/freeshard-diagnostics-and-tooling/scripts/test-db-cleanup.sh
+#   The "portal" network is also used by a real dev shard (`just run-dev`).
+#   The script refuses to touch a portal network that still has containers
+#   attached unless you pass --force (which force-disconnects them first,
+#   mirroring tests/util.py:_force_remove_docker_network).
+
+set -u
+FORCE=0
+[ "${1:-}" = "--force" ] && FORCE=1
+
+if [ ! -f tests/docker-compose.yml ]; then
+	echo "ERROR: run from the freeshard repo root." >&2
+	exit 2
+fi
+
+echo "== compose project shard-core-test =="
+docker compose -p shard-core-test -f tests/docker-compose.yml down -v --remove-orphans
+
+echo "== docker network 'portal' =="
+if ! docker network inspect portal >/dev/null 2>&1; then
+	echo "portal network does not exist — nothing to do."
+	exit 0
+fi
+
+attached=$(docker network inspect portal --format '{{range .Containers}}{{.Name}} {{end}}')
+if [ -n "${attached// /}" ]; then
+	if [ "$FORCE" -eq 1 ]; then
+		for name in $attached; do
+			echo "force-disconnecting $name"
+			docker network disconnect -f portal "$name" || true
+		done
+	else
+		echo "REFUSING: portal network still has containers attached: $attached"
+		echo "If these are test leftovers (e.g. filebrowser/immich/paperless-ngx), re-run with --force."
+		echo "If a dev shard is running on this host, do NOT force — you would break it."
+		exit 1
+	fi
+fi
+docker network rm portal && echo "portal network removed."

--- a/.claude/skills/freeshard-diagnostics-and-tooling/scripts/todo-scan.sh
+++ b/.claude/skills/freeshard-diagnostics-and-tooling/scripts/todo-scan.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# todo-scan.sh — find code-debt markers in this repo.
+#
+# Two traps this script exists to avoid:
+#   1. ALL markers in this repo are LOWERCASE ("# todo:"). An uppercase-only
+#      scan (TODO|FIXME, what most scanners default to) returns ZERO hits.
+#   2. Plain `grep -r` from repo root sweeps .worktrees/ (stale agent worktrees
+#      with duplicate hits) and data/eff_large_wordlist.txt ('hacker' matches
+#      'hack'). `git grep` only searches tracked files of THIS checkout, and we
+#      exclude data/ explicitly.
+#
+# Usage (from repo root): .claude/skills/freeshard-diagnostics-and-tooling/scripts/todo-scan.sh
+# Exit code: 0 always (a scan with hits is not a failure).
+
+set -u
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+	echo "ERROR: not inside a git checkout." >&2
+	exit 2
+fi
+
+EXCLUDES=(':!data' ':!*.lock' ':!tests/fixtures' ':!*.png')
+echo "== todo/fixme/hack/xxx markers (case-insensitive, tracked text files; data/, fixtures excluded) =="
+git grep -inI --color=never -E 'todo|fixme|hack|xxx' -- "${EXCLUDES[@]}" | grep -vE '^\S+:[0-9]+:.*https?://' || echo "(no markers found)"
+echo
+echo "== count by file =="
+git grep -icI -E 'todo|fixme|hack|xxx' -- "${EXCLUDES[@]}" || true

--- a/.claude/skills/freeshard-diagnostics-and-tooling/scripts/verify-env-override.sh
+++ b/.claude/skills/freeshard-diagnostics-and-tooling/scripts/verify-env-override.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# verify-env-override.sh — prove that a FREESHARD_* env var actually lands in Settings().
+#
+# Why this exists: pydantic-settings uses env_nested_delimiter="__" (DOUBLE underscore,
+# shard_core/settings.py). A single-underscore nested var is SILENTLY ignored — this
+# shipped a production bug once (commit 5de2998: self-hosted compose used
+# FREESHARD_DNS_ZONE, shards silently fell back to zone "freeshard.cloud").
+# Run this whenever you add a FREESHARD_* var to docker-compose.yml, justfile, or CI.
+#
+# Usage (from repo root):
+#   .claude/skills/freeshard-diagnostics-and-tooling/scripts/verify-env-override.sh FREESHARD_DNS__ZONE=example.test dns.zone
+#   .claude/skills/freeshard-diagnostics-and-tooling/scripts/verify-env-override.sh FREESHARD_PATH_ROOT_HOST=/srv/x path_root_host
+#
+# Arg 1: VAR=value assignment. Arg 2: dotted Settings attribute path.
+# Exit code: 0 = override landed, 1 = it did NOT land, 2 = usage/setup error.
+
+set -u
+
+if [ $# -ne 2 ]; then
+	echo "usage: $0 FREESHARD_SECTION__FIELD=value section.field" >&2
+	exit 2
+fi
+ASSIGN="$1"
+ATTR_PATH="$2"
+VAR="${ASSIGN%%=*}"
+VAL="${ASSIGN#*=}"
+
+if [ ! -f "shard_core/settings.py" ]; then
+	echo "ERROR: run from the freeshard repo root (Settings loads config.toml CWD-relative)." >&2
+	exit 2
+fi
+PY=".venv/bin/python"
+[ -x "$PY" ] || PY="python3"
+
+ACTUAL=$(env "$VAR=$VAL" "$PY" -c "
+from shard_core.settings import Settings
+obj = Settings()
+for part in '$ATTR_PATH'.split('.'):
+    obj = getattr(obj, part)
+print(obj)
+") || {
+	echo "ERROR: Settings() failed to construct or attribute path '$ATTR_PATH' is wrong." >&2
+	exit 2
+}
+
+if [ "$ACTUAL" = "$VAL" ]; then
+	echo "PASS: $VAR=$VAL -> Settings().$ATTR_PATH == '$ACTUAL'"
+	exit 0
+else
+	echo "FAIL: $VAR=$VAL was IGNORED -> Settings().$ATTR_PATH == '$ACTUAL'"
+	echo "      Most common cause: single underscore where the nested delimiter needs '__'."
+	echo "      Correct form: FREESHARD_<SECTION>__<FIELD> (e.g. FREESHARD_DNS__ZONE)."
+	exit 1
+fi

--- a/.claude/skills/freeshard-docs-and-positioning/SKILL.md
+++ b/.claude/skills/freeshard-docs-and-positioning/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: freeshard-docs-and-positioning
+description: Maintaining Freeshard's docs of record (agents.md, README.md, docs.freeshard.net) and writing anything user- or public-facing. TRIGGER on editing agents.md or README.md, "update the docs", "is this doc still true", contradictions between a doc and the code (especially the Ed25519-vs-RSA claim), the Portal/Freeshard naming question ("should I rename portal to shard?"), portal_controller.py vs freeshard_controller.py confusion, writing PR descriptions/commit messages/release notes, or any external claim about what Freeshard is or does. SKIP when the task is the mechanics of config options (use freeshard-config-and-flags), cross-repo type-sync (use freeshard-ecosystem-contracts), release *execution* (use freeshard-run-and-operate), or change gating/review policy (use freeshard-change-control).
+---
+
+# Freeshard docs and positioning
+
+How to keep this repo's documentation truthful and how to write anything a human will read: PR descriptions, commit messages, docs pages, release notes, public copy.
+
+Vocabulary used below: a **shard** is a personal cloud VM; **shard_core** (this repo) is the FastAPI backend running on each shard; the **controller** (repo `freeshard-controller`) is the central management service; **web-terminal** is the Vue 2 end-user UI; the project's pre-2025 name was **Portal**, and residue of that name is load-bearing (see "Naming discipline").
+
+## When NOT to use this skill
+
+| You are doing... | Use instead |
+|---|---|
+| Adding/changing a config option, env var, or flag | freeshard-config-and-flags |
+| Syncing types from the controller, cross-repo contract changes | freeshard-ecosystem-contracts |
+| Cutting a release, deploying, operating a shard | freeshard-run-and-operate |
+| Deciding whether a change is allowed / how it gets reviewed | freeshard-change-control |
+| Understanding the crypto/auth design itself (not documenting it) | freeshard-domain-reference |
+| Setting up the dev environment the README describes | freeshard-build-and-env |
+
+## Docs of record and authority order
+
+When documents disagree, trust them in this order — and trust **code over all of them**:
+
+| Rank | Document | Audience | Authority |
+|---|---|---|---|
+| 1 | The code + `git log` | — | Ground truth. Always wins. |
+| 2 | `agents.md` (repo root, 131 lines) | Agents/engineers working on shard_core | Primary agent-facing reference: stack, architecture, commands, patterns. Mostly accurate; known errors listed below. |
+| 3 | This skill library (`.claude/skills/`) | Agents | Curated, date-stamped; defers to code. |
+| 4 | `README.md` (repo root) | Humans: overview, self-hosting, dev setup | Concept sections good; several dead mechanics (below). |
+| 5 | docs.freeshard.net (sibling repo `documentation/`, MkDocs Material, deployed to GitHub Pages via `.github/workflows/ci.yml`) | End users + third-party app developers | User-level truth; not an engineering reference. |
+| 6 | `/home/ubuntu/projects/freeshard/agents.md` (workspace-level, one directory up) | Agents working across repos | Useful repo map + cross-repo command reference. NOT in any git repo — exists only on the dev machine; do not cite it as a versioned source. |
+
+**Standing rule — agents.md must not rot:** when your PR changes anything agents.md describes (tech stack, architecture, key patterns, commands, file-path conventions), updating agents.md in the same PR is part of the change, not optional polish. Stale statements there cause real agent mistakes — the Ed25519 error below is the proof.
+
+## Known-stale docs (as of 2026-07-03)
+
+Fixing a stale doc is **in scope for any PR that touches the described area**. You do not need a separate issue to correct a doc you just proved wrong — but a pure doc-fix PR is also fine and cheap to review.
+
+| # | Location | Stale claim | The truth | Evidence |
+|---|---|---|---|---|
+| 1 | `agents.md:32`, `agents.md:74`, `agents.md:105` | "Ed25519 key generation / signature verification / requests are signed with Ed25519 keys" | Crypto is **RSA-4096 with PSS padding**; HTTP Message Signatures use **RSA_PSS_SHA512**. There is zero Ed25519 anywhere in `shard_core/`. | `shard_core/service/crypto.py:4-58` (`rsa.generate_private_key`, `padding.PSS`), `shard_core/service/signed_call.py:27` (`algorithms.RSA_PSS_SHA512`) |
+| 2 | `README.md:160-161` | Export `CONFIG=config.yml,local_config.yml`; edit `local_config.yml` | Dead mechanism AND dead file format. No code reads `CONFIG` (grep `shard_core/` — only an unrelated enum member matches). Config is pydantic-settings loading `config.toml` + `local_config.toml` from CWD, env prefix `FREESHARD_`, since commit e2c06a7 ("Fix #41: Replace gconf with pydantic-settings"). `agents.md:11` has the correct description. | `shard_core/settings.py:129-152`; https://github.com/FreeshardBase/freeshard/issues/41 |
+| 3 | `justfile` recipes `run-dev` and `run-dev-for-freeshard-controller` | Both export the same dead `CONFIG=config.yml,local_config.yml` | Inert for the same reason as #2. The recipes work anyway (TOML files auto-load from CWD). Related live bug in the second recipe (single-underscore env var, silently ignored) belongs to freeshard-config-and-flags. | `justfile:48,51` |
+| 4 | `README.md:79` | "[API-doc](https://ptl.gitlab.io/portal_core/) of the latest stable release" | Dead link — GitLab Pages from before the Feb 2025 GitHub migration (commit b33eada deleted `.gitlab-ci.yml`). Live API doc is the local `/docs` endpoint (`just run-dev`, then http://localhost:8080/docs). | `README.md:79` |
+| 5 | `documentation/README.md` (sibling repo) | "Documentation for Portal app developers" + GitLab Pages boilerplate, badge to ptl-public.gitlab.io | Legacy scaffold README. The repo's `agents.md` is the current reference: MkDocs Material site at docs.freeshard.net. | `documentation/README.md` vs `documentation/agents.md:1-10` |
+| 6 | `documentation/agents.md:61` | "Built and deployed via GitLab Pages" | Deploys via **GitHub** Pages: `.github/workflows/ci.yml` builds with `mkdocs build --strict` and deploys with `actions/upload-pages-artifact` / `actions/deploy-pages` on main. No `.gitlab-ci.yml` exists in the repo. | `documentation/.github/workflows/ci.yml` |
+
+Before repeating ANY doc claim in new writing, verify it against code first. Re-verification one-liners for this table are in "Provenance and maintenance".
+
+## House style: PRs, commits, issues
+
+Conventions observable in merged history — follow them.
+
+**Commit messages**
+- Narrative. Subject line in conventional-commit-ish form (`fix(profile): ...`, `chore(deps): ...`, `perf(backup): ...`); body explains symptom, cause, and why this fix — see commit e55ce51 for the model.
+- **Rationale lives in the commit message, not code comments.** Do not annotate code with "why this change exists" comments; a future reader gets the reasoning from `git log`/`git blame`. Comment code only when it is genuinely puzzling without one.
+
+**PR descriptions**
+- Must cover **all commits on the branch**, not just the last one. Reviewers read the description as the change's contract.
+- Structure that has worked: `## Symptom` → `## Cause` → `## Fix` (see https://github.com/FreeshardBase/freeshard/pull/102).
+- Multi-file PRs include a **"Recommended reading order"** section listing changed files in dependency order (schema/config → leaf services → API handlers → tests). Precedent: PRs https://github.com/FreeshardBase/freeshard/pull/83, /pull/90, /pull/108 all carry one.
+- End agent-authored PR bodies per the harness convention (the `Co-Authored-By` / generated-with footer).
+
+**Issues**
+- Reference issues and PRs by **full URL** (https://github.com/FreeshardBase/freeshard/issues/N), never a bare `#N` — bare numbers are ambiguous across the 13 FreeshardBase repos and break when text is copied elsewhere.
+- Issue/PR states are volatile: re-query with `gh` before asserting one is open/merged; never trust memory or an earlier point in the session.
+
+## Naming discipline: the Portal residue
+
+The project was named **Portal** until the Feb 2025 rebrand (rename commit 88e5842, "rename lots of stuff from portal to shard"). The README's top NOTE acknowledges the leftover naming publicly. What remains is **intentional-until-refactored** — much of it is external contract, not sloppiness:
+
+| Residue | Where | Why you must NOT rename it opportunistically |
+|---|---|---|
+| Docker network `portal` | `docker-compose.yml:2-3`, every app compose template, `shard_core/web/internal/call_peer.py:36-39` | Every installed app's container joins this network by name. Renaming orphans running apps fleet-wide. |
+| `X-Ptl-*` headers (`X-Ptl-Client-Type/Id/Name`, `X-Ptl-ID`, ...) | `shard_core/service/traefik_dynamic_config.py:92-111`, `shard_core/web/internal/auth.py:57-59`, app `app_meta.json` header templates | Apps in the store consume these headers for auth context. Wire contract. |
+| `{{ portal.* }}` template variables | `shard_core/service/app_installation/util.py:91-98` (render passes `portal=` and `fs=`) | Every published app template in app-repository uses them; docs.freeshard.net documents both `portal.*` and the newer `fs.*` sets with an explicit backwards-compat note (`documentation/docs/developer_docs/includes/template_vars_portal.md`, `portal_name_info.md`). |
+| `minimum_portal_size` | `shard_core/data_model/app_meta.py:125` | Field name in the published app_meta.json format (schema v1.2). Renaming = format migration, not a refactor. |
+| `portal_controller.py` module | `shard_core/service/portal_controller.py` | See trap below. |
+| `portal_core/` paths | Git history before 88e5842 | Use both `portal_core/` and `shard_core/` prefixes when running `git log --follow`/churn analysis across the rename. |
+
+**Rule: no mass-renames.** A rename touching any row above is a cross-repo, fleet-affecting migration (app templates, published docs, running containers) and goes through freeshard-change-control as its own planned change. Never fold "cleaned up old Portal naming" into an unrelated PR.
+
+**Trap — two modules, one controller:** `shard_core/service/portal_controller.py` and `shard_core/service/freeshard_controller.py` both call the SAME backend (`settings().freeshard_controller.base_url` = https://controller.freeshard.net) with different path conventions:
+
+- `portal_controller._call_freeshard_controller` **prepends `api/`**: `url = f"{controller_base_url}/api/{path}"` (`portal_controller.py:16`). Handles profile + backup SAS URLs.
+- `freeshard_controller.call_freeshard_controller` does **not** — callers pass `api/shards/self` themselves (`freeshard_controller.py:15`). Handles the shared secret.
+
+Adding a controller call to the wrong module produces `/api/api/...` or a missing `/api/` prefix. Check which module the neighboring calls live in, and pass the path in that module's convention. (Also: `[portal_controller]` in `config.toml` is dead config — `portal_controller.py` reads `settings().freeshard_controller`; see freeshard-config-and-flags.)
+
+## External positioning and claims discipline
+
+What Freeshard publicly is: **a personal cloud computer** — the missing category between local software, the big-cloud web, and DIY self-hosting. One person (or household) owns the machine; sovereignty over data is the point. The public anchor phrasing is `README.md:15`: "a personal cloud computer that a consumer can rent for a small monthly fee (or selfhost) and which is as simple to use as a smartphone. Its aim is to restore people's sovereignty regarding the data they consume and produce."
+
+Rules for anything public-facing (README, docs site, release notes, blog/newsletter copy, issue comments that will be read by users):
+
+1. **No performance, security, or privacy claim without a reproducible demonstration.** If you cannot point to a script, test, or measurement someone else can rerun, do not state the claim. Write what IS demonstrable ("auth decisions are made on your shard, not in a central service") rather than superlatives ("bulletproof", "zero-knowledge", "blazing fast").
+2. **Status vocabulary is fixed:** unshipped work is "planned"; a spike/PoC is a "prototype" (e.g. the embedded OIDC provider on branch `spike/oidc-provider-poc` is a prototype — unmerged as of 2026-07-03); merged-but-not-deployed is not "shipped" (deployment gates are freeshard-change-control's territory). Never present prototype results as product capabilities.
+3. **License precision.** shard_core is licensed **FSL-1.1-ALv2** (`LICENSE.md`) — Functional Source License, source-available, each version converting to Apache-2.0 two years after release (`LICENSE.md:87-91`). In external copy, describe shard_core as "source-available" / "Fair Source (FSL)" rather than unqualified "open source". The apps in the store, by contrast, ARE FOSS by policy (next rule).
+4. **FOSS-only app store is public policy.** Third-party apps must carry a license from the allowlist — MIT, Apache-2.0, BSD-2/3-Clause, GPL-2.0/3.0, AGPL-3.0, LGPL-*, MPL-2.0, ISC, Unlicense, CC0-1.0 (`app-repository/.claude/skills/add-app/reference/exit-criteria.md:38`). Source-available licenses (BSL, SSPL, Elastic, O'Saasy) are a hard block regardless of technical fit — precedent: Fizzy, blocked 2026-05-18, recorded in `app-repository/blocked_apps/fizzy.md`. Rejections are documented in `app-repository/blocked_apps/` so nobody re-litigates them; when writing about the store, you may state the policy plainly and cite that directory.
+5. **Third-party facts get verified, not remembered.** Anything you assert about PayPal, OVH, Azure, Traefik, an upstream app, or any external product must come from a checked source or be labeled uncertain.
+
+## Release notes and user-visible communication
+
+- Version history: 0.x tags on this repo (`git tag | sort -V`); as of 2026-07-03 the latest tag is 0.39.4 (2026-06-24). Minor = feature, patch = hotfix. A move to full semantic versioning is decided-in-principle but not implemented — https://github.com/FreeshardBase/freeshard/issues/118 (OPEN as of 2026-07-03).
+- **Patch bursts after a minor are normal, not a scandal.** Every infra-level minor has produced a hotfix tail: 0.28.0→0.28.6 (7 releases in 3 days, 2024, rclone rollout), 0.38.0→0.38.4 (5 tags in 6 days, 2026, Postgres migration). Write the notes accordingly: state the fix plainly ("0.38.3 fixes backup validation failures on some shards"), never bury or euphemize it ("minor improvements"). Users on a broken version need to recognize their symptom in one line.
+- Don't infer "latest version" from the local working tree — the checkout may sit on a stale branch (this one pins 0.39.2 in `docker-compose.yml` while 0.39.4 is tagged). Query `git fetch --tags && git tag | sort -V | tail -1` or the GitHub releases page.
+- Tag order ≠ commit topology here: 0.37.5 was tagged AFTER 0.38.0 as a deliberate old-line backport (branch `origin/release/0.37.5`). When writing "what changed between X and Y", diff the tags, don't assume linearity.
+- For prose style and voice of newsletters/blog posts, this skill only sets the facts-discipline; the maintainer has separate style guides outside this repo.
+
+## Doc-impact checklist (run for every PR)
+
+- [ ] Did I change anything `agents.md` describes (stack, architecture, patterns, commands, paths)? → update `agents.md` in this PR.
+- [ ] Did I touch an area with a known-stale doc (table above)? → fix that entry in this PR and remove it from the skill's table.
+- [ ] Did I add/rename/remove a `just` recipe, config option, or env var? → README dev section + `agents.md` Commands section; config specifics per freeshard-config-and-flags.
+- [ ] Does the change alter what third-party app developers see (template vars, headers, app_meta format)? → the `documentation/` repo needs a matching PR (separate repo, own review).
+- [ ] Does my text reference issues/PRs? → full URLs, states re-checked with `gh` now.
+- [ ] Does my text make any public claim? → run it against the five claims-discipline rules above.
+- [ ] PR description: covers all commits, has Symptom/Cause/Fix or equivalent, has Recommended reading order if multi-file.
+
+## Provenance and maintenance
+
+Written 2026-07-03 against working tree at commit e55ce51 (branch `fix-profile-billing-fields`; origin/main then at 0a40684) plus sibling checkouts `documentation/` and `app-repository/` under `/home/ubuntu/projects/freeshard/`. Primary sources: repo files cited inline, `git log`/`git tag`, GitHub via `gh` (issues 41, 118; PRs 83, 90, 102, 108).
+
+Drift-prone facts — re-verify before relying on them:
+
+| Fact | Re-verify with |
+|---|---|
+| agents.md still claims Ed25519 (stale rows 1) | `grep -n Ed25519 agents.md` — empty means FIXED; delete row 1 |
+| Crypto is RSA-4096/PSS, RSA_PSS_SHA512 | `grep -n "RSA_PSS\|generate_private_key" shard_core/service/signed_call.py shard_core/service/crypto.py` |
+| README still documents dead CONFIG mechanism | `grep -n "CONFIG=config.yml" README.md justfile` |
+| No code reads CONFIG env var | `grep -rn "environ\|getenv" shard_core/ --include="*.py" \| grep -i config` |
+| README dead GitLab API-doc link | `grep -n "ptl.gitlab.io" README.md` |
+| documentation repo README/agents.md staleness | `head -5 ../documentation/README.md; grep -n "GitLab Pages" ../documentation/agents.md` |
+| portal_controller `api/` prefix split | `grep -n "api/" shard_core/service/portal_controller.py shard_core/service/freeshard_controller.py` |
+| Docker network still named `portal` | `grep -n "name: portal" docker-compose.yml` |
+| Template render still passes `portal=` and `fs=` | `grep -n "portal=portal\|fs=fs" shard_core/service/app_installation/util.py` |
+| Latest tag / semver issue state | `git fetch --tags && git tag \| sort -V \| tail -1`; `gh issue view 118 --repo FreeshardBase/freeshard --json state` |
+| License still FSL-1.1-ALv2 | `head -5 LICENSE.md` |
+| FOSS allowlist unchanged | `grep -n "foss" ../app-repository/.claude/skills/add-app/reference/exit-criteria.md` |

--- a/.claude/skills/freeshard-domain-reference/SKILL.md
+++ b/.claude/skills/freeshard-domain-reference/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: freeshard-domain-reference
+description: Theory pack for shard_core's protocols and standards AS APPLIED HERE — HTTP Message Signatures (RSA-PSS, not Ed25519), shard ID / short_id derivation, Traefik forwardAuth + errors middleware + DNS-01 wildcard ACME, terminal JWT pairing, rclone crypt backups, compose-file-per-app orchestration, yoyo + psycopg3 transaction semantics, Pydantic v2 idioms. TRIGGER on "how does peer/signature auth work", "key_id / short_id / shard id", edits to shard_core/service/{crypto,signed_call,peer,pairing,backup,traefik_dynamic_config}.py, data/traefik.yml, migrations/, shard_core/settings.py, app_meta versioning, X-Forwarded-* / X-Ptl-* headers, "forwardAuth protocol mechanics" (for "why is there no auth on this route", use freeshard-architecture-contract), rclone flags, "where do transactions commit". SKIP when you need step-by-step failure triage (use freeshard-debugging-playbook), running/deploying the stack (freeshard-run-and-operate), config-key catalogs (freeshard-config-and-flags), cross-repo type sync (freeshard-ecosystem-contracts), or writing tests (freeshard-testing-and-qa).
+---
+
+# Freeshard Domain Reference
+
+The theory a zero-context engineer needs before touching shard_core's crypto, proxy, auth, backup, orchestration, DB, or settings code. Each section: what you must know, how THIS repo uses it (file:line), and the classic mistake. Line numbers verified 2026-07-03 against origin/main (v0.39.4); the branch you're on may drift — re-grep before relying on an exact line.
+
+**Terms used throughout** (defined once):
+
+| Term | Meaning |
+|---|---|
+| shard | One user's personal cloud VM running the shard_core stack (this repo) |
+| shard_core | The FastAPI control-plane app in this repo, container port 80 |
+| controller | freeshard-controller — central cloud management service at controller.freeshard.net (separate repo) |
+| terminal | A paired end-user device/browser (holds a JWT cookie) |
+| peer | Another shard, authenticated by HTTP message signature |
+| identity | An RSA keypair + derived ID; the default identity IS the shard's identity |
+| `portal` | Legacy project name (pre-2025 rename). Survives as the docker network name, jinja2 template var, `X-Ptl-*` header prefix, `portal_controller.py`. Never "fix" this naming in passing. |
+| kv_store | Postgres table of JSON values keyed by string; shard_core's junk drawer for secrets/flags |
+
+---
+
+## 1. HTTP Message Signatures (IETF RFC 9421 family)
+
+**What you must know.** Requests between shards, and from shard to controller, are authenticated by signing HTTP request components (method, URL, headers, body digest) with the sender's private key. The `requests-http-signature` library (over `http_message_signatures`) does the signing/verification; the verifier looks up the public key by the `keyid` parameter embedded in the `Signature-Input` header. Because the signature covers the URL, **the verifier must reconstruct the exact URL the sender signed** — behind a reverse proxy that means rebuilding it from forwarded headers.
+
+**How this repo uses it.**
+- Outgoing (shard → controller, shard → peer): `shard_core/service/signed_call.py:14-30` — `signed_request(...)` wraps `requests.request` in `asyncio.to_thread` with `HTTPSignatureAuth(signature_algorithm=algorithms.RSA_PSS_SHA512, key_id=identity.short_id, key=<private key PEM>)`. The `key_id` is the shard's 6-char `short_id` (section 2).
+- Incoming (peer → this shard): `shard_core/service/peer.py:79-106` `verify_peer_auth`. Traefik's forwardAuth sub-request doesn't carry the original request line, so the code rebuilds a `requests.Request` from the headers `X-Forwarded-Method`, `X-Forwarded-Proto`, `X-Forwarded-Host`, `X-Forwarded-Uri` plus the body, then calls `HTTPSignatureAuth.verify(..., algorithms.RSA_PSS_SHA512, key_resolver=_PreloadedKR(...))`. The key resolver is sync, so all peers are preloaded from the DB into a dict keyed by `peer.short_id` first (`peer.py:85-92`, resolver at `peer.py:109-122`). The verified `keyid` then resolves the peer row by ID prefix.
+- Incoming (shard → controller side): `freeshard-controller` repo, `freeshard-controller-backend/freeshard_controller/api/auth.py` — `_verify_request` rewrites the scheme from `x-forwarded-proto` before verifying with the same `RSA_PSS_SHA512`, and caches shard public keys in a module dict because the key resolver can't be async.
+- Peers learn each other's public keys by fetching `GET /core/public/meta/whoareyou` (returns `OutputIdentity` incl. `public_key_pem`; `shard_core/web/public/meta.py:21`), triggered on peer insert via the `async_on_peer_write` signal (`peer.py:125-127`).
+
+**Classic mistakes.**
+- Touching the proxy header config. The `X-Forwarded-*` headers are **load-bearing crypto inputs**: if Traefik (or any middleware) stops forwarding them, or rewrites host/URI, every peer signature verification fails. Same on the controller side with `x-forwarded-proto`.
+- Dropping semantically load-bearing headers in a sign-and-forward proxy. shard_core's `/internal/call_backend` proxy once forwarded a body without its `Content-Type`; years later a FastAPI upgrade on the controller (strict content-type parsing) turned every proxied write into a 422 while reads stayed green. When proxying, forward `Content-Type` with the body.
+- Making the key resolver async or lazy — the library calls it synchronously; that's why both sides preload/caches keys.
+
+## 2. RSA-PSS keys and shard IDs (the Ed25519 myth)
+
+**What you must know.** `agents.md` claims Ed25519 crypto. **This is false — do not implement against it.** The code is RSA-4096 end to end. Verify yourself: `grep -ri ed25519 shard_core/` → zero hits.
+
+**How this repo uses it.**
+- Key generation: `shard_core/service/crypto.py:52-57` — `rsa.generate_private_key(public_exponent=65537, key_size=4096)`.
+- Raw sign/verify (not HTTP): PSS padding, MGF1(SHA-256), SHA-256 digest (`crypto.py:34-46, 79-86`).
+- HTTP message signatures: `algorithms.RSA_PSS_SHA512` (`signed_call.py:27`, `peer.py:103`). Two different digest choices in one codebase — both RSA-PSS, neither Ed25519.
+- Shard ID pipeline: public key PEM bytes → SHA-512 → `human_encoding.encode` (`crypto.py:29-32`). The encoding (`shard_core/service/human_encoding.py`) maps 5 bits per character onto a 32-char alphabet `abcdefghjklnpqrstvwxyz0123456789` (line 102 — note: no `i`, `m`, `o`, `u`; chosen to avoid lookalikes). 512 bits / 5 = **103-character ID** (verified by generating a key).
+- `short_id` = first 6 chars of the ID (`shard_core/data_model/identity.py:44-47`); the shard's domain = `id[:dns.prefix_length].lower() + "." + dns.zone` with `prefix_length` defaulting to 6 (`identity.py:58-64`, `shard_core/settings.py:10-12`). So a hosted shard lives at e.g. `c0p3x5.freeshard.cloud`.
+- 6 chars × 5 bits = 30 bits of prefix. That is a deliberate usability/security compromise: the short_id is a routable DNS label and a signature `keyid`, not a security boundary by itself — trust comes from the full-ID/public-key binding (peers verify `peer_identity.id.startswith(peer.id)` on refresh, `peer.py:60-63`, and the `Peer` model validates pubkey-matches-id). Collision handling between hosted shards' short_ids would have to live controller-side — **not verifiable from this repo (unverified as of 2026-07-03)**.
+
+**Classic mistake.** Writing new signing/verification code against Ed25519 because agents.md says so, or "harmonizing" the SHA-256 raw-crypto and SHA-512 HTTP-signature digests. Both changes break every existing identity and peer relationship — key format and ID derivation are wire/storage contracts.
+
+## 3. Traefik mechanics (forwardAuth is THE auth layer; repo compose pins v3.6, fleet runs v2.11 — see below)
+
+**What you must know.** FastAPI enforces **no** auth. There is no `Depends` auth anywhere in `shard_core/web/`. All authentication happens in Traefik via `forwardAuth` middlewares: Traefik sends a sub-request to a shard_core `/internal/*` endpoint; 2xx = allow, and selected response headers are copied onto the upstream request. `/internal/*` itself is protected only by network topology (shard_core publishes no host ports; only Traefik does — `docker-compose.yml:32-35`; everything shares the docker network `portal`).
+
+**How this repo uses it.** Dynamic config is compiled in Python (`shard_core/service/traefik_dynamic_config.py`) and written to `{path_root}/core/traefik_dyn/traefik_dyn.yml`; static config is rendered from `data/traefik.yml` at `create_app()` time. The routing map and auth-level table (external routes → middlewares → auth targets, incl. the dashboard) is owned by **freeshard-architecture-contract §1** — this section carries only the protocol theory behind it.
+
+- `strip` removes the `/core/` prefix (`stripPrefix.prefixes=["/core/"]`, :82-85): external `/core/protected/apps` hits FastAPI at `/protected/apps`. Router prefixes and Traefik rules must stay in lockstep.
+- **errors middleware discards upstream bodies.** `app-error` catches status `400-499`/`500-599` from app containers and replaces the ENTIRE response with the splash page from `GET /internal/app_error/{status}` (`shard_core/web/internal/app_error.py:26-32`). A FastAPI 422 detail from an app is gone; only the status survives. Known pain: https://github.com/FreeshardBase/freeshard/issues/91 (open as of 2026-07-03: embed the real upstream response hidden in the splash).
+- **Wildcard cert ⇒ DNS-01 ⇒ hardcoded provider.** Every app gets `<app>.<domain>`, so certs are issued for `<domain>` + `*.<domain>` (`traefik_dynamic_config.py:215-221`). Let's Encrypt only issues wildcards via the DNS-01 challenge, and the challenge provider is hardcoded `provider: azure` in `data/traefik.yml` (with the Azure credential env vars stubbed in `docker-compose.yml:38-42`). Non-Azure DNS = no certs until both are changed. That Traefik-on-every-shard holds DNS-zone credentials is acknowledged security debt with a TSIG-based redesign under discussion — treat as open, don't build on it.
+- **readTimeout is load-bearing.** `data/traefik.yml` (origin/main) sets `respondingTimeouts.readTimeout: "300s"` on the http and https entrypoints; `writeTimeout` deliberately stays 0 so downloads/SSE aren't cut. History: with readTimeout=0, internet scanners hold half-open connections forever; each holds a file descriptor; traefik eventually EMFILEs and the shard goes dark while the container still shows "Up" (PR https://github.com/FreeshardBase/freeshard/pull/108). Related Go lore: binaries built with Go < 1.19 do **not** self-raise `RLIMIT_NOFILE` to the hard limit (Go 1.19 added that), so an old traefik build in a container with soft nofile 1024 dies far earlier than a new one. Diagnostic: `docker exec traefik sh -c 'ulimit -n'`.
+- This repo pins `traefik:v3.6` (`docker-compose.yml:29`, as of 2026-07-03). Deployed-fleet traefik versions are controller territory — don't assume they match.
+
+**Classic mistakes.**
+- Adding a "protected" FastAPI route and assuming something in-process checks auth. Nothing does. Any container on the `portal` network can `curl http://shard_core/protected/...` or `/management/...` directly — the mock app template in tests joins that same external network (`tests/mock_app_store/mock_app/docker-compose.yml.template`). Endpoints trusting `X-Ptl-*` request headers (e.g. `GET /protected/backup/passphrase` reads `X-Ptl-Client-Id`) are only trustworthy through Traefik.
+- Regenerating the 1117-line `shard_core/data_model/traefik_dyn_config.py` model. It was hand-patched to add `authResponseHeadersRegex`; the generator script deliberately raises on import (`scripts/generate_traefik_dyn_config_model.py:6`). Regenerating silently drops the field the app-auth middleware depends on.
+- Adding a per-request DB query to `/internal/auth`. It runs on EVERY app request; it's zero-DB at steady state via module-global `_identity_cache`/`_app_cache` invalidated by blinker signals (`shard_core/web/internal/auth.py:32-44`). A 4-conn pool once exhausted under a ~30-request SPA burst → batch 500s (issue https://github.com/FreeshardBase/freeshard/issues/89, PR #90). New lookups on this path need a cache + signal invalidation.
+
+## 4. Terminal pairing and JWTs
+
+**What you must know.** Terminal sessions are HS256 (shared-secret) JWTs — symmetric, unlike the RSA peer scheme. Freeshard treats *pairing* as the auth boundary: a paired device gets long-lived access; revocation is by deleting the terminal, not by token expiry.
+
+**How this repo uses it** (`shard_core/service/pairing.py`):
+- Secret: auto-generated on first use, `secrets.token_urlsafe(settings().terminal.jwt_secret_length=64)`, stored in kv_store key `terminal_jwt_secret` (:92-98).
+- Payload: `{sub: terminal_id, iat}` — **deliberately no `exp`** (:59-66). `verify_terminal_jwt` decodes, then looks up the terminal row by `sub`; a deleted terminal ⇒ `InvalidJwt` (:69-89). Row existence IS the revocation mechanism. An optional `Bearer ` prefix is stripped (:75-77).
+- Pairing code: 6 random digits, **single active code** stored in kv_store key `pairing_code` (a new one overwrites the old), default validity `terminal.pairing_code_deadline=600s` (`settings.py:104-106`), deleted on redemption (:28-56). Minted via `GET /protected/terminals/pairing-code`, `GET /management/pairing_code` (controller-initiated), or printed in the first-start welcome log.
+- Redemption (`shard_core/web/public/pair.py`): inserts the terminal and sets cookie `authorization`, `domain=<shard domain>`, `secure`, `httponly`, `expires=60*60*24*356*10` (~10 years; the 356 is a long-standing typo for 365 — harmless, don't be confused by it).
+
+**Classic mistakes.**
+- "Fixing" the missing `exp`. Adding expiry breaks the product model (paired ≈ permanent) and buys nothing: revocation already works via row deletion, and every verification hits the terminals table anyway.
+- Assuming a second pairing code can coexist — minting a code invalidates the previous one (single kv slot). UI/flows that fetch a code twice race themselves.
+
+## 5. rclone crypt backups to Azure Blob
+
+**What you must know.** `rclone` "connection-string" remotes need no config file: `:azureblob:<container>` is an on-the-fly Azure Blob remote (authenticated here by `--azureblob-sas-url`), and `:crypt:<path>` wraps another remote (`--crypt-remote`) with client-side encryption. `rclone sync` makes the destination match the source (deletes remote extras). `rclone obscure` is reversible obfuscation of the password for the command line — it is NOT encryption; the crypt passphrase itself does the encrypting. `--fast-list` trades memory for drastically fewer List calls — on Azure, per-directory List ops are billed and can cost multiples of the storage itself.
+
+**How this repo uses it** (`shard_core/service/backup.py`, origin/main):
+- Trigger: CronTask `0 3 * * *` + uniform random jitter ≤3600s (`config.toml [services.backup.timing]`), or `POST /protected/backup/start`.
+- SAS URL comes from the controller: signed `GET api/shard_backup/backup_sas_url` (`shard_core/service/portal_controller.py:39-42`). Self-hosted shards (no controller) therefore cannot run this backup path.
+- Command (`COMMAND_TEMPLATE`, backup.py top): `rclone --azureblob-sas-url <SAS> --crypt-password <obscured> --crypt-remote :azureblob:{container} sync {dir} :crypt:{container}/{dir} --create-empty-src-dirs --stats-log-level NOTICE --stats 1000m --use-json-log --fast-list` for each of `directories = ["core", "user_data"]`, cwd = `path_root`. Passphrase: plaintext in kv_store key `backup_passphrase` (10 EFF-wordlist words, auto-generated at startup), obscured via a sync `subprocess.run(["rclone","obscure",...])`.
+- Flag history you must respect: `--fast-list` and `--azureblob-no-check-container` were both added for Azure cost (PR #106); `--azureblob-no-check-container` was then **removed** because the image bundles rclone 1.60.1 from Debian bookworm apt (`Dockerfile:30`) and that flag needs ≥1.61.0 — every backup died with `unknown flag` (issue https://github.com/FreeshardBase/freeshard/issues/117, PR #119). A regression test pins this: `tests/test_backup.py::test_command_templates_only_use_supported_flags`.
+- Stats protocol: with `--use-json-log` rclone writes JSON log lines to **stderr**; the code takes the last line (`stderr.split("\n")[-2]`), parses it, and stores `rclone_result["stats"]` in the report. `BackupStats.rclone_stats` is typed `dict` on purpose (`shard_core/data_model/backup.py:11`): rclone's stats schema shifts between versions, and modeling it once caused validation failures (commit b9dfcfd "treat rclone stats as opaque dict"). Since PR #119 the process returncode is checked first and non-zero raises `BackupFailedError` with stderr.
+- After a successful run, a `_last_backup` marker blob is uploaded; its Last-Modified is the controller's recency signal (failures only warn).
+
+**Classic mistakes.**
+- Giving `rclone_stats` a typed schema. Keep it an opaque dict.
+- Adding any rclone flag without checking it exists in 1.60.1 (`docker run --rm python:3.13-slim-bookworm sh -c 'apt-get update -qq && apt-cache policy rclone'`).
+- Assuming the backup covers the database. It syncs only `core/` and `user_data/`; **Postgres data (`postgres_data/`, containing identities/private keys, terminals, kv_store) is NOT in the rclone backup set** — whether hosted infra snapshots it separately is outside this repo.
+- The command is built with `str.split()` on the template — any whitespace in the SAS URL or paths breaks tokenization. Know it before you extend the template.
+
+## 6. Docker Compose orchestration of apps
+
+**What you must know.** shard_core is a compose-driving control plane: every installed app is its own compose project, started/stopped by shelling out to `docker compose` against the **host's** docker daemon through the mounted `/var/run/docker.sock` (`docker-compose.yml:60`). Because the daemon is the host's, volume paths inside app compose files must be host paths, not container paths.
+
+**How this repo uses it.**
+- Template: each app ships `docker-compose.yml.template`, rendered with jinja2 (`shard_core/service/app_installation/util.py:78-100`) with two var groups: `fs.{app_data, all_app_data, shared, installation_dir}` — all under `settings().path_root_host` (host side!) — and `portal` = the shard's `SafeIdentity` (`domain`, `id`, `short_id`, `public_key_pem`). ALL templates are re-rendered at every startup (`util.py:65-75`), so templates must be idempotent. App containers join the external network `portal` — same network as shard_core (see §3 classic mistake).
+- Path invariant: `path_root` (in-container view, `/` in prod, `run/` in dev) for everything shard_core itself reads/writes; `path_root_host` ONLY for paths rendered into app compose files.
+- Lifecycle (idle-stop): every authorized app request fires `on_request_to_app` (`web/internal/auth.py:111`), which records `time.time()` in an **in-memory** dict and fire-and-forgets a start (`shard_core/service/app_lifecycle.py:24-36`). A `PeriodicTask control_apps` (every 10s in prod, `config.toml [apps.lifecycle]`) stops non-`always_on` apps idle longer than `lifecycle.idle_time_for_shutdown` (default 60s, min 5, mutually exclusive with `always_on` — validators at `shard_core/data_model/app_meta.py:90-111`), starts `always_on` apps, and stops everything when disk space is low. The in-memory dict is lost on restart, so all running non-always-on apps get stopped on the first tick after boot; the DB `last_access` column is a separate, slower signal not consulted by idle-stop.
+- The docker.sock control plane is acknowledged security debt: a compromised shard_core (or anything that reaches the socket) owns the host. Don't widen the surface.
+- **Healthcheck/depends_on gating — the PWA lie.** Idle-stopped apps cold-start on first request; the splash (§3) shows until the app responds non-error. A split web/backend app whose web container 200s before the backend is ready makes the proxy think "up" and skips the splash into a broken UI; worse, an installed PWA's service worker serves its cached shell *without hitting the proxy at all*. Mitigation pattern for app authors: gate the entrypoint container with `depends_on: condition: service_healthy` on the backend. Related open work: startup/migration visibility https://github.com/FreeshardBase/freeshard/issues/120 and a no-interruption window during updates https://github.com/FreeshardBase/freeshard/issues/121 (both open as of 2026-07-03).
+
+**Classic mistakes.**
+- Using `path_root` in a compose template (container path handed to the host daemon → empty/wrong mounts).
+- Trusting "container Up" or an early 200 as app-ready — health is per-entrypoint semantics, not container state.
+- Forgetting `await signals.on_apps_update.send_async()` after a status change: it drives both the websocket UI push and the `/internal/auth` app-cache invalidation; forgetting it serves stale auth decisions.
+
+## 7. yoyo-migrations + psycopg3 async pool
+
+**What you must know.** yoyo applies plain-SQL migration files at startup (sync, before the app serves). psycopg3's pool hands out connections as async context managers: **exiting the `connection()` block commits; an exception inside rolls back**. One `async with` block = one transaction. You never call `conn.commit()`.
+
+**How this repo uses it.**
+- Startup: `database.init_database()` (`shard_core/database/database.py:26-34`) = sync `migrate()` → open pool → one-time TinyDB→Postgres data import. Called first thing in lifespan.
+- `migrate()` (`shard_core/database/migration.py`): `get_backend("postgresql+psycopg://...")`, reads `Path.cwd() / "migrations"`, applies under `backend.lock()`. CWD-dependent: run from repo/image root or it silently finds zero migrations.
+- Exactly one migration exists as of 2026-07-03: `migrations/shard-core-0001-init.sql`, header `-- shard-core-0001-init` / `-- depends:` (yoyo's ID + dependency lines), all `CREATE TABLE IF NOT EXISTS` (idempotent against pre-yoyo databases). New migrations: `shard-core-NNNN-<slug>.sql` with `-- depends: <previous-id>` (naming convention implied by the single existing file, not documented elsewhere).
+- Pool: module-global `AsyncConnectionPool`, `max_size=20, timeout=10` (`shard_core/database/connection.py:17-33`) — the 20 is a fix for forwardAuth pool exhaustion (issue #89); don't shrink it. `db_conn()` (:52-55) is the only sanctioned way to get a connection.
+- Access pattern: every function in `shard_core/database/*.py` takes `conn: AsyncConnection` as first arg; callers do `async with db_conn() as conn:`. `grep -rn "commit()" shard_core/` → zero hits, by design. `database.py` additionally offers pool-managing `get_value/set_value/remove_value` for one-shot kv_store ops.
+
+**Classic mistakes.**
+- Calling `conn.commit()` or wrapping extra transaction management — the context manager already does it; explicit commits mask the rollback-on-exception guarantee.
+- Spreading one logical write across two `db_conn()` blocks and assuming atomicity — each block is its own transaction.
+- Holding a `db_conn()` block open across slow awaits (HTTP calls, subprocesses): with `max_size=20` and forwardAuth traffic, hoarded connections recreate issue #89.
+
+## 8. Pydantic v2 idioms used here
+
+**What you must know.** Three v2 features carry real weight in this repo: layered `BaseSettings` sources, `@computed_field` (which puts derived properties INTO serialized output), and `model_validator(mode="before")` as a data-migration hook that rewrites raw input before validation.
+
+**How this repo uses it.**
+- Settings layering (`shard_core/settings.py:109-152`): `settings_customise_sources` builds one `TomlConfigSettingsSource` **per file** so overlay files override individual fields, not whole nested sections. Precedence: init kwargs > env (`FREESHARD_` prefix, `__` nested delimiter, e.g. `FREESHARD_TRAEFIK__DISABLE_SSL`) > `local_config.toml` (if present) > `config.toml`. Access is via the `settings()` singleton (:155-159). A `CONFIG` env var appears in the justfile/CI but is read by nothing — dead.
+- `@computed_field` on `Identity`/`SafeIdentity` (`shard_core/data_model/identity.py:44-64`): `short_id`, `public_key_pem`, `domain` are computed AND serialized — that's why `GET /public/meta/whoareyou` returns them and why compose templates can use `{{ portal.short_id }}`. `domain` reads `settings()` at property-access time, so identity serialization depends on live settings.
+- AppMeta version-migration chain (`shard_core/data_model/app_meta.py:128-140` + `app_meta_migration.py`): `CURRENT_VERSION = "1.2"`. A `model_validator(mode="before")` loops: while `values["v"] != CURRENT_VERSION`, look up `migrations[values["v"]]` (dict keyed by OLD version) and apply. Each migration function must set `values["v"]` to the next version or the loop raises "migration seems to be stuck". This lets years-old app-store zips (`app_meta.json` v1.0) parse today. To bump the format: add `migrate_1_2_to_1_3` to the dict under key `"1.2"`, set `CURRENT_VERSION = "1.3"`.
+- `shard_core/data_model/backend/` is a verbatim copy of controller models (`just get-types`), every file stamped `# DO NOT MODIFY`. `Profile.from_shard` uses `getattr(shard, field, default)` for newer fields (`shard_core/data_model/profile.py:42-46`) so a stale copy degrades gracefully instead of stripping fields — a real shipped failure (fields silently dropped at re-validation; fixed in commits 6d4b101 + e55ce51). Cross-repo procedure: freeshard-ecosystem-contracts.
+
+**Classic mistakes.**
+- Editing files under `data_model/backend/` — the next `just get-types` erases your change.
+- Adding a migration function that forgets to bump `values["v"]` → infinite-loop guard exception for every app parse.
+- Assuming `model_validate` keeps unknown fields. It strips them — that's exactly how the profile/billing fields vanished. When data passes THROUGH shard_core to another consumer, either type it fully (after a type sync) or pass it opaquely.
+
+---
+
+## When NOT to use this skill
+
+| You actually want | Go to |
+|---|---|
+| Symptom→cause triage, discriminating experiments | freeshard-debugging-playbook |
+| History of incidents/reverts with evidence | freeshard-failure-archaeology |
+| Which invariants must hold and why (decision records) | freeshard-architecture-contract |
+| Every config key, env override rules, dead config | freeshard-config-and-flags |
+| Dev env setup, uv, worktrees | freeshard-build-and-env |
+| Running the stack, first start, release, restore | freeshard-run-and-operate |
+| Test fixtures, adding tests, flaky tests | freeshard-testing-and-qa |
+| Controller/web-terminal/app-repository contracts, `just get-types` | freeshard-ecosystem-contracts |
+| Change gates, review rules, release discipline | freeshard-change-control |
+| OIDC identity provider campaign | freeshard-oidc-identity-campaign |
+
+## Provenance and maintenance
+
+Written 2026-07-03 against origin/main (`0a40684`, v0.39.4) with cross-checks into the freeshard-controller sibling checkout. Primary sources: repo code as cited per section; GitHub issues/PRs https://github.com/FreeshardBase/freeshard/issues/89, /pull/90, /issues/91, /pull/106, /pull/108, /issues/117, /pull/119, /issues/120, /issues/121; commits b9dfcfd, 6d4b101, e55ce51, fd1d05b.
+
+Drift-prone facts — re-verify before relying:
+
+| Fact (as of 2026-07-03) | Re-verify with |
+|---|---|
+| Signing is RSA-4096 / RSA_PSS_SHA512, not Ed25519 | `grep -rn "RSA_PSS_SHA512\|generate_private_key" shard_core/service/{signed_call,crypto,peer}.py` |
+| Shard ID = 103 chars, alphabet in human_encoding.py:102 | `grep -n 'init("' shard_core/service/human_encoding.py` |
+| Traefik pinned v3.6; images 0.39.4 / web-terminal 0.37.4 | `git fetch && git show origin/main:docker-compose.yml \| grep image:` |
+| readTimeout 300s on http/https entrypoints | `git show origin/main:data/traefik.yml \| grep -A2 respondingTimeouts` |
+| DNS-01 provider hardcoded `azure` | `grep -n "provider:" data/traefik.yml` |
+| errors-middleware splash swallows bodies; #91 still open | `gh issue view 91 --json state` |
+| rclone flags: `--fast-list` yes, `--azureblob-no-check-container` absent; rclone from bookworm apt | `git show origin/main:shard_core/service/backup.py \| sed -n '/COMMAND_TEMPLATE/,/^"""/p'` and `grep -n rclone Dockerfile` |
+| JWT payload has no `exp`; HS256; kv key `terminal_jwt_secret` | `grep -n "sub\|iat\|HS256" shard_core/service/pairing.py` |
+| One yoyo migration; naming `shard-core-NNNN-*` | `git ls-tree origin/main migrations/` |
+| Pool max_size=20, timeout=10 | `grep -n "max_size\|timeout" shard_core/database/connection.py` |
+| AppMeta CURRENT_VERSION "1.2" | `grep -n CURRENT_VERSION shard_core/data_model/app_meta.py` |
+| agents.md still claims Ed25519 (stale-doc warning still needed) | `grep -in ed25519 agents.md` |
+| Settings precedence env > local_config.toml > config.toml | read `settings_customise_sources` in shard_core/settings.py |

--- a/.claude/skills/freeshard-ecosystem-contracts/SKILL.md
+++ b/.claude/skills/freeshard-ecosystem-contracts/SKILL.md
@@ -1,0 +1,256 @@
+---
+name: freeshard-ecosystem-contracts
+description: Cross-repo contracts between shard_core (this repo) and freeshard-controller, web-terminal, app-repository, landing-page — and how they drift. Use when a change spans repos or touches a contract surface. TRIGGER on: shard_core/data_model/backend/*, `just get-types`, shard_core/data_model/profile.py, service/signed_call.py, service/portal_controller.py, service/freeshard_controller.py, web/protected/management.py, web/internal/call_backend.py, data_model/app_meta.py version bumps, docker-compose.yml image pins, pricing changes, "field added on the controller doesn't show up in the web-terminal", "type sync", "app store zip", "shared secret", "HTTP message signatures". SKIP when: the change is confined to shard_core internals with no controller/web-terminal/app-repo surface (use freeshard-architecture-contract), you need crypto/forwardAuth theory (use freeshard-domain-reference), you're releasing/deploying (use freeshard-run-and-operate and freeshard-change-control), or you're debugging a live failure (use freeshard-debugging-playbook).
+---
+
+# Freeshard ecosystem contracts
+
+This repo (`freeshard`, code name `shard_core`) is one node in a multi-repo system. Most contracts between the repos are **convention-only**: a hand-maintained file copy, hardcoded URLs, and a duplicated pricing formula. They drift silently. This skill maps every contract, gives the sync procedures, and records the incidents that prove what happens when you skip a step.
+
+Terms used throughout (defined once):
+
+| Term | Meaning |
+|---|---|
+| **shard** | One customer VM running the shard_core stack (Traefik + postgres + shard_core + web-terminal via Docker Compose) |
+| **controller** | freeshard-controller: central cloud service at controller.freeshard.net; provisions VMs (OVH), billing (PayPal), rolls out core versions to shards |
+| **core version** | A numbered fleet rollout unit (`v18`, `v19`, ...) — a directory in the controller repo containing the docker-compose.yml + scripts the controller pushes to every shard |
+| **web-terminal** | Vue 2 SPA served on each shard; the end-user UI |
+| **app store** | Azure blob storage container `app-store` holding app zips + `store_metadata.json`, built from the app-repository repo |
+| **backend copy** | `shard_core/data_model/backend/` — a verbatim copy of the controller's pydantic models, synced by `just get-types` |
+
+## 1. Repo map
+
+All siblings are checked out under `/home/ubuntu/projects/freeshard/` (each its own git repo; org = FreeshardBase on GitHub).
+
+| Repo | Role | Stack | Ships as |
+|---|---|---|---|
+| `freeshard` (this) | Per-shard backend: app orchestration, Traefik config, pairing, backup | FastAPI + PostgreSQL + docker-py | `ghcr.io/freeshardbase/freeshard:<tag>` on GitHub Release (`.github/workflows/release.yml`) |
+| `freeshard-controller` | Central: VM provisioning, billing, core-version rollout, email relay, diagnostics | FastAPI backend + Vue 3/Quasar frontend | Azure-hosted service |
+| `web-terminal` | Shard UI | Vue 2.6 + Vuex 3 + Bootstrap-Vue, plain JS, **no generated API client** | `ghcr.io/freeshardbase/web-terminal:<tag>`, pinned separately in shard compose files |
+| `app-repository` | App catalog: `apps/<name>/{app_meta.json, docker-compose.yml.template, icon, update_check.py}` | Python build script + GH Actions | Uploaded to Azure blob `app-store/master/all_apps` (`.github/workflows/deploy.yml:28`) |
+| `documentation` | docs.freeshard.net | MkDocs Material | Static site (its README.md is stale legacy "Portal" content — trust its agents.md) |
+| `landing-page` | Marketing site incl. pricing widget | Astro | Static site |
+| `cicd-image` | CI container used by this repo's workflows | Docker | `ghcr.io/freeshardbase/cicd-image:1.0.3` (release.yml:30) |
+
+Naming residue: the project was formerly "Portal". `portal_controller.py`, the `portal` docker network, `X-Ptl-*` headers, `{{ portal.domain }}` template vars, and `minimum_portal_size` all predate the rename — they are live code, not dead code.
+
+## 2. Contract map
+
+| # | Producer → Consumer | Transport | Auth | Typed? |
+|---|---|---|---|---|
+| C1 | shard → controller | HTTPS to `settings().freeshard_controller.base_url` (prod: `https://controller.freeshard.net`, config.toml:64) | HTTP Message Signatures, `RSA_PSS_SHA512`, `keyid` = identity short_id (`shard_core/service/signed_call.py:26-30`); controller verifies with same algorithm (`freeshard_controller/api/auth.py`) | Responses parsed with the **backend copy** models |
+| C2 | controller → shard | `https://{shard.domain}/core/management/{path}` | Header `authorization: <shared_secret>`; shard validates by re-fetching `api/shards/self` and comparing (`shard_core/service/freeshard_controller.py:28-44`) | Shard-side routers: `shard_core/web/management/{apps,notify,pairing_code}.py` |
+| C3 | web-terminal → controller | Via shard's **untyped pass-through** `/core/protected/management/{rest:path}` (`shard_core/web/protected/management.py:31-37`) — shard signs and relays bytes | Terminal JWT cookie (Traefik forwardAuth) on the shard hop; C1 signature on the controller hop | **No.** Only `/core/protected/management/profile` is typed (`response_model=profile.Profile`, management.py:16) |
+| C4 | app-repository → shard + web-terminal | Azure blob `https://storageaccountportab0da.blob.core.windows.net/app-store/...` | None (public blob) | `store_metadata.json` + zips; format = AppMeta (section 7) |
+| C5 | controller backend → controller frontend | OpenAPI spec → generated TS client | n/a | Yes — the only generated contract in the system (section 6) |
+
+WARNING (stale doc): `agents.md` in this repo claims Ed25519 crypto. The code is **RSA-4096 with PSS padding**; signatures are `RSA_PSS_SHA512` (`shard_core/service/crypto.py`, `signed_call.py:27`). Never implement against Ed25519.
+
+### C1 endpoints shard_core actually calls
+
+| Endpoint | Caller | Note |
+|---|---|---|
+| `GET api/shards/self` | `service/portal_controller.py:22` (profile refresh) and `service/freeshard_controller.py:21` (shared-secret refresh) | Two client modules for the same controller: `portal_controller._call_freeshard_controller` **prepends `api/`** (portal_controller.py:16); `freeshard_controller.call_freeshard_controller` does **not** — its callers pass `api/...` themselves |
+| `GET api/shard_backup/backup_sas_url` | `service/portal_controller.py:40` | Returns SAS URL for rclone backup |
+| `POST api/telemetry` | `service/telemetry.py:39` | |
+| `POST {settings().management.api_url}/app_usage` | `service/app_usage_reporting.py:54-55` | config.toml:58 default is a **legacy Azure Functions URL** (`ptlfunctionapp.azurewebsites.net/api/management`), not controller.freeshard.net; the fleet v18 compose sets no override env var. The controller has its own `api/app_usage` router. Where production reports actually land is unverified as of 2026-07-03 — check before touching |
+
+Related dead config: `[portal_controller]` in config.toml (settings.py:124) is defined but no code reads `settings().portal_controller` — see freeshard-config-and-flags.
+
+## 3. The type-sync copy: `just get-types`
+
+`shard_core/data_model/backend/` is a **verbatim file copy** of `../freeshard-controller/freeshard-controller-backend/freeshard_controller/data_model/` (justfile:13-24). The recipe `rm -rf`'s the target, `cp -r`'s from the **LOCAL sibling checkout**, and prepends `# DO NOT MODIFY - copied from freeshard-controller` to every file. It is not OpenAPI-generated. There is **no CI enforcement** (only release.yml, snapshot.yml, test.yml exist in `.github/workflows/`).
+
+**Invariant — pull the source first.** The sync source is whatever your local controller checkout happens to be on:
+
+```bash
+cd ../freeshard-controller && git checkout main && git pull
+cd ../freeshard && just get-types
+```
+
+As of 2026-07-03 the local controller checkout was stale (local main `1e28abe` vs origin `b495a676`), and the copy shows **bidirectional drift** in `subscription_model.py`: the copy has `approval_url` which controller main removed, and lacks `plan_id` which controller main added — proof that a past sync ran against a checkout that had diverged from what later landed on main.
+
+Blast radius of a sync: the copy contains ~10 files but shard_core runtime imports only 2 of them directly —
+`shard_model` (from service/freeshard_controller.py:3, service/portal_controller.py:4, data_model/profile.py:6), `telemetry_model` (from service/telemetry.py:4) — plus tests (tests/conftest.py, tests/test_profile.py, tests/test_terminals.py, tests/test_telemetry.py). But `shard_model` itself transitively pulls in `permission_model` (`PermissionHolder`), `subscription_model` (`SubscriptionStatus`), and `telemetry_model` (backend/shard_model.py:9-11), so drift in those files is runtime-relevant too: `ShardResponse` inherits `permissions: Set[Permission]` and carries `subscription.status: SubscriptionStatus`, so a controller payload with an enum member the stale copy lacks fails `ShardResponse` validation in `refresh_profile()`. The copy also drags in modules shard_core never uses (`email_model` imports jinja2 and renders controller-only templates; `promo_code_model`, `revenue_share_model`, `api_token_model` are unused) — a new controller-only import can break shard_core after a sync, so run the test suite after every `get-types`.
+
+### The incident that defines this contract (why staleness is silent)
+
+Data can flow through the untyped C3 proxy perfectly and **still be dropped** by shard_core's own typed profile path, because that path re-serializes twice:
+
+1. `refresh_profile()` parses the controller's `api/shards/self` JSON with the **copied** `ShardResponse` — pydantic silently discards fields the stale copy doesn't declare.
+2. `Profile.from_shard()` maps a hand-picked subset into shard_core's own `Profile` model (`data_model/profile.py:29-47`).
+
+Both layers must know a field or the web-terminal never sees it. This shipped as a real bug: `billing_enabled`/`paypal_client_id`/`paypal_environment` and `ShardSubscriptionSummary.last_payment_failed_at`/`ended` were stripped, so the subscription UI stayed hidden for subscribed shards. Fixed by commits `6d4b101` (re-sync) and `e55ce51`, merged as https://github.com/FreeshardBase/freeshard/pull/102 (2026-06-05). The fix also introduced the defensive pattern that `Profile.from_shard` now uses for every newer field so a lagging copy degrades to defaults instead of crashing:
+
+```python
+billing_enabled=getattr(shard, "billing_enabled", False),   # profile.py:44
+```
+
+Keep that pattern for any field you add.
+
+### Drift check (no clone update needed)
+
+Preferred — the maintained script (exit 0 = in sync, 1 = drift):
+
+```bash
+.claude/skills/freeshard-diagnostics-and-tooling/scripts/check-type-drift.sh
+```
+
+Quick manual check of one file:
+
+```bash
+f=shard_model.py
+gh api "repos/FreeshardBase/freeshard-controller/contents/freeshard-controller-backend/freeshard_controller/data_model/$f?ref=main" \
+  --jq '.content' | base64 -d | diff <(tail -n +3 shard_core/data_model/backend/$f) -
+```
+
+(`tail -n +3` strips the injected DO-NOT-MODIFY header.)
+
+Drift state as of 2026-07-03 (all verified with the diff above):
+
+| File | Drift | Matters to shard_core? |
+|---|---|---|
+| `shard_model.py` | in sync | the one that matters most |
+| `subscription_model.py` | copy has `approval_url`, remote has `plan_id` (bidirectional) | yes, transitively: shard_model imports `SubscriptionStatus` from it (backend/shard_model.py:10), so the file loads at runtime. The copy's `approval_url` is pure legacy — web-terminal main dropped it for the PayPal SDK flow reading `plan_id` (section 5) |
+| `settings_model.py` | copy lacks `NEW_INSTANCE_IMAGE` | not imported by shard_core |
+| `permission_model.py` | copy lacks `OPEN_DIAGNOSTIC`, `RUN_DIAGNOSTIC` | yes, transitively: shard_model imports `PermissionHolder` from it (backend/shard_model.py:9), and `ShardResponse` inherits its `permissions` set — a controller shard payload carrying one of the missing enum members fails `ShardResponse` validation |
+| `diagnostic_model.py` | missing from copy entirely | not imported by shard_core |
+
+## 4. Checklist: controller field → web-terminal UI
+
+Use this whenever a value produced by the controller must appear in the shard UI. Skipping steps 2–4 silently drops the field (the PR #102 failure mode).
+
+1. Add the field on the controller (`ShardBase`/`ShardResponse`/`ShardSubscriptionSummary` in `freeshard_controller/data_model/shard_model.py`) → merged to controller main.
+2. `cd ../freeshard-controller && git checkout main && git pull` — sync source must be fresh.
+3. `cd ../freeshard && just get-types` → verify the diff touches only expected files; run `pytest`.
+4. Add the field to `Profile` **and** to `Profile.from_shard` in `shard_core/data_model/profile.py`, using `getattr(shard, "field", default)` so an older copy degrades instead of crashing. Add a mapping test in `tests/test_profile.py`.
+5. web-terminal reads it from `GET /core/protected/management/profile` (store.js:109; force-refresh variant `?refresh=true` at store.js:116). No client generation — just read `profile.data.<field>` in the component.
+6. Ship: both a shard_core release **and** a web-terminal release may be needed, and neither reaches customers until a new controller core version pins them (section 8; gates in freeshard-change-control).
+
+## 5. web-terminal ↔ controller: the untyped pass-through
+
+`/core/protected/management/{rest:path}` (management.py:31-37) forwards any method + body from the paired terminal to the controller, signed as the shard. web-terminal uses it for billing:
+
+- `POST /core/protected/management/api/shards/self/resize` (origin/main Settings.vue:551 immediate path, :595 SDK path; JSON body `{new_vm_size}`)
+- `POST /core/protected/management/api/shards/self/subscribe` (origin/main Settings.vue:642)
+
+There is **no schema contract anywhere on this chain** — shard_core relays bytes. Two known weak points:
+
+1. **Content-Type is not forwarded.** Issue https://github.com/FreeshardBase/freeshard/issues/93 (controller 422'd every proxied write after its FastAPI bump) was fixed in https://github.com/FreeshardBase/freeshard/pull/94 — but only for the *other* proxy, `/internal/call_backend` (`shard_core/web/internal/call_backend.py:34-40`, which now forwards Content-Type, query params, and streams). The management pass-through still forwards neither Content-Type nor query strings (verified 2026-07-03). Why current billing writes survive this is unverified — before routing any **new** write through it, either test against the real controller or port the call_backend header/query/streaming fixes over.
+2. **Response-shape drift is only caught by grep.** Controller main's `ResizeResponse` replaced `approval_url` with `plan_id` (section 3 drift table), and web-terminal main followed: the redirect flow was replaced by an in-window PayPal SDK revise flow that reads `r.plan_id` (origin/main Settings.vue:599; web-terminal PR https://github.com/FreeshardBase/web-terminal/pull/29, merged 2026-06-05). The backend-copy's `approval_url` field is pure legacy. Nothing automated would have flagged the breaking rename — the coordinated SDK rework absorbed it. When changing a controller response consumed by web-terminal, grep web-terminal for the field name **on a freshly fetched origin/main, never the possibly-stale local checkout** — that grep *is* the contract check.
+
+## 6. Controller-side changes: OpenAPI sync order
+
+The controller has its own, separate typed pipeline for its frontend. After changing controller backend routes/models, run the chain in this order (documented in the workspace-level `../agents.md:91`):
+
+```bash
+cd ../freeshard-controller/freeshard-controller-backend && just openapi      # regenerate spec
+cd ../freeshard-controller-app && just api-client                            # regenerate TS client (never hand-edit generated-sources)
+cd ../../freeshard && just get-types                                          # refresh shard_core's copy (after pulling, section 3)
+```
+
+## 7. AppMeta: the self-migrating app format
+
+`app_meta.json` (contract C4, authored in app-repository, parsed by shard_core) is versioned by `CURRENT_VERSION = "1.2"` (`shard_core/data_model/app_meta.py:13`). A `model_validator(mode="before")` walks `app_meta_migration.migrations` from the zip's `v` up to CURRENT_VERSION (app_meta.py:132-135), so old store zips keep working.
+
+To evolve the format: bump `CURRENT_VERSION`, add `migrate_X_to_Y` in `shard_core/data_model/app_meta_migration.py` keyed by the **old** version. Each migration must set `values["v"]` to the new version — otherwise the loop raises `"migration seems to be stuck, perhaps a migration does not increment the version number?"` (app_meta.py:135). Then update the authoring docs in `app-repository/agents.md` so new apps are written in the new format.
+
+Shards download app zips from `{apps.app_store.base_url}/{container_name}/master/all_apps/{name}/{name}.zip` (config.toml:26-28 → `service/app_installation/worker.py:181-182`). app-repository's GH Actions uploads there (`deploy.yml:28`; branch and `preview/<head_ref>` paths too). web-terminal fetches `store_metadata.json` and icons from the **same blob URL hardcoded** in 4 files (Apps.vue:220, AppStoreEntry.vue:163, UsagePromptModal.vue:109, Banner.vue:13) — changing the storage account means touching both repos, one of them in scattered literals.
+
+### Platform rules an app must obey (enforced by shard_core behavior, documented in `app-repository/agents.md`)
+
+| Rule | Mechanism / evidence |
+|---|---|
+| `access` per path: `private` = paired devices only, `public` = anyone, `peer` = peer shards (agents.md:62) | Every app router gets Traefik forwardAuth to `/internal/auth` (`service/traefik_dynamic_config.py:171`); the auth endpoint rejects non-terminal clients for PRIVATE and non-peer for PEER paths, and lets anything through for public paths (`web/internal/auth.py:88-100`). So "public skips auth" means the check passes for anonymous — the app must do its own token/HMAC auth on public paths |
+| `lifecycle.always_on: true` = never auto-stopped; mutually exclusive with `idle_time_for_shutdown` (validator at app_meta.py:103-109) | Cost = permanently held RAM; reserve for IoT/messaging apps |
+| No `docker exec` first-user bootstrap | Shard owners have no shell access by design — hard-exit criterion `j` in `app-repository/.claude/skills/add-app/reference/exit-criteria.md` |
+| Split web/backend apps must health-gate the entrypoint container (`depends_on: condition: service_healthy`) | Otherwise the entrypoint 200s before the backend is up and the wake-from-idle splash lies; see `app-repository/apps/kitchenowl/docker-compose.yml.template:14-16` |
+| Email only via the controller relay | `POST /api/email_relay` on the controller, shard-signature auth, sends to the shard **owner only**, default 10/rolling-hour (`freeshard_controller/settings.py:101 relay_rate_limit_per_hour`). No general SMTP from shards, by design |
+| FOSS-only license gate | Allowlist (MIT, Apache-2.0, BSD-*, GPL-*, AGPL-3.0, LGPL-*, MPL-2.0, ISC, Unlicense, CC0-1.0) in exit-criteria.md:38; source-available (BSL/SSPL/Elastic) is a hard block, recorded in `app-repository/blocked_apps/` |
+| `minimum_portal_size` biased to smallest tier that runs (agents.md:83,313); only the entrypoint container joins the `portal` docker network (agents.md:241) | |
+
+## 8. Version pins: who bumps what
+
+There are **two different compose files** and they currently differ. The traefik pin divergence is an **unresolved inconsistency** (see freeshard-change-control §4.2) — don't "fix" one to match the other without an issue:
+
+| | `freeshard/docker-compose.yml` (this repo — dev/self-hosted) | Controller `data/core-versions/v18/docker-compose.yml` (fleet — what customer shards actually run) |
+|---|---|---|
+| traefik | `v3.6` (pinned Dec 2025, commit e78862d) | `v2.11` — deliberate: stay on v2, v3 migration is a needs-Intent backlog item (decision recorded in closed PR https://github.com/FreeshardBase/freeshard/pull/112) |
+| postgres | `17` | `17` |
+| shard_core | `0.39.4` | `0.39.4` |
+| web-terminal | `0.37.4` (lagging; not bumped) | `0.39.4` |
+
+All values as of 2026-07-03, from `git show origin/main:docker-compose.yml` and the controller repo's `core-versions/v18` on main. Latest GitHub Releases at that date: freeshard `0.39.4` (2026-06-24), web-terminal `0.39.4` (2026-06-05).
+
+Who bumps what:
+
+| Artifact | Bumped by | Command / trigger |
+|---|---|---|
+| shard_core version (pyproject.toml + this repo's compose tag, together) | maintainer, in this repo | `just set-version <x.y.z>` (commits automatically — justfile:26) |
+| `ghcr.io/freeshardbase/freeshard:<tag>` image | GitHub Release on this repo | release.yml verifies the release tag matches the code version, then builds/pushes |
+| web-terminal image | GitHub Release on web-terminal (independent release cycle) | its own CI |
+| Fleet pins (what customers run) | **controller repo only** — a new `core-versions/vN/` directory, rolled out by the controller | See freeshard-change-control. Merged-is-not-shipped: a fix on main is invisible to the fleet until (a) a version bump + GitHub Release here AND (b) a new controller core version pins it — the gap is a real incident (https://github.com/FreeshardBase/freeshard/issues/111) |
+
+Never infer release state from a local checkout — `git fetch` and check `origin/main` + published releases first (a redundant version-bump PR was opened exactly this way: closed-unmerged PR https://github.com/FreeshardBase/freeshard/pull/113).
+
+## 9. Pricing duplication invariant
+
+The subscription price formula is **manually duplicated in six places across three repos** plus the canonical site. Formula (gross EUR/month, incl. 19% German VAT):
+
+```
+price_eur = (vm_base + disk_gb * 0.04) * 1.5 * 1.19
+cents     = int(price_eur * 100 + 0.5)        # half-up — NEVER Python round()
+```
+
+VM base net EUR/mo: xs 5.50, s 11.00, m 19.80, l 51.00, xl 102.00.
+
+| # | Site | File |
+|---|---|---|
+| 1 | **Canonical** | `freeshard-controller-backend/freeshard_controller/service/pricing.py:20` |
+| 2 | Controller test | `freeshard-controller-backend/tests/test_pricing.py` |
+| 3 | Controller test | `freeshard-controller-backend/tests/test_paypal_webhook.py` |
+| 4 | web-terminal | `web-terminal/src/lib/pricing.js` (labels the Subscribe button only; active subscribers render controller-supplied `price_cents` — grandfathered) |
+| 5 | web-terminal spec | `web-terminal/tests/unit/pricing.spec.js` |
+| 6 | Landing page | `landing-page/src/components/Pricing.astro:90-115` |
+
+Change all six together, and recompute pinned test values from the real function — don't hand-edit expected numbers. Rounding must be bit-identical between Python `int(x*100+0.5)` and JS `Math.round(x*100)`: Python's `round()` is banker's rounding and diverged from JS by 1 cent on half-cent results in production (UI label vs PayPal charge) — the comment block in pricing.py:22-24 is the standing warning.
+
+## 10. Cross-repo gotchas (quick table)
+
+| Gotcha | Detail |
+|---|---|
+| `gh issue view N --comments` fails on this org | GraphQL "Projects (classic) is being deprecated" — use `gh issue view N --repo FreeshardBase/freeshard --json body,comments` |
+| Controller repo has dual CI | Both `.gitlab-ci.yml` (leftover) and GitHub Actions exist there — check which gates before trusting green |
+| Two VM-size enums by design-debt | shard_core `VMSize` (app_meta.py:47, lowercase) vs copied `VmSize` (backend/shard_model.py); `Profile.from_shard` converts via `.value.lower()` (profile.py:38); a `# todo` at app_meta.py:48 tracks unification — don't half-fix it in passing |
+| get-types after controller adds a module with controller-only deps | The copy is everything-or-nothing; run `pytest` (or at least `python -c "import shard_core.app"`) after every sync |
+
+## When NOT to use this skill
+
+- Identity crypto / signature / forwardAuth **theory** and how JWT pairing works → **freeshard-domain-reference**.
+- Deciding whether a cross-repo change is allowed, release gates, "merged is not shipped" procedure → **freeshard-change-control**.
+- Actually cutting a release, running the stack, first start → **freeshard-run-and-operate**.
+- Recreating the dev environment, worktrees, uv → **freeshard-build-and-env** (it covers running `get-types` as environment setup; this skill covers *when and why*).
+- Debugging a live cross-repo failure (422s on proxied writes, profile not refreshing) → **freeshard-debugging-playbook**; past investigations → **freeshard-failure-archaeology**.
+- Config keys and env overrides (e.g. the dead `[portal_controller]` section) → **freeshard-config-and-flags**.
+- Running the drift-check script and other measurement tools → **freeshard-diagnostics-and-tooling** (script lives there; this skill only points at it).
+
+## Provenance and maintenance
+
+Written 2026-07-03 against freeshard origin/main (`0a40684`), local sibling checkouts, and FreeshardBase remotes via `gh api`. Primary sources: `justfile`, `shard_core/service/{signed_call,portal_controller,freeshard_controller,telemetry,app_usage_reporting}.py`, `shard_core/data_model/{profile,app_meta}.py`, `shard_core/web/protected/management.py`, `shard_core/web/internal/{auth,call_backend}.py`, sibling repos' source as cited inline, PRs/issues https://github.com/FreeshardBase/freeshard/pull/102, /pull/94, /pull/112, /pull/113, /issues/93, /issues/111, commits `6d4b101`, `e55ce51`, `e78862d`.
+
+Drift-prone facts — re-verify before relying:
+
+| Fact (as of 2026-07-03) | Re-verification command (repo root) |
+|---|---|
+| Backend-copy drift state (section 3 table) | `.claude/skills/freeshard-diagnostics-and-tooling/scripts/check-type-drift.sh` |
+| Local controller checkout freshness | `cd ../freeshard-controller && git fetch && git log --oneline main..origin/main` |
+| Repo compose pins (shard_core 0.39.4, web-terminal 0.37.4, traefik v3.6) | `git fetch && git show origin/main:docker-compose.yml \| grep image:` |
+| Fleet pins / latest core version (v18: traefik v2.11, web-terminal 0.39.4) | `gh api "repos/FreeshardBase/freeshard-controller/contents/freeshard-controller-backend/data/core-versions?ref=main" --jq '.[].name' \| sort -V \| tail -1` then fetch that version's docker-compose.yml the same way |
+| Latest releases | `gh release view --repo FreeshardBase/freeshard --json tagName` (same for web-terminal) |
+| Pricing formula + six duplication sites | `grep -n "0.04" ../freeshard-controller/freeshard-controller-backend/freeshard_controller/service/pricing.py ../web-terminal/src/lib/pricing.js ../landing-page/src/components/Pricing.astro` |
+| AppMeta CURRENT_VERSION ("1.2") | `grep -n CURRENT_VERSION shard_core/data_model/app_meta.py` |
+| Management pass-through still drops Content-Type/query | `grep -n "content" shard_core/web/protected/management.py` (empty = still drops) |
+| web-terminal main no longer reads `approval_url` (SDK flow reads `plan_id`) | `git -C ../web-terminal fetch && git -C ../web-terminal grep -n 'approval_url\|plan_id' origin/main -- src/` (never grep the local working tree — it has been 15 commits stale before) |
+| Email relay rate limit (10/hr) | `grep -n relay_rate_limit_per_hour ../freeshard-controller/freeshard-controller-backend/freeshard_controller/settings.py` |
+| No CI enforcement of get-types | `grep -rn get-types .github/workflows/` (empty = still unenforced) |
+| `management.api_url` still legacy Azure Functions default | `grep -n api_url config.toml` |

--- a/.claude/skills/freeshard-failure-archaeology/SKILL.md
+++ b/.claude/skills/freeshard-failure-archaeology/SKILL.md
@@ -1,0 +1,338 @@
+---
+name: freeshard-failure-archaeology
+description: Chronicle of every major Freeshard incident, dead-end branch, rejected fix, and revert — so you never re-fight a settled battle. TRIGGER when starting work that touches backup/rclone, TinyDB/Postgres/storage, Docker lifecycle (stale containers/networks, python-on-whales), Traefik/proxy/call_backend, splash screens, releases/CI, or when you wonder "has this been tried before?", "why is this code weird?", "why is this PR/branch abandoned?". Also TRIGGER before resurrecting any unmerged branch or closed PR. SKIP when you need live-symptom triage steps (use freeshard-debugging-playbook), design rationale for current architecture (use freeshard-architecture-contract), or release/merge procedure (use freeshard-change-control).
+---
+
+# Freeshard Failure Archaeology
+
+This is the incident chronicle for shard_core (this repo, `shard_core/` — the per-VM FastAPI service that manages Docker apps behind Traefik on a "shard", a customer's personal cloud VM). It records what broke, why, and what was decided, so a fresh session does not re-attempt a dead end or undo a settled decision.
+
+Terms used throughout:
+
+- **controller** = [FreeshardBase/freeshard-controller](https://github.com/FreeshardBase/freeshard-controller), the central service that provisions shard VMs and delivers **core versions** (v1…v18: per-shard bundles of docker-compose.yml + host migration scripts). Production shards run what the core version pins, NOT what this repo's `docker-compose.yml` says.
+- **call_backend / call_peer** = shard_core's sign-and-forward HTTP proxies (`shard_core/web/protected/`, `shard_core/web/internal/call_peer.py`) that relay requests to the controller / other shards with HTTP-signature auth.
+- **grind** = the overnight agent loop: one headless AI session per GitHub issue, own worktree, branch from main, PR for human review. Nothing auto-merges.
+
+Entry format: **SYMPTOM → ROOT CAUSE → EVIDENCE → STATUS**. All issue/PR numbers without a repo prefix are in FreeshardBase/freeshard. Dates of volatile facts are as of 2026-07-03.
+
+---
+
+## 1. Backup / rclone pipeline
+
+The single most incident-dense subsystem. Read this whole section before touching `shard_core/service/backup.py`.
+
+### 1.1 rclone rollout incident chain, 0.28.0–0.28.6 (seven releases in three days, 2024-04-20..22)
+
+- SYMPTOM: auto-backup feature shipped in 0.28.0; production backups failed repeatedly, each fix revealing the next failure.
+- ROOT CAUSE (serial): Docker image shipped without the rclone binary; then rclone's multi-line output broke parsing; then strict Pydantic validation of rclone's log JSON broke on missing fields; then a wrong SAS-token path.
+- EVIDENCE: commits `cba5806` "install rclone to docker image", `2d2ec22` "use last line of rclone output", `9666db5` "make all rclone log fields optional", `b4c5eda` "Use new backup sas token path"; tags 0.28.0 (2024-04-20) through 0.28.6 (2024-04-22).
+- STATUS: fixed by 0.28.6, but the parsing class of bug **recurred** — see 1.2.
+
+### 1.2 rclone-output validation recurrence (2026) — the opaque-dict rule
+
+- SYMPTOM: backups failed validation again two years later, right after the Postgres release.
+- ROOT CAUSE: same class as `9666db5` (2024): Pydantic-validating rclone's stats JSON, whose shape is not a stable contract.
+- EVIDENCE: commit `b9dfcfd` "treat rclone stats as opaque dict to prevent backup validation failures" (released 0.38.3, 2026-04-18).
+- STATUS: fixed. **Standing rule: never Pydantic-validate rclone stats/log output — treat it as an opaque dict.** It changed shape twice; assume it will again.
+
+### 1.3 The 0.37.5 backport anomaly — tag order ≠ commit topology
+
+- SYMPTOM (for archaeologists): tag 0.37.5 (2026-04-18) is *newer in time* than 0.38.0 (2026-04-17).
+- ROOT CAUSE: the freshly released 0.38 Postgres line was evidently not trusted for immediate fleet rollout, so the rclone-stats fix was cherry-picked (`0a5f249`) onto branch `origin/release/0.37.5` (`3392ff3`) and shipped on the old TinyDB line too.
+- STATUS: historical fact. **Never assume tag order equals commit topology in this repo.** Resolve with `git branch -a --contains <tag>`.
+
+### 1.4 CronTask silent death kills backups permanently
+
+- SYMPTOM: scheduled backups stopped forever with no error surfaced; only a restart revived them.
+- ROOT CAUSE: `CronTask` background scheduler died on the first uncaught exception and never rescheduled.
+- EVIDENCE: issue [#58](https://github.com/FreeshardBase/freeshard/issues/58), fixed in PR [#61](https://github.com/FreeshardBase/freeshard/pull/61) (merged 2026-04-14).
+- STATUS: fixed. Rule: any background/periodic task must catch and log exceptions, or it dies silently and permanently.
+
+### 1.5 No external backup-recency signal → marker blob
+
+- SYMPTOM: the controller could not tell whether a shard's backups were actually running (see 1.4 for why that mattered).
+- FIX: write a marker blob after each successful backup; the controller polls it.
+- EVIDENCE: issue [#59](https://github.com/FreeshardBase/freeshard/issues/59), PR [#62](https://github.com/FreeshardBase/freeshard/pull/62) (merged 2026-04-14).
+- STATUS: fixed. Any change to backup flow must keep the marker-blob write.
+
+### 1.6 datetime in JSONB
+
+- SYMPTOM: post-Postgres backups broke on serializing the directories structure.
+- ROOT CAUSE: `datetime` objects are not JSON-serializable when writing JSONB columns.
+- EVIDENCE: PR [#74](https://github.com/FreeshardBase/freeshard/pull/74) "fix(backup): serialize datetime in directories JSONB" (commit `935250b`, released 0.38.4).
+- STATUS: fixed. Explicitly serialize datetimes before they hit JSONB.
+
+### 1.7 Azure list-ops cost fix → v18 release-blocker regression
+
+- SYMPTOM (first): Azure "List and Create Container Operations" meter cost several times the actual stored backup data.
+- FIX (first): add `--fast-list` and `--azureblob-no-check-container` to the rclone sync, PR [#106](https://github.com/FreeshardBase/freeshard/pull/106) (merged 2026-06-13).
+- SYMPTOM (second): **all** backups on core v18 failed — the rclone binary pinned in the shipped image did not know `--azureblob-no-check-container`.
+- EVIDENCE: release-blocker issue [#117](https://github.com/FreeshardBase/freeshard/issues/117), fixed by PR [#119](https://github.com/FreeshardBase/freeshard/pull/119) dropping the unsupported flag (2026-06-30).
+- STATUS: fixed. **Rule: any new rclone flag must be validated against the rclone version pinned in the Docker image before merge.**
+
+Also in this subsystem: empty directories were silently lost by backup/restore — fixed in PR [#52](https://github.com/FreeshardBase/freeshard/pull/52).
+
+---
+
+## 2. Database: three dead migrations, one success, and the rollout fallout
+
+### 2.1 The THREE dead DB-migration attempts before PR #56
+
+TinyDB→relational-DB was attempted four times. Before restarting ANY storage work, read the dead branches (section 10 checklist).
+
+| Attempt | Branch | Last commit | Fate |
+|---|---|---|---|
+| 1. SQLite route | `origin/feature/sqlite` | 2025-01-13 | Abandoned mid-way (per-store migration commits: peers, tours, terminals, app-usage, backup-stats). No in-repo rationale for abandonment. |
+| 2. Copilot Postgres | `origin/copilot/migrate-database-to-postgres` | 2026-02-01 | PR [#29](https://github.com/FreeshardBase/freeshard/pull/29) closed unmerged. |
+| 3. Agent Postgres | `origin/issue/25-replace-tinydb-with-postgres` | 2026-02-24 (tip lineage includes `ab73e25` "WIP claude interrupted") | PR [#34](https://github.com/FreeshardBase/freeshard/pull/34) closed unmerged. |
+| 4. **Success** | `origin/replace-tinydb-with-postgres` | — | PR [#56](https://github.com/FreeshardBase/freeshard/pull/56) merged 2026-04-17 (commit `2980bfb`, merge `0837749`), released 0.38.0. Driving issue [#25](https://github.com/FreeshardBase/freeshard/issues/25) (closed 2026-06-29 in bulk backlog cleanup). |
+
+### 2.2 Postgres rollout fallout, 0.38.0–0.38.4 (2026-04-17..23)
+
+- SYMPTOM: four patch releases within six days of the biggest storage change in project history.
+- FIX SEQUENCE: 0.38.1 `c824636` (CI app-install timeout flakiness), 0.38.2 `dc45ced` (LifespanManager `shutdown_timeout` teardown flakiness), 0.38.3 `b9dfcfd` (rclone opaque dict, see 1.2), 0.38.4 `935250b` (datetime JSONB, see 1.6). Plus `358a908` "Fix CI test hang: commit migration SQL and guard pool cleanup" inside the migration branch itself.
+- STATUS: all fixed. Pattern to expect: **any infra-level minor release is followed by a burst of 2–4 patch releases within days.** Plan review and rollout capacity accordingly.
+
+### 2.3 DB pool exhaustion under forwardAuth bursts
+
+- SYMPTOM: batches of 500s on private apps; SPA page loads (~30 parallel requests, e.g. Actual Budget) exhausted the small connection pool via Traefik forwardAuth calls to `/internal/auth`, requests waited ~30 s then failed.
+- ROOT CAUSE: `/internal/auth` runs on EVERY private-app request and did 2–3 DB queries per call against a 4-connection pool.
+- FIX: pool bump (max_size=20) + in-process auth-path caches; then a follow-up commit on the same PR fixing cache invalidation correctness (signal-driven, no TTLs).
+- EVIDENCE: issue [#89](https://github.com/FreeshardBase/freeshard/issues/89) (was labeled high-priority), PR [#90](https://github.com/FreeshardBase/freeshard/pull/90) (merged 2026-05-22); commits `1e0e7c1` (cache added) then `868e690` (invalidation fixed).
+- STATUS: fixed. If you touch identity or app state, check whether the auth caches need an invalidation signal — the first cut of the cache shipped without one and had to be patched.
+
+---
+
+## 3. Docker lifecycle: stale state fixed three times
+
+Docker objects (containers, networks) survive shard_core updates and go stale. This bit three separate times before the lesson stuck:
+
+| # | Fix | Commit / PR | Date |
+|---|---|---|---|
+| 1 | Recover from stale Docker **network references** on app start | `d66d889`, PR [#54](https://github.com/FreeshardBase/freeshard/pull/54) | 2026-04-08 (0.37.4) |
+| 2 | Handle stale **container name conflicts** on `docker_start_app` (symptom fix) | `fefd2f4`, PR [#63](https://github.com/FreeshardBase/freeshard/pull/63) | 2026-04-14 |
+| 3 | Fix **root cause** of stale containers on core update | `751678d` (same PR window as #63) | 2026-04-14 |
+
+- STATUS: fixed, but structural. **Rule: any new docker-start code path must recover from name conflicts and dangling network references** — do not assume clean Docker state after a core update.
+
+Related settled work: zombie healthcheck `curl` processes fixed by tini as PID 1 (PR [#55](https://github.com/FreeshardBase/freeshard/pull/55), commit `57ac53d`); standalone `docker-compose` v1 → `docker compose` v2 plugin (issue [#35](https://github.com/FreeshardBase/freeshard/issues/35), PR [#87](https://github.com/FreeshardBase/freeshard/pull/87)); app compose templates re-rendered on startup (PR [#49](https://github.com/FreeshardBase/freeshard/pull/49)).
+
+### 3.1 python-on-whales migration — stalled, not dead, not approved
+
+- Oldest open issue: [#24](https://github.com/FreeshardBase/freeshard/issues/24) "Integrate Python on Whales or some other docker python lib" (2025-12-19). PR [#88](https://github.com/FreeshardBase/freeshard/pull/88) has been open with **zero reviews since 2026-05-18**.
+- STATUS: open/stalled. Do not start a competing docker-lib migration, and do not treat PR #88 as accepted direction — it has never been reviewed.
+
+---
+
+## 4. Traefik / ingress / proxying
+
+### 4.1 fd-exhaustion outage arc (June 2026) — the worst recent incident
+
+- SYMPTOM: shards "up but not serving" — containers healthy, nothing reachable. Traefik logged `accept4: too many open files` (EMFILE) in a hot loop; the error spam itself filled the root disk (controller issue [#306](https://github.com/FreeshardBase/freeshard-controller/issues/306): unbounded container logs bricked shard upgrades).
+- ROOT CAUSE — **two factors, both required**:
+  1. Production Traefik was pinned v2.6, built with a pre-1.19 Go (measured go1.17.10; the "Go 1.16" figure in controller PR #322's prose is imprecise — see freeshard-proof-and-analysis-toolkit Recipe 1). Go only self-raises `RLIMIT_NOFILE` from 1.19 on, so Traefik ran with the soft limit.
+  2. Newly provisioned shards moved to an Ubuntu 26.04 base image (controller PR [#299](https://github.com/FreeshardBase/freeshard-controller/pull/299), forced by OVH image rotation — see 6.3) where the effective per-container nofile soft limit was 1024. Older shards had the identical socket leak (`readTimeout=0` on an internet-scanned IP) but survived only because their fd ceiling was higher — "old shards are fine, must be luck" was investigated and disproven; it was ceiling height, not luck.
+- FIXES (multi-repo):
+  - shard_core: finite `readTimeout` on Traefik entrypoints stops the leak — commit `fd1d05b`, PR [#108](https://github.com/FreeshardBase/freeshard/pull/108) (merged 2026-06-21, released 0.39.4 on 2026-06-24).
+  - controller: core v16 log rotation ([#309](https://github.com/FreeshardBase/freeshard-controller/pull/309)) — which silently did nothing at first, see 6.1; core v17 nofile ulimit ([#311](https://github.com/FreeshardBase/freeshard-controller/pull/311)) and daemon restart so config actually applies ([#312](https://github.com/FreeshardBase/freeshard-controller/pull/312)).
+- DECISION — **stay on Traefik v2**: bump to v2.11 (built with Go 1.25, self-raises nofile ≈1024→64000) instead of the "obvious" risky v3 migration. Canonical statement is the closing comment on PR [#112](https://github.com/FreeshardBase/freeshard/pull/112) (closed unmerged 2026-06-24): v3 migration folded into a needs-Intent P3 backlog ticket. Confirmed in production: core v18 compose pins `traefik:v2.11`.
+  - **Do not resurrect v3-prep changes** (HostRegexp→Host() style); local branch `fix/traefik-dashboard-host-rule` (2026-06-23) is that dropped work.
+  - TRAP: this repo's own `docker-compose.yml` says `image: traefik:v3.6` (bumped `e78862d`, 2025-12-16) — that is the **dev/self-hosted compose only**. Production shards run the controller core-version pin (v2.11 as of core v18, 2026-07-03). Do not "fix" either to match the other without reading PR #112 first.
+- PROCESS FALLOUT: the readTimeout fix was merged but sat in no released tag while shards kept failing — issue [#111](https://github.com/FreeshardBase/freeshard/issues/111). **Merged-is-not-shipped**; see freeshard-change-control. A redundant version-bump PR [#113](https://github.com/FreeshardBase/freeshard/pull/113) was closed unmerged because main had already been bumped directly — always `git fetch` and check origin/main + published releases before opening a release PR.
+- STATUS: fixed (0.39.4 + core v17/v18); Traefik-v3 migration = open backlog, decided-not-now.
+
+### 4.2 Content-Type proxy landmine
+
+- SYMPTOM: every proxied **write** to the controller returned 422; reads worked fine. Red herring chased: body double-encoding.
+- ROOT CAUSE: `call_backend` relayed bodies but dropped the `Content-Type` header (Python `requests` sets none for `data=<bytes>`). Harmless for years, until the controller's FastAPI upgrade made JSON parsing strict about the header — a latent bug armed by a *dependency bump in a different repo*.
+- EVIDENCE: issue [#93](https://github.com/FreeshardBase/freeshard/issues/93) (high-priority), PR [#94](https://github.com/FreeshardBase/freeshard/pull/94) (merged 2026-05-27). Diagnosed with tcpdump in the container netns because Traefik swallowed the detail.
+- STATUS: fixed.
+
+### 4.3 call_backend/call_peer is a repeat offender — full rap sheet
+
+| Bug | Evidence | Fixed |
+|---|---|---|
+| Query strings not forwarded to controller | PR [#19](https://github.com/FreeshardBase/freeshard/pull/19) | 2025-12-13 |
+| Slow proxying (buffered instead of streamed bodies) | issue [#38](https://github.com/FreeshardBase/freeshard/issues/38), PR [#39](https://github.com/FreeshardBase/freeshard/pull/39) | 2026-03-22 |
+| Content-Type dropped on writes | [#93](https://github.com/FreeshardBase/freeshard/issues/93)/[#94](https://github.com/FreeshardBase/freeshard/pull/94) | 2026-05-27 |
+
+Checklist when touching any sign-and-forward proxy code here: forward query strings, forward Content-Type (and other load-bearing headers), stream bodies. Note `_get_app_for_ip_address` in `shard_core/web/internal/call_peer.py` is `lru_cache`'d and carries a "todo: test this" — untested hot path.
+
+### 4.4 Splash-screen stalemate (#91/#92) — UNRESOLVED, do not code around it
+
+- GOAL: embed the real upstream error response (hidden) in the splash page so it's visible in dev tools — issue [#91](https://github.com/FreeshardBase/freeshard/issues/91).
+- CONFLICT: PR [#92](https://github.com/FreeshardBase/freeshard/pull/92) implements an internal reverse proxy; maintainer max-tet requested changes ("too complex — no need for a separate endpoint"). The agent's counter-argument: Traefik's errors middleware discards the upstream body, so some proxy is technically required. No movement since 2026-05-27.
+- STATUS as of 2026-07-03: **open architectural disagreement.** Do not merge-adjacent work that presumes either outcome; if you pick this up, resolve the disagreement in the issue thread first (see freeshard-change-control for how decisions get made).
+
+---
+
+## 5. CI and release-process incidents
+
+### 5.1 GitLab→GitHub CI bring-up chain, 0.31.0→0.32.0 (six tags in three days, 2025-02-24..26)
+
+- CONTEXT: GitLab registry credentials had already died once (0.30.4–0.30.6, commits `584113e`, `4d6e30f`, 2025-01-20..21). Full migration: `b33eada` "delete .gitlab-ci.yml" + `0729394` "add github actions" (2025-02-24).
+- SYMPTOM: pipeline debugged by trial and error directly on main: `b258fbd` "fix pipeline env vars", `d67abc6` "fix pipeline permissions", `d2acc45` "try another way to handle slug vars", `59c4e07` "use sha as label temporarily", `42cf5c6` "hard code registry path", `d309113` "skip json-schema and api-docs for now".
+- STATUS: pipeline works, BUT the "temporary" skip from `d309113` (2025-02-26) is **still in place** — the json-schema job is commented out in `.github/workflows/release.yml` (line ~75) as of 2026-07-03. If your change relies on published JSON schemas or API docs, they are not being published.
+
+### 5.2 Chronic CI flakiness (multi-year)
+
+`tests/conftest.py` is the most fix-touched file in the repo (33 fix-commit touches). Landmarks: `dcf6207` skip flaky peer-call tests (2022), `28964fd` network not torn down between tests, `aad605a` telemetry test converted to unit test, `c824636` install-timeout bump (2026), `dc45ced` LifespanManager shutdown_timeout. Before "fixing" a flaky test, check freeshard-testing-and-qa — most flake classes here have a known cause.
+
+### 5.3 Reverts are rare — treat them as signals
+
+Only ONE true `git revert` exists in ~784 commits: `3ee5a71` (reverts `e0c4bed`, 2023 test-infra). The project's failure mode is not revert-thrash; it is *fix-tails* (patch bursts after infra releases) and *abandoned branches*. When you see an unmerged branch, assume "pending decision or dead end", never "free code to merge" — check the PR/issue state first.
+
+---
+
+## 6. Controller-side incidents shard work must know about
+
+These live in FreeshardBase/freeshard-controller but bite shard_core work directly.
+
+### 6.1 Docker daemon.json reload-vs-restart trap
+
+- SYMPTOM: core v16 shipped daemon-wide log rotation (`max-size`/`max-file`); it silently did nothing.
+- ROOT CAUSE: it was applied with `systemctl reload docker`. SIGHUP reloads only a whitelisted subset of daemon.json — **log-driver/log-opts and default-ulimits are NOT in it**, and containers keep stale in-memory values even when recreated after a reload.
+- EVIDENCE: controller PRs [#309](https://github.com/FreeshardBase/freeshard-controller/pull/309) (v16, ineffective) → [#312](https://github.com/FreeshardBase/freeshard-controller/pull/312) "v17 daemon-wide docker config + restart (rotation actually applies, fd ceiling)".
+- STATUS: fixed in core v17. Rule: log-opts/ulimit changes need `systemctl restart docker` (bounces all containers — maintenance window), never `reload`.
+
+### 6.2 Migration-delivery trap — the sentinel guards the wrong thing
+
+- SYMPTOM: host migrations silently never ran on fresh shards and on version-skipping upgrades (e.g. v15→v17); a broken shard was found where the nofile migration had never executed.
+- ROOT CAUSE: script delivery was version-scoped (only the target version's scripts were uploaded), and the `.migrations_applied` sentinel only prevented *re-running* — it gave zero protection against *never-delivered* scripts.
+- EVIDENCE: controller issue [#307](https://github.com/FreeshardBase/freeshard-controller/issues/307), fix PR [#308](https://github.com/FreeshardBase/freeshard-controller/pull/308) (cumulative union of all versions' scripts, globally-unique `vN-NN-description.sh` names, numeric ordering); follow-up [#323](https://github.com/FreeshardBase/freeshard-controller/pull/323) replaced run-once sentinels with idempotent reconcilers run on every converge.
+- STATUS: fixed. Design rule: prefer idempotent reconcile-on-every-converge over run-once sentinels.
+
+### 6.3 OVH base-image rotation broke provisioning
+
+- SYMPTOM: shard provisioning failed with a cryptic `list index out of range`; auto-provisioning disabled itself.
+- ROOT CAUSE: OVH removed the non-LTS "Ubuntu 25.04" image from the region without notice; code did exact-name match + `[0]` on an empty list.
+- EVIDENCE: controller PRs [#299](https://github.com/FreeshardBase/freeshard-controller/pull/299) (bump image), [#300](https://github.com/FreeshardBase/freeshard-controller/pull/300) (image name becomes a controller-managed runtime setting), [#301](https://github.com/FreeshardBase/freeshard-controller/pull/301) (clear error when image/key not found).
+- STATUS: fixed; lessons: pin LTS images only; provider provisioning inputs are runtime settings, not static config. Side effect: the Ubuntu 26.04 image was factor 2 of the fd-exhaustion outage (4.1).
+
+### 6.4 OVH SDK singleton auth-brick
+
+- SYMPTOM: after one transient OVH token-endpoint 500, ALL subsequent OVH calls returned "401 You must login first" until controller restart; two shard deletions failed and the VMs kept billing.
+- ROOT CAUSE: process-level `ovh.Client` singleton cached a stale token with no recovery path.
+- EVIDENCE: controller issue [#275](https://github.com/FreeshardBase/freeshard-controller/issues/275) (closed 2026-06-05).
+- STATUS: fixed. Pattern: SDK singletons with token caching need auth-error reset+retry.
+
+### 6.5 Lexical version sort — "everything was fine until v10"
+
+- SYMPTOM: the system thought core v9 was newer than v10; bit in four places at once (backend latest-version, `/core-versions` list, frontend latest, upgrade dropdown).
+- ROOT CAUSE: version directory names sorted as strings: `"v10" < "v9"`.
+- EVIDENCE: controller PRs [#260](https://github.com/FreeshardBase/freeshard-controller/pull/260), [#262](https://github.com/FreeshardBase/freeshard-controller/pull/262) (merged 2026-05-26).
+- STATUS: fixed. Rule: never sort version identifiers lexically; use a numeric ordinal, and the frontend trusts backend order. Related: shard_core's move to real semver is open — issue [#118](https://github.com/FreeshardBase/freeshard/issues/118).
+
+### 6.6 Pricing rounding divergence — Python `round()` vs JS `Math.round()`
+
+- SYMPTOM: displayed price label could disagree with the actual PayPal charge by 1 cent on half-cent results.
+- ROOT CAUSE: Python `round()` is banker's rounding, JS `Math.round()` is half-up; they agreed under the old formula and diverged once the 19%-VAT factor produced half-cent values.
+- EVIDENCE: controller PR [#298](https://github.com/FreeshardBase/freeshard-controller/pull/298) — switched backend to half-up `int(x + 0.5)`, bit-identical to `Math.round` for positive values; sibling PRs web-terminal#30 and landing-page#15 (formula is manually duplicated across repos and must change in lockstep).
+- STATUS: fixed. Rule: never use Python `round()` in pricing code.
+
+### 6.7 PayPal quantity-pricing workaround
+
+- CONSTRAINT: PayPal forbids repricing a running subscription (`422 OVERRIDES_ON_SAME_PLAN_NOT_ALLOWED`).
+- ACCEPTED DESIGN: ONE plan priced €0.01 with `quantity_supported`; quantity = price in cents; resize = quantity revision, applies next cycle. Webhooks must read `resource.quantity`, not `last_payment` (lags a cycle).
+- REJECTED ALTERNATIVES: per-resize plan overrides (hard 422 above); ping-ponging between two €1 plans (rejected in review as unmaintainable); redirect-based resize (broke behind the shard proxy — reworked to fully in-window PayPal JS SDK, controller PR [#292](https://github.com/FreeshardBase/freeshard-controller/pull/292)).
+- EVIDENCE: controller PRs [#291](https://github.com/FreeshardBase/freeshard-controller/pull/291) (quantity pricing), [#316](https://github.com/FreeshardBase/freeshard-controller/pull/316) (runbook corrected to penny-quantity model).
+- STATUS: live in production since 2026-06-23. Do not propose plan-per-price designs.
+
+---
+
+## 7. Identity direction: Authelia is dead, embedded OIDC is the path
+
+- HISTORY: PR [#86](https://github.com/FreeshardBase/freeshard/pull/86) "Add Authelia as core IAM service" is still open but **orphaned** — never reviewed, and its driving issue [#36](https://github.com/FreeshardBase/freeshard/issues/36) was closed 2026-06-29 in a bulk backlog cleanup (same-minute closures of #18, #33, #36, #37, #71, #72; #25 shortly after). Branch: `origin/clayde/issue-36-authelia-yaml-backend` (2026-05-18).
+- DECISION (2026-06-12, recorded outside this repo): identity = embedded OIDC provider inside shard_core (Authlib), NOT Authelia. A PoC exists on the local-only branch `spike/oidc-provider-poc` (last commit 2026-06-12, zero-click Immich login); production implementation had not started in this repo as of 2026-07-03.
+- STATUS: Authelia = decided-won't-do. **Do not resurrect PR #86 or issue #36.** All OIDC work goes through freeshard-oidc-identity-campaign, which owns the decision gates.
+
+---
+
+## 8. Platform traps without a clean "fixed" commit
+
+### 8.1 Idle-sleep × PWA service worker
+
+Idle-slept apps cold-start on demand, but a split web/backend app (seen with KitchenOwl) serves a static 200 before its backend is ready — shard_core thinks "reachable" and skips the splash. Worse, a PWA service worker serves the cached shell without ever hitting the shard, then hard-redirects to `/unreachable`; after version bumps the stale cached frontend trips `min_frontend_version` until a hard refresh. Partial mitigation: gate the web container with `depends_on: condition: service_healthy` in the app's compose (app-repository side). General rule: scale-to-zero in front of SPAs/PWAs lies to your proxy. (No public tracking issue found as of 2026-07-03; treat details as unverified-but-load-bearing.)
+
+### 8.2 Ops-visibility gaps from the July 2026 Immich incidents — OPEN
+
+Two real incidents (DB-extension migration killed mid-flight; OOM restart loop shown to the user as a bare 502) produced two open issues: [#121](https://github.com/FreeshardBase/freeshard/issues/121) no-interruption window for app updates so on-startup migrations finish, and [#120](https://github.com/FreeshardBase/freeshard/issues/120) make OOM kills / restart loops visible. STATUS: open as of 2026-07-03 — check current state before starting related work.
+
+### 8.3 The overbuilt agentic dev-loop — retired after one day
+
+The first autonomous dev-loop build (in-container execution, derived-phase state machine, review-packet pipeline) was retired the day after going live as overbuilt, replaced by the current dumb grind script (one fresh headless session per issue; GitHub is the only state store; nothing auto-merges). EVIDENCE: [ClaydeCode/me PR #100](https://github.com/ClaydeCode/me/pull/100) "Gate freeshard loop behind CLAYDE_FS_ENABLED (default off)" (merged 2026-06-30). LESSON: for agent tooling here, the dispatcher stays dumb and all intelligence lives in the per-issue agent — don't rebuild the state machine.
+
+---
+
+## 9. Repo-archaeology command set
+
+These are the exact commands used to build this chronicle. **Path trap:** the codebase was renamed `portal_core/` → `shard_core/` in commit `88e5842` (2025-02-11, part of open-sourcing). Any history search MUST cover both prefixes.
+
+```bash
+# Tag → date table (release cadence, incident-burst detection)
+for t in $(git tag | sort -V); do echo "$t $(git log -1 --format=%ad --date=short $t)"; done
+
+# Churn: most-changed files ever
+git log --format= --name-only | sort | uniq -c | sort -rn | head -30
+
+# Fix hotspots: files most touched by fix-commits
+git log -i --grep=fix --format= --name-only | sort | uniq -c | sort -rn | head -30
+
+# History of one file ACROSS the rename (list both paths; --follow only takes one path)
+git log --oneline -- shard_core/service/backup.py portal_core/service/backup.py
+
+# Stale-branch triage: what each remote branch has that main doesn't
+for b in $(git branch -r | grep -v HEAD); do echo "== $b"; git log --oneline main..$b | head -5; done
+
+# Resolve tag/branch topology surprises (e.g. the 0.37.5 backport)
+git branch -a --contains <tag>
+
+# Which release first contained a commit
+git tag --contains <sha> | sort -V | head -1
+```
+
+gh gotchas for this org: `gh issue view N --comments` fails ("Projects classic deprecated") — use `--json body,comments`. Issue and PR numbers share one sequence; check `gh api repos/FreeshardBase/freeshard/issues/N -q '.pull_request!=null'` when unsure which one a "Fix #N" commit means (e.g. #54, #63 are PRs, not issues).
+
+---
+
+## 10. Checklist: before restarting storage / DB / docker-lib work
+
+Copy this into your plan and tick each item:
+
+- [ ] Read the three dead DB-migration branches before proposing any storage change: `git log --oneline main..origin/feature/sqlite`, `...main..origin/copilot/migrate-database-to-postgres`, `...main..origin/issue/25-replace-tinydb-with-postgres`. The merged pattern is `origin/replace-tinydb-with-postgres` → PR #56.
+- [ ] For docker-lib work: read PR [#88](https://github.com/FreeshardBase/freeshard/pull/88) (python-on-whales, open, unreviewed) and issue [#24](https://github.com/FreeshardBase/freeshard/issues/24) — don't fork a fourth approach.
+- [ ] Any new docker-start path handles stale container names AND stale network refs (section 3).
+- [ ] Backup changes keep: opaque-dict rclone parsing (1.2), CronTask exception safety (1.4), marker-blob write (1.5), datetime serialization (1.6), rclone-flag-vs-pinned-binary check (1.7).
+- [ ] Proxy changes forward query strings, Content-Type, and stream bodies (4.3).
+- [ ] No Traefik v3 work — settled in PR [#112](https://github.com/FreeshardBase/freeshard/pull/112); v2.11 is the production pin (4.1).
+- [ ] No Authelia work — settled; embedded OIDC is the path (7).
+- [ ] Re-check the live state of anything marked OPEN here (`gh issue view N --repo FreeshardBase/freeshard --json state,title`) — this file is a snapshot dated 2026-07-03.
+
+## When NOT to use this skill
+
+- You have a **live symptom to triage right now** → freeshard-debugging-playbook (it has the symptom→experiment tables; this file is the historical record behind them).
+- You need **why the architecture is the way it is** / current invariants → freeshard-architecture-contract.
+- You need **how to classify, gate, or release a change** (including merged-is-not-shipped mechanics) → freeshard-change-control.
+- You need **crypto/signatures/Traefik-forwardAuth theory** → freeshard-domain-reference.
+- You are working the **OIDC identity provider** → freeshard-oidc-identity-campaign (it owns the live decision gates; section 7 here is only the back-story).
+- You want **analysis technique** (how investigations like 4.1 were actually run) → freeshard-proof-and-analysis-toolkit.
+
+## Provenance and maintenance
+
+Written 2026-07-03 by repo archaeology (git log/tags/branches at local checkout, origin state via gh) plus GitHub issue/PR reads on FreeshardBase/freeshard, FreeshardBase/freeshard-controller, and ClaydeCode/me. All commit hashes, tag dates, issue/PR states, and titles were individually verified on 2026-07-03. Maintainer knowledge without a public artifact is labeled inline (sections 4.1 partial, 7, 8.1).
+
+Drift-prone facts and how to re-verify each:
+
+| Fact (as of 2026-07-03) | Re-verify with |
+|---|---|
+| PR #92 splash stalemate still open/CHANGES_REQUESTED | `gh pr view 92 --repo FreeshardBase/freeshard --json state,reviews` |
+| PR #88 python-on-whales still open, zero reviews | `gh pr view 88 --repo FreeshardBase/freeshard --json state,reviews` |
+| PR #86 Authelia still open (orphaned) | `gh pr view 86 --repo FreeshardBase/freeshard --json state` |
+| Issues #120, #121 still open | `gh issue view 120 121 --repo FreeshardBase/freeshard --json state` (one call each) |
+| Production Traefik pin is v2.11 (core v18 latest) | `gh api repos/FreeshardBase/freeshard-controller/contents/freeshard-controller-backend/data/core-versions --jq '.[].name' \| sort -V \| tail -1`, then fetch that version's docker-compose.yml and grep `traefik:` |
+| Dev compose still diverges (traefik:v3.6) | `grep 'image: traefik' docker-compose.yml` |
+| json-schema/api-docs release jobs still skipped | `grep -n '#  json-schema' .github/workflows/release.yml` |
+| spike/oidc-provider-poc still local-only / no production OIDC branch | `git branch -r \| grep -i oidc` |
+| Dead migration branches still exist on origin | `git branch -r \| grep -Ei 'sqlite\|postgres'` |
+| Latest release tag (was 0.39.4) | `git fetch --tags && git tag \| sort -V \| tail -1` |
+| Semver migration #118 still open | `gh issue view 118 --repo FreeshardBase/freeshard --json state` |

--- a/.claude/skills/freeshard-oidc-identity-campaign/SKILL.md
+++ b/.claude/skills/freeshard-oidc-identity-campaign/SKILL.md
@@ -1,0 +1,392 @@
+---
+name: freeshard-oidc-identity-campaign
+description: "Executable, decision-gated campaign to productionize the embedded OIDC identity provider inside shard_core (Authlib), replacing the rejected Authelia direction. TRIGGER on: OIDC, OpenID Connect, SSO, single sign-on, identity provider, IdP, Authlib, authorization code, PKCE, id_token, JWKS, discovery document, redirect_uri, 'zero-click login', Immich login, spike/oidc-provider-poc, shard_core/service/oidc_provider.py, shard_core/web/public/oidc.py, tests_poc/, Authelia, PR #86, issue #36, 'pairing session bridge'. SKIP when the task is about the existing terminal-pairing JWT auth or Traefik forwardAuth as-is (use freeshard-domain-reference), general auth debugging (freeshard-debugging-playbook), or generic release mechanics (freeshard-change-control)."
+---
+
+# Freeshard OIDC Identity Campaign
+
+Mission: give every shard a built-in OpenID Connect provider so installed apps
+(Immich first) log the owner in with **zero clicks**, riding on the existing
+terminal-pairing session. This is the hardest live problem in the repo. This
+skill is the campaign plan: numbered phases, each ending in a GATE with exact
+commands and expected observations.
+
+**Vocabulary** (project terms, defined once):
+
+| Term | Meaning |
+|---|---|
+| shard | One customer VM running shard_core (FastAPI) + PostgreSQL + Traefik + per-app Docker Compose stacks |
+| terminal | A paired browser/device. Pairing = redeem a 6-digit code at `POST /public/pair/terminal`, get an HS256 JWT in an `authorization` cookie (no `exp`; revoked by deleting the terminal row) |
+| forwardAuth | Traefik middleware calling `GET /internal/auth` on every app-subdomain request; enforces per-path `access: private/peer/public` from the app's `app_meta.json` |
+| pairing-as-auth-boundary | Freeshard design decision: "private" means *only my paired devices* — a stronger gate than app-level login. The OIDC provider extends this: a paired session IS the login |
+| the spike | Local branch `spike/oidc-provider-poc` (4 commits, 2026-06-12), worktree `.worktrees/spike-oidc-poc`. Reference only — production work happens on a FRESH branch |
+
+## Decision context (settled — do not relitigate without Max)
+
+- **Decided 2026-06-12**: identity = embedded OIDC provider inside shard_core
+  using **Authlib**, NOT Authelia. Method: a solution-neutral requirements
+  brief was given to a fresh AI session with zero hints; it re-derived Authelia
+  as a candidate and still recommended embedding. Drivers: restart-free config
+  (Authelia needs restarts/reloads on client changes), memory footprint on 1GB
+  XS VMs, passwordless pairing-based onboarding, and the no-email constraint
+  (shards have no general outbound email by design; apps can only mail the
+  owner via the controller relay).
+- **Same-day PoC**: ~740 LoC of provider code + 13 integration tests + a
+  live deployment achieving zero-click Immich login. See Phase 0.
+- **Known counter-risk (maintainer-acknowledged, not waved away)**: a
+  self-built IdP carries crypto unknown-unknowns, in a public repo that is
+  trivially scannable by AI tooling. This does not reverse the decision; it
+  creates the explicit security obligations in Phases 1 and 6.
+
+### Fenced-off wrong paths — do NOT go here
+
+| Dead path | Status as of 2026-07-03 | Rule |
+|---|---|---|
+| Authelia as core IAM | PR https://github.com/FreeshardBase/freeshard/pull/86 still OPEN, zero reviews; its issue https://github.com/FreeshardBase/freeshard/issues/36 was bulk-closed 2026-06-29. The PR is orphaned. | Do not revive, rebase, or borrow architecture from it without a NEW recorded decision from Max. If asked to "finish #86", surface this fence first. |
+| Per-app SSO patches | — | No app-specific auth hacks (custom header trust, per-app reverse-auth shims). Apps integrate via standard OIDC or not at all. |
+| Rolling your own JOSE | — | No hand-implemented JWT signing/verification, PKCE hashing beyond `hashlib.sha256` for test helpers, or key generation outside Authlib/joserfc. Verified gate in Phase 6. |
+| Vaultwarden SSO | — | Known to WORSEN login UX (SSO still demands the master password on top; its SSO exists for enterprise deprovisioning). Fenced out of rollout scope — see Phase 5. |
+| Merging the spike | — | The spike is reference material. Production implementation is a fresh branch off main; copy ideas, not commits. |
+
+---
+
+## Phase 0 — Read the spike (inventory, ~30 min)
+
+The spike branch exists **only locally** in this checkout (not on
+`origin` as of 2026-07-03 — `git ls-remote origin | grep oidc` returns
+nothing). It lives at branch `spike/oidc-provider-poc`, checked out in
+worktree `.worktrees/spike-oidc-poc`.
+
+```bash
+git log --oneline main..spike/oidc-provider-poc        # expect 4 spike commits (fb7f914..1d4ca85) + whatever main lacks
+git diff main...spike/oidc-provider-poc --stat          # ~30 files; provider core is 4 files
+git show spike/oidc-provider-poc:shard_core/service/oidc_provider.py   # 388 lines: Authlib server, grants, key mgmt
+git show spike/oidc-provider-poc:shard_core/web/public/oidc.py         # 184 lines: FastAPI adapter + endpoints
+git show spike/oidc-provider-poc:shard_core/database/oidc.py           # 151 lines: sync psycopg storage
+git show spike/oidc-provider-poc:migrations/shard-core-0002-oidc.sql   # 3 tables: oidc_clients, oidc_codes, oidc_tokens
+git show spike/oidc-provider-poc:tests_poc/test_oidc_poc.py            # 13 tests
+git show spike/oidc-provider-poc:deploy/poc-compose.yml                # live PoC deployment (Immich, no ML)
+```
+
+GATE 0: all commands above succeed and the file line counts roughly match.
+If `spike/oidc-provider-poc` is unknown → the local branch was pruned; look
+for the worktree (`git worktree list | grep spike`), then ask Max where the
+spike went before proceeding. Do NOT reconstruct it from memory.
+
+### What the spike PROVED vs what it STUBBED (verified against the branch)
+
+| Proved (evidence on branch) | Stubbed / unproven (do not assume) |
+|---|---|
+| Authlib code+PKCE+refresh flow works against real Postgres — 13 green integration tests in `tests_poc/` (discovery, JWKS, confidential + public-client flows, userinfo, refresh rotation, wrong-redirect-uri → 400 not redirect, wrong secret → 401, unknown/expired code → 400, code reuse → 400, anonymous → login redirect, scope narrowing) | Tests live in `tests_poc/` with their own conftest (session-scoped loop, external Postgres on :5432) — deliberately NOT integrated with the main `tests/` suite or CI |
+| Zero-click Immich login end-to-end on a live deployment: paired cookie → `/authorize` → code → Immich session, 0 clicks / 0 keystrokes (playwright script `scripts/oidc_poc_browser_test.py`, deployment `deploy/poc-compose.yml`) | The deployment used a slim app (`scripts/oidc_poc_app.py`) with only the public router and a hand-rolled pairing page — NOT the real shard stack behind Traefik with `/core/` prefix stripping |
+| Pairing-session bridge concept: `/authorize` accepts the `authorization` terminal-JWT cookie via `pairing.verify_terminal_jwt`; anonymous browsers 302 to `/?oidc_rd=<authorize-url>` | The `oidc_rd` return redirect is UNVALIDATED in the PoC pairing page (open-redirect if copied as-is); the real login/pairing UI belongs to web-terminal and does not exist yet |
+| Separate RS256 signing key (RSA-2048 via joserfc), private JWK persisted in `kv_store` key `oidc_provider_jwk`; JWKS endpoint never leaks `d` (tested) | No key rotation, single kid forever; private JWK stored plaintext (same posture as identity private_key — but see Phase 1 obligation) |
+| Immich specifics: needs an email claim to auto-provision (spike synthesizes `owner@{domain}`); sends `client_secret_post`; strict about `nonce: null` vs absent (spike strips null claims); redirect URIs `/auth/login`, `/user-settings`, `app.immich:///oauth-callback`; OAuth auto-launch configurable via API (`scripts/oidc_poc_immich_setup.py`) | Client registration is manual (setup script calls `register_client()`); no wiring into app installation, no `app_meta.json` contract, no secret delivery to app containers |
+| Scope escalation blocked at the grant layer (uses `request.scope` resolved against registered scope, not raw payload — see comment in `save_authorization_code`) | Token revocation on terminal unpair: tokens carry `user_sub` only, no terminal linkage — unpairing a device revokes NOTHING in the spike |
+| Single-user mapping is forward-compatible: `sub` = default identity id (stable across a future multi-user rollout) | Multi-user, consent UI, logout/end_session endpoint, token-endpoint rate limiting, `plain` PKCE lockdown — all absent |
+| Sync-Authlib-in-async-FastAPI bridge: `asyncio.to_thread` + pre-built `OAuth2Request` + `CaseInsensitiveDict` headers shim | Storage opens a new sync psycopg connection per call — the module docstring itself says "revisit before productizing" |
+
+Also true: `authlib>=1.7.2` is a spike-only dependency — main's
+`pyproject.toml` has no authlib (verify: `grep authlib pyproject.toml`).
+
+---
+
+## Phase 1 — Requirements freeze + threat model
+
+Before writing code, produce a threat model as an intent spec on the GitHub
+issue (see Phase 7 for the issue workflow). Each row below is an
+**obligation to derive and write down an answer**, not a to-do to silently
+implement. The AI-scannable-public-repo risk means every one of these will
+eventually be read by an adversary with a static analyzer.
+
+| Threat | Spike posture (verified) | Derivation obligation for the spec |
+|---|---|---|
+| Redirect-URI manipulation | Exact string match against registered list; mismatch → 400, never a redirect (tested) | Keep exact match, no wildcards, no substring/prefix logic. State why (open-redirect + code exfiltration). |
+| Session fixation / pairing brute force | Pairing code = 6 digits, single active code, 600 s TTL, single-use, but `POST /public/pair/terminal` has NO rate limit | Derive attack math (10^6 space vs request rate) and decide: rate limit, longer code, or accept + document. The OIDC provider inherits whatever pairing's strength is — it IS the login. |
+| Token substitution / audience | id_token `aud=[client_id]`; access tokens are opaque random strings bound to client_id in DB; but `/userinfo` accepts ANY valid access token (client-agnostic) | Prove or bound: can app A's token do anything at app B? Single-user today makes this low-stakes — write the argument down so multi-user work re-opens it. |
+| Signing-key storage | Private JWK plaintext in Postgres `kv_store` (`oidc_provider_jwk`) — same posture as identity `private_key` and `terminal_jwt_secret` | Decide: accept (consistent with existing posture, documented) or encrypt at rest. Don't silently diverge from repo posture either way. |
+| Identity key vs OIDC signing key | Spike uses a SEPARATE RSA-2048 RS256 key, not the RSA-4096 identity key (`shard_core/service/crypto.py` — note: the repo's crypto is RSA-4096 with PSS, HTTP signatures RSA_PSS_SHA512; agents.md's "Ed25519" claim is wrong) | Recommend keeping separation: independent rotation, smaller blast radius, no cross-protocol key reuse. Record as an explicit decision. |
+| Key rotation | None — one key, one kid, forever | Design rotation: generate new key, publish old+new in JWKS for a grace window, sign with new. Decide trigger (manual? age?). May ship post-v1 but must be *designed* pre-v1 so storage schema allows multiple keys. |
+| Clock skew | Authlib default iat/exp handling; codes expire via DB `expires_at > now()` | State the assumption: provider and RP run on the SAME VM (same clock) for first-party apps — skew is a non-issue until remote RPs exist. Write that boundary down. |
+| Open redirect via `oidc_rd` | PoC pairing page does `location.href = rd` unvalidated | Production login page (web-terminal) MUST validate `oidc_rd` is a same-origin path to the authorize endpoint. Cross-repo obligation — flag it in the spec. |
+| PKCE downgrade | `CodeChallenge(required=True)` but discovery advertises `plain` alongside `S256` | Require S256 only in production; remove `plain` from discovery and enforcement. |
+| Docker-network bypass | Any installed app shares the `portal` network and can reach `http://shard_core/...` directly, skipping Traefik (known repo weak point — see freeshard-architecture-contract) | Token endpoint is gated by client secret, so direct reach is survivable — derive this explicitly. Also decide how apps receive their client secret (Phase 2 D). |
+| Refresh-token reuse | Rotation on every refresh; rotated-out token → 400/401 (tested); refresh lifetime hack: 24× access-token lifetime | Decide real refresh lifetime + whether reuse of a rotated-out token revokes the whole token family (recommended standard practice). |
+| Revocation on unpair | Absent — tokens have no terminal linkage | Design it: record the issuing terminal_id on codes/tokens; deleting a terminal revokes its tokens. This is a Phase 4 milestone with a test. |
+
+GATE 1: the spec exists as a comment on the campaign's GitHub issue and Max
+has approved it (post the spec as an issue comment and wait for approval; the
+freeshard-intent-capture skill automates this flow where available). If Max pushes back on
+any row → the spec changes, not the fence. No code before this gate.
+
+---
+
+## Phase 2 — Architecture decision points (ranked menu)
+
+Present these to Max in the spec; ranked = recommended first. The issuer URL
+gets baked into every app's OIDC config, so **A must be decided before any
+app rollout** — changing issuer later is a fleet migration.
+
+**A. Where the provider mounts**
+1. *(spike-proven, least change)* Under the existing public router:
+   FastAPI path `/public/oidc/...`, external URL
+   `https://<domain>/core/public/oidc/...` (Traefik strips `/core/`;
+   the `auth-public` middleware only injects headers, never blocks — the
+   `authorization` cookie flows through untouched). Ugly issuer, zero Traefik
+   changes. The spike needed a `SHARD_OIDC_ISSUER` env override because its
+   slim deployment had no `/core` strip — production on this option must
+   compute issuer as `https://{identity.domain}/core/public/oidc` and the
+   override should remain a dev-only escape hatch.
+2. Dedicated Traefik router for a clean issuer (`https://<domain>/oidc` or
+   root-level `/.well-known/...`): nicer, but touches
+   `shard_core/service/traefik_dynamic_config.py` (compiled Python config —
+   see freeshard-domain-reference) and adds a new auth level to reason about.
+3. Subdomain `oidc.<domain>`: cookie still arrives (pairing cookie is set
+   with `domain=identity.domain`), but a new router + cert surface for little
+   gain.
+
+**B. Signing key** — keep the spike's separate-key choice (see Phase 1 row).
+Alternative (reusing the RSA-4096 identity key) is ranked last: couples
+identity rotation to token validity and reuses one key across two protocols.
+
+**C. Per-app client registration model**
+1. *(recommended)* Install-time hook: the app-installation worker
+   (`shard_core/service/app_installation/`) reads an `oidc` block from
+   `app_meta.json` (contract to be defined — Phase 5), calls
+   `register_client(...)`, and injects `client_id`/`client_secret` into the
+   app's compose template variables (the existing jinja2 `portal.*`/`fs.*`
+   mechanism). Uninstall deletes the client and revokes its tokens.
+2. Manual/API registration: fine for dev, not a product.
+   The spike's `register_client()` is REPLACE-on-conflict by app_name — keep
+   that idempotence for reinstalls.
+
+**D. Storage layer** — the spike's per-call sync psycopg connections must be
+revisited (its own docstring says so). Options: small dedicated sync
+`psycopg_pool.ConnectionPool` for the to-thread'd Authlib hooks
+*(recommended — bounded, simple)*; or rework hooks to async (fights
+Authlib's sync core; not worth it). Remember the repo invariant: the
+forwardAuth hot path must stay zero-DB-query
+(https://github.com/FreeshardBase/freeshard/pull/90) — OIDC endpoints are
+NOT on that path, but don't add OIDC lookups to `/internal/auth`.
+
+**E. Discovery + JWKS placement** — keep OIDC-standard shape:
+`{issuer}/.well-known/openid-configuration` and `jwks_uri` under the issuer,
+exactly as the spike does. Strict RPs derive the well-known URL from the
+issuer string; do not invent nonstandard paths.
+
+GATE 2: each of A–E has a recorded decision in the approved spec. If a
+decision is still open when implementation pressure mounts → stop and get
+the decision; a guessed issuer or registration model is rework, not progress.
+
+---
+
+## Phase 3 — Skeleton + tests on a fresh branch (TDD)
+
+```bash
+git checkout main && git pull
+git worktree add .worktrees/oidc-provider -b feature/clayde/oidc-provider  # agent naming per freeshard-change-control §3
+cd .worktrees/oidc-provider && uv sync --extra dev                  # ALWAYS --extra dev (pytest/ruff); never symlink .venv
+```
+
+Order of work (write the failing test first — use the superpowers:test-driven-development skill if your session has it):
+
+1. **Migration**: next `migrations/shard-core-NNNN-<slug>.sql` with yoyo
+   headers (`-- <id>` / `-- depends: <previous>`). As of 2026-07-03 main has
+   only `shard-core-0001-init.sql`, but other in-flight worktrees may claim
+   0002 — check `git fetch && git ls-tree origin/main migrations/` AND open
+   PRs before picking the number. Start from the spike's three tables
+   (`oidc_clients`, `oidc_codes`, `oidc_tokens`) plus whatever Phase 1
+   decided (terminal_id column for revocation, multi-key storage).
+2. **Service + web layer**: port `oidc_provider.py` / `web/public/oidc.py`
+   ideas deliberately, applying Phase 1/2 decisions (S256-only, issuer
+   computation, storage pool). Add `authlib` to `pyproject.toml` deps.
+3. **Tests in the MAIN suite** (`tests/`, not a new `tests_poc/`): the main
+   conftest gives you pytest-docker Postgres 17 (port 5433) with all tables
+   truncated before each test — the spike's unique-app_name workaround is
+   unnecessary there. Use the `app_client` fixture (app without lifespan,
+   DB + default identity, no Docker) for protocol tests; see
+   freeshard-testing-and-qa for fixture decision rules. Port ALL 13 spike
+   test behaviors — they are the regression floor, not the ceiling — and add
+   the Phase 1 obligations (S256-only, revocation-on-unpair once built).
+4. **Zero-click flow test** at the HTTP level: paired-cookie client hits
+   `/authorize` → 302 with code; anonymous client → 302 to login with
+   `oidc_rd`. The spike's `tests_poc/conftest.py` shows how to mint a
+   terminal session in-test (`Terminal.create` + `db_terminals.insert` +
+   `pairing.create_terminal_jwt`).
+
+Run: `pytest tests/ -k oidc` and the full suite; `just cleanup` before commits.
+
+GATE 3: full test suite green locally AND in CI on the PR branch
+(`gh pr checks <n>`). If tests pass locally but CI fails on dependency
+resolution → check CI installs from lockfile (`uv sync --frozen`;
+https://github.com/FreeshardBase/freeshard/issues/114 history).
+
+---
+
+## Phase 4 — Pairing-session bridge (the novel part)
+
+This is the piece with no off-the-shelf precedent: **paired-terminal cookie →
+authorization code, with no login UI ever shown**. Everything else is
+standard OIDC; this is where reviewers must look hardest.
+
+Mechanism (spike-proven shape): `/authorize` reads the `authorization`
+cookie → `pairing.verify_terminal_jwt` (HS256, secret in kv_store, terminal
+row must exist) → resource owner = shard owner → Authlib issues the code
+immediately (first-party clients, no consent screen). Anonymous → 302 to the
+web-terminal login/pairing page with `oidc_rd=<full authorize URL>`.
+
+**What proves the bridge safe** (each becomes a test or a spec paragraph):
+
+1. An expired/garbage/absent cookie NEVER yields a code — only the login
+   redirect. (Spike test: `test_anonymous_authorize_redirects_to_login`.)
+2. A cookie for a DELETED terminal is rejected — `verify_terminal_jwt`
+   already enforces row existence; add an explicit test (unpair → authorize
+   → login redirect, not code).
+3. Unpairing a terminal revokes the OIDC tokens it minted (Phase 1 design;
+   NOT in the spike). Test: full flow, delete terminal, assert refresh →
+   401 and userinfo → 401 within the access-token lifetime or immediately,
+   per the spec's decision.
+4. `oidc_rd` on the web-terminal side only ever navigates to a same-origin
+   authorize path (cross-repo: web-terminal PR; see
+   freeshard-ecosystem-contracts for multi-repo checklists).
+5. The cookie is `httponly` + `secure` with Starlette's default
+   `SameSite=Lax` (`shard_core/web/public/pair.py` sets no explicit
+   samesite) — Lax sends it on top-level GET navigations, which is exactly
+   the authorize redirect. Document that the bridge *depends* on Lax
+   semantics; an over-eager "harden to Strict" change would silently break
+   zero-click.
+
+GATE 4: a headless-browser run on a fresh dev stack reproduces the spike's
+zero-click result against the PRODUCTION implementation: 0 clicks, 0
+keystrokes, logged-in Immich. Adapt `scripts/oidc_poc_browser_test.py`
+(spike) — it counts interactions and asserts none. If the browser lands on
+Immich's login page instead → check OAuth auto-launch in Immich config and
+issuer consistency (discovery `issuer` must equal id_token `iss` must equal
+the URL Immich was configured with, byte-identical).
+
+---
+
+## Phase 5 — App-side rollout
+
+Define the `app_meta.json` contract (candidate shape — NOT yet designed;
+agree in the spec first): an `oidc` block declaring redirect URI paths and
+required claims, from which install-time registration (Phase 2 C) builds the
+client and injects credentials into the compose template.
+
+Rollout ladder, in order:
+
+| App | Status as of 2026-07-03 | Action |
+|---|---|---|
+| Immich | Known-smooth. Spike wired it live: needs email claim (synthesize `owner@{domain}` when identity has none), `client_secret_post`, strips-null-nonce quirk, redirect URIs `/auth/login` + `/user-settings` + `app.immich:///oauth-callback`, auto-launch via system config API | First and reference integration. Its `app_meta.json` in app-repository gets the first `oidc` block. |
+| Paperless-ngx | Open external dependency: an upstream PR for OIDC claims handling was in flight (outcome unverified as of 2026-07-03) | Check upstream before promising; fork threshold is Max's call. |
+| Vaultwarden | **Fenced off.** SSO demonstrably worsens its login (master password still required after IdP) | Do not integrate. If asked, point at this fence. |
+| File Browser / others | Unassessed | One at a time, only after Immich ships. |
+
+GATE 5: Immich installs from the app store on a fresh dev stack and
+zero-click login works with ZERO manual configuration steps (the
+`oidc_poc_immich_setup.py` script's job is now done by install-time
+registration + app config). Manual steps remaining = phase not done.
+
+---
+
+## Phase 6 — Hardening gate before ANY release
+
+Run before the first version bump that contains the provider. All must pass:
+
+```bash
+# 1. No hand-rolled crypto primitives — only Authlib/joserfc/stdlib-hashlib-for-tests
+grep -rn 'from cryptography' shard_core/service/oidc* shard_core/web/public/oidc* shard_core/database/oidc*   # expect: no hits
+grep -rn 'jwt.encode\|jws\|jose' shard_core/ --include='*.py' | grep -vi 'authlib\|joserfc'                    # expect: no hits outside pairing.py (existing HS256 terminal JWT)
+# 2. JWKS never leaks private material (also a permanent test)
+pytest tests/ -k jwks
+# 3. Discovery advertises S256 only
+curl -s localhost:8080/public/oidc/.well-known/openid-configuration | python3 -c 'import json,sys; d=json.load(sys.stdin); assert d["code_challenge_methods_supported"]==["S256"], d'
+# 4. Full suite
+pytest tests/
+```
+
+Plus non-command checks: every Phase 1 obligation has a written resolution in
+the spec; the open-redirect fix exists in web-terminal; revocation-on-unpair
+test is green. **External security review is Max's call** — raise it
+explicitly in the PR description (the counter-risk that motivated it is the
+public, AI-scannable repo), don't decide for him either way.
+
+GATE 6: all four command checks pass and Max has explicitly acknowledged the
+review question. Any failure → fix before Phase 7, no exceptions.
+
+---
+
+## Phase 7 — Promotion through change control
+
+Follow freeshard-change-control; summary of the non-negotiables as they apply
+here:
+
+1. Work is anchored to a GitHub issue with an approved intent spec (Phase 1).
+2. PR from the feature branch; description covers the whole branch and lists
+   a recommended reading order (migration → database → service → web →
+   tests). Nothing auto-merges; **Max's review+merge is the only ship gate**.
+3. **Merged ≠ shipped.** A release requires: `just set-version <version>`
+   (bumps `pyproject.toml` + `docker-compose.yml` image tag and COMMITS —
+   run on a clean tree) + a published GitHub Release (builds
+   `ghcr.io/freeshardbase/freeshard:<tag>`) + the controller's core-version
+   compose bump. History: https://github.com/FreeshardBase/freeshard/issues/111
+   (merged fix sat unreleased),
+   https://github.com/FreeshardBase/freeshard/pull/113 (version bump raced
+   main — always `git fetch` and check `origin/main` + published releases
+   first). Versioning may move to semver
+   (https://github.com/FreeshardBase/freeshard/issues/118, open) — re-check
+   before releasing.
+4. NEVER auto-ship. An agent may prepare the release PR; publishing is Max's.
+
+## Measurable success (the campaign is done when…)
+
+1. On a fresh dev stack, Immich installed from the app store: headless
+   browser with a paired-terminal cookie reaches a logged-in Immich with 0
+   clicks and 0 keystrokes (Gate 4 script, now in `scripts/` as a kept tool).
+2. CI-green tests prove, by name: redirect-URI rejection (400, no redirect),
+   token audience (`aud == [client_id]`), code single-use, PKCE-S256
+   required, scope narrowing, refresh rotation with old-token revocation,
+   JWKS privacy, and **revocation on terminal unpair**.
+3. `grep`-level absence of hand-rolled crypto (Gate 6 commands).
+4. A released image tag contains it all, promoted per Phase 7.
+
+Anything short of all four is "in progress", not "done" — say so plainly.
+
+## When NOT to use this skill
+
+- Understanding how terminal pairing, forwardAuth, RSA-4096/HTTP-signature
+  crypto, or Traefik config work **today** → freeshard-domain-reference.
+- Debugging a broken auth flow on an existing shard → freeshard-debugging-playbook.
+- Why Authelia/other approaches were rejected, full investigation history →
+  freeshard-failure-archaeology.
+- Release mechanics, gate definitions, review rules in general →
+  freeshard-change-control.
+- Writing/structuring the tests themselves → freeshard-testing-and-qa.
+- Changing `app_meta.json` handling or cross-repo contracts broadly →
+  freeshard-ecosystem-contracts.
+
+## Provenance and maintenance
+
+Written 2026-07-03. Primary sources: local branch `spike/oidc-provider-poc`
+(commits fb7f914, e09af8d, 587bd8c, 1d4ca85 — read via `git show`, never
+checked out), repo files on main (`shard_core/service/pairing.py`,
+`shard_core/web/public/pair.py`, `shard_core/service/crypto.py`, `justfile`,
+`pyproject.toml`, `migrations/`), GitHub state via `gh`
+(https://github.com/FreeshardBase/freeshard/issues/36,
+https://github.com/FreeshardBase/freeshard/pull/86,
+https://github.com/FreeshardBase/freeshard/issues/111,
+https://github.com/FreeshardBase/freeshard/issues/118).
+
+| Drift-prone fact | Re-verify with |
+|---|---|
+| Spike branch still exists locally, 4 commits, not on origin | `git log --oneline main..spike/oidc-provider-poc && git ls-remote origin \| grep -i oidc` |
+| Production OIDC work not yet started on main | `git fetch && git ls-tree origin/main shard_core/service \| grep oidc` (expect empty) |
+| PR #86 (Authelia) still open/orphaned | `gh pr view 86 --repo FreeshardBase/freeshard --json state,reviews` |
+| Issue #36 still closed | `gh issue view 36 --repo FreeshardBase/freeshard --json state,closedAt` |
+| authlib absent from main deps | `git show origin/main:pyproject.toml \| grep -i authlib` (expect empty) |
+| Only migration on main is 0001 (next free number) | `git fetch && git ls-tree origin/main migrations/` |
+| Pairing cookie attrs (secure, httponly, no samesite) | `grep -n -A8 'set_cookie' shard_core/web/public/pair.py` |
+| Terminal JWT semantics (HS256, no exp, row-existence revocation) | `sed -n '55,100p' shard_core/service/pairing.py` |
+| `just set-version` behavior (commits; clean tree needed) | `sed -n '/set-version/,/^$/p' justfile` |
+| Semver migration state (#118) | `gh issue view 118 --repo FreeshardBase/freeshard --json state` |
+| Paperless upstream OIDC-claims PR outcome | ask Max / check paperless-ngx upstream; unverified as of 2026-07-03 |

--- a/.claude/skills/freeshard-proof-and-analysis-toolkit/SKILL.md
+++ b/.claude/skills/freeshard-proof-and-analysis-toolkit/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: freeshard-proof-and-analysis-toolkit
+description: First-principles analysis recipes for the Freeshard repos — how to PROVE a root cause instead of pattern-matching to the first plausible fix. Use when only a subset of shards/requests fails, when two components disagree about the same bytes, when a formula is duplicated across languages, when adding per-request DB/IO work, when a container "looks OOM-killed", when a guard/sentinel exists and you must say what it protects, when optimizing cloud cost, or before running any discriminating experiment. TRIGGER on "root cause", "why does only X fail", "prove the mechanism behind this failure class (fd exhaustion, pool exhaustion, proxy write rejection, kill loops)", "rounding mismatch", "prices disagree", "Azure cost", "migration never ran", "prove it". If you only have the raw symptom string (an EMFILE loop, a 422, an OOM-looking restart loop), load freeshard-debugging-playbook first. SKIP when you need the symptom→triage lookup table for a KNOWN failure mode (use freeshard-debugging-playbook), the history of a specific past investigation (use freeshard-failure-archaeology), or the evidence-bar/idea-lifecycle discipline itself (use freeshard-research-methodology).
+---
+
+# Freeshard proof and analysis toolkit
+
+Eight recipes for turning "probably X" into "proven X", each with a worked example from this project's real history. The house rule they encode: **prove it, don't just install it** — a fix shipped on an unproven root cause here has repeatedly either done nothing (reload-vs-restart, controller PR [#312](https://github.com/FreeshardBase/freeshard-controller/pull/312)) or broken production (rclone flag regression, [#117](https://github.com/FreeshardBase/freeshard/issues/117)).
+
+Terms used throughout, defined once:
+
+| Term | Meaning |
+|---|---|
+| shard | A customer VM running the shard stack (Traefik + shard_core + web-terminal + Postgres) |
+| shard_core | This repo — the FastAPI service on each shard that manages apps, auth, backup |
+| controller | freeshard-controller — the central service that provisions shards, deploys core versions, bills |
+| core version (vN) | A versioned compose stack + host scripts the controller pushes to shard hosts (`freeshard-controller-backend/data/core-versions/vN/`) |
+| forwardAuth | Traefik middleware that calls shard_core `/internal/auth` on **every** request to a private app |
+
+Reading issue threads for evidence — two gh traps: `gh issue view N --comments` 500s on this org (deprecated Projects classic); use `gh issue view N --repo FreeshardBase/freeshard --json body,comments`. And the richest evidence is usually in PR/issue **bodies and comment corrections**, not commit messages.
+
+## Recipe index
+
+| Your situation | Recipe |
+|---|---|
+| Only a subset (new shards, some requests, one region) fails; the rest is "fine" | 1. Two-factor root-cause proof |
+| Component A and component B disagree about the same request/bytes | 2. Wire-level ground truth |
+| The same formula/logic is hand-duplicated across languages or repos | 3. Exhaustive-domain verification |
+| You're adding per-request DB/IO work, or a burst caused mass failures | 4. Resource arithmetic |
+| A container dies repeatedly and "it's OOM" is the leading theory | 5. Kill-signal forensics |
+| A guard/sentinel/check exists and you're relying on it | 6. Delivery-vs-execution guard analysis |
+| Cloud spend is high and you're about to optimize storage/compute | 7. Cost-meter attribution |
+| You're about to run ANY discriminating experiment | 8. Hypothesis-predicts-numbers (run this inside every other recipe) |
+
+---
+
+## Recipe 1 — Two-factor root-cause proof (when only a subset fails)
+
+**When:** a failure hits some shards/requests/environments and not others, and the tempting explanation is one-factor ("new shards are broken") or no-factor ("the old ones are just lucky").
+
+**Steps:**
+1. Write down the exact partition: which population fails, which doesn't. Refuse to proceed until the partition is crisp.
+2. Enumerate every variable that differs across the partition (image version, base OS, ulimits, config, age, provider region). Get each value by **measurement on both sides**, not from docs.
+3. A subset-only failure usually needs an **interaction of ≥2 factors** — one factor supplies the defect, the other the threshold. Find the pair whose combination predicts the partition exactly.
+4. Explicitly DISPROVE the lazy hypothesis ("survivors are lucky / it's random"): show the survivors' measured values put them on the safe side of the threshold.
+5. Only then choose a fix — and prefer the one that removes the defect, not the one that moves the threshold.
+
+**Worked example — the June 2026 fd-exhaustion outage.** Shards went silently unreachable; traefik logged `accept4: too many open files` (EMFILE) in a hot loop; that log spam itself grew 38 GB in 3 days and filled root disk, bricking upgrades (controller [#306](https://github.com/FreeshardBase/freeshard-controller/issues/306)). Only **newer** shards died. The partition: new shards ran on the Ubuntu 26.04 base image (OVH had rotated out 25.04) with a per-container `nofile` soft limit of **1024**; old shards had a higher ceiling. The defect was shared by *all* shards: traefik entrypoints had `readTimeout=0`, so internet scanners' abandoned connections each leaked one fd forever ([freeshard#108](https://github.com/FreeshardBase/freeshard/issues/108)). The interaction: leak × low ceiling = EMFILE on new shards only. "Old shards fine = luck" was disproven by measuring `docker exec traefik sh -c 'ulimit -n'` on both populations (1024 confirmed on failing shard 333 — controller PR [#322](https://github.com/FreeshardBase/freeshard-controller/pull/322)) and by Go-toolchain archaeology: a Go binary ≥1.19 self-raises RLIMIT_NOFILE to the hard limit at startup; the pinned traefik v2.6 predates that.
+
+```bash
+# the threshold, on a live shard (via diagnostics; needs an open diagnostic):
+docker exec traefik sh -c 'ulimit -n'
+# toolchain archaeology, lower bound from go.mod at the tag:
+gh api 'repos/traefik/traefik/contents/go.mod?ref=v2.6' --jq '.content' | base64 -d | grep '^go '   # -> go 1.17
+# definitive: what the shipped binary was actually built with:
+docker run --rm traefik:v2.6 version    # -> Go version: go1.17.10  (verified 2026-07-03)
+docker run --rm traefik:v2.11 version   # -> Go version: go1.25.x
+```
+
+(PR #322's body says "v2.6 is Go 1.16"; the measured current v2.6 image is go1.17.10 — either way <1.19, so the conclusion stands. Trust `version` output over go.mod over prose.)
+
+The proof changed the fix: instead of the "obvious" risky traefik v2→v3 migration, the fleet got traefik **v2.11** (Go 1.25, self-raises ~1024→hard limit; controller PRs [#320](https://github.com/FreeshardBase/freeshard-controller/pull/320), [#322](https://github.com/FreeshardBase/freeshard-controller/pull/322)) plus finite `readTimeout` in shard_core ([freeshard#108](https://github.com/FreeshardBase/freeshard/issues/108), shipped 0.39.4) plus a `nofile` ulimit and log rotation as defense-in-depth (controller PRs [#311](https://github.com/FreeshardBase/freeshard-controller/pull/311), [#312](https://github.com/FreeshardBase/freeshard-controller/pull/312)). The stay-on-v2 decision is recorded in the closing comment of [freeshard PR #112](https://github.com/FreeshardBase/freeshard/pull/112) — do not resurrect v3-prep changes.
+
+**Failure mode of skipping it:** you ship the one-factor fix (a v3 migration, or just log rotation as [#306](https://github.com/FreeshardBase/freeshard-controller/issues/306) first proposed) — the leak persists, the outage recurs on the next threshold change, and you've taken migration risk for nothing. Note also [freeshard#111](https://github.com/FreeshardBase/freeshard/issues/111): the readTimeout fix was merged but sat in no released tag — merged-is-not-shipped (see freeshard-change-control).
+
+---
+
+## Recipe 2 — Wire-level ground truth (when two components disagree)
+
+**When:** component A insists it sends X, component B insists it receives Y, and you're on your second hour of reading both codebases. Also whenever a proxy/middleware sits between them — on shards, Traefik **swallows upstream error bodies** (controller [#266](https://github.com/FreeshardBase/freeshard-controller/issues/266)), so the error you see is not the error that was sent.
+
+**Steps:**
+1. Stop reading code. Capture the actual bytes on the wire at the hop closest to the disagreement — the plaintext internal hop (Traefik→backend) is capturable without TLS games.
+2. Get the **full** error payload, not the proxied summary: `curl` the backend container directly, or tcpdump inside its network namespace.
+3. Compare captured bytes against each side's claim. One of them is wrong; now you know which.
+4. Treat any intermediate log line as a *claim*, not evidence — logs render bytes through a serializer that can lie about structure.
+
+```bash
+# tcpdump inside another container's netns, no tools installed on it:
+docker run --rm --net container:<backend-container> nicolaka/netshoot \
+  tcpdump -i any -A -s0 'tcp port 80'
+```
+
+**Worked example — the Content-Type bug (May 2026).** Every proxied write from shards to the controller returned 422; reads were fine. Static analysis of both repos concluded "the code as written should NOT return 422" and produced a wrong leading hypothesis (version skew) — see controller [#267](https://github.com/FreeshardBase/freeshard-controller/issues/267)'s body. The tcpdump capture of the Traefik→backend hop got the real 422 detail: `model_attributes_type`, with the payload rendered as a string. First reading of that capture spawned a **red herring**: "the body is double-JSON-encoded" — two full comments in #267 chased re-encoding through shard_core, the TS client, and axios before the correction landed. The actual cause: `shard_core/web/internal/call_backend.py` forwarded the body but passed no `headers=`, and `requests` sets no Content-Type for bytes `data`; the controller's FastAPI bump 0.115→0.136 flipped `strict_content_type=True`, which skips JSON-parsing a body without a JSON Content-Type — pydantic then validates raw bytes and the 422's `input` field *renders* them as a string. Fix: forward Content-Type (only) — [freeshard#93](https://github.com/FreeshardBase/freeshard/issues/93) / PR [#94](https://github.com/FreeshardBase/freeshard/pull/94), commit 167d779, now `shard_core/web/internal/call_backend.py:34-40`.
+
+Two durable lessons from the red herring: (a) an error message's *rendering* of the input is not the input's wire encoding — the capture disproved double-encoding as fast as it suggested it, once re-read against the fix hypothesis; (b) prove the innocent party innocent: a direct request with the header present returned 200/204, isolating the defect to the sending side.
+
+**Failure mode of skipping it:** codebase archaeology proves both sides "correct" forever (both *were* internally consistent here), while the actual defect lives in an unstated default between them. #267 shows the full cost: three hypotheses, two of them wrong, until bytes were captured.
+
+---
+
+## Recipe 3 — Exhaustive-domain verification (duplicated formulas)
+
+**When:** the same computation is hand-duplicated across languages/repos and must agree bit-identically. In this ecosystem that is the **pricing formula**, duplicated on purpose: controller `freeshard-controller-backend/freeshard_controller/service/pricing.py` (canonical) + its tests, web-terminal `src/lib/pricing.js` + its spec, landing-page `src/components/Pricing.astro` (see the sibling-PR blocks in controller PR [#298](https://github.com/FreeshardBase/freeshard-controller/pull/298) and web-terminal PR [#30](https://github.com/FreeshardBase/web-terminal/pull/30)).
+
+**Steps:**
+1. Enumerate the **entire** input domain the product actually offers (every VM size × every disk-size option in the UI picker). It is small — tens of combinations. Never sample.
+2. Run both implementations over the full domain and diff outputs **in integer cents** (never floats-to-2-decimals).
+3. Pin a handful of the results as test values in each repo, *recomputed from the real function*, never hand-derived (#298 did exactly this: "16 expected-cent values recomputed from the real function").
+4. Any change to the formula changes **all** copies in one lockstep set of sibling PRs.
+
+```bash
+python3 - <<'EOF'
+vm = {'xs': 5.50, 's': 11.00, 'm': 19.80, 'l': 51.00, 'xl': 102.00}  # verify against pricing.py first
+for size, base in vm.items():
+    for gb in DISK_OPTIONS_FROM_UI:   # enumerate exactly what the picker offers — all of it
+        eur = (base + gb * 0.04) * 1.5 * 1.19
+        print(size, gb, int(eur * 100 + 0.5))
+EOF
+# then the same loop in node with Math.round(total*100), and `diff` the two outputs.
+```
+
+**Worked example — the rounding divergence (June 2026).** When the 19% VAT factor landed (controller PR [#298](https://github.com/FreeshardBase/freeshard-controller/pull/298)), Python's `round()` (banker's rounding) and JS's `Math.round()` (half-up) — which had agreed under the old formula — began diverging by 1 cent on half-cent results (e.g. S + 250 GB). Consequence if unfixed: the UI price label disagrees with the PayPal charge. Sampling would likely have missed it — the divergent cases are a thin slice of the domain; only enumerating every size×disk combination surfaced them. Fix: backend switched to half-up `int(eur * 100 + 0.5)`, bit-identical to `Math.round` for positive values — the comment in `pricing.py` records this. **Never use Python `round()` in pricing code.**
+
+**Failure mode of skipping it:** a green test suite on both sides (each internally consistent), pinned test values that encode the divergence as "expected", and a customer charged a different amount than displayed — a trust/legal problem, not a rounding problem.
+
+---
+
+## Recipe 4 — Resource arithmetic (before shipping per-request work)
+
+**When:** adding any per-request DB query, connection, subprocess, or lock on a hot path — especially anything reachable from Traefik forwardAuth, which fires on **every** request to a private app. Also when a burst caused simultaneous mass failures and you need the mechanism.
+
+**Steps:**
+1. Write the arithmetic down: peak parallel requests × resources acquired per request vs. pool/limit size. A SPA loading is a legitimate burst of ~30 parallel requests, not an attack.
+2. Compute the failure timeline the numbers predict (queue-wait timeouts stack — see the worked example's 45 s) and check it against the observed symptom. If the numbers reproduce the symptom, the mechanism is proven.
+3. Fix the *rate*, not just the *capacity*: a bigger pool moves the threshold; caching removes the per-request work. Ship both, but know which one is the fix.
+4. New per-request state needs signal-driven invalidation, not TTLs — follow the existing pattern in `shard_core/web/internal/auth.py` (caches invalidated by `on_identity_update` / `on_apps_update`).
+
+**Worked example — DB pool exhaustion, [freeshard#89](https://github.com/FreeshardBase/freeshard/issues/89) (May 2026).** Actual Budget's frontend fetched ~30 migration files in parallel; all uncached ones 500'd simultaneously at ~45 s, with **zero** log entries in the app container. The issue body shows the arithmetic that proved it: pool opened with psycopg_pool defaults → `max_size=4`; each forwardAuth call serially acquired 2–3 connections (`_find_app`, `_get_identity`, plus `docker_start_app`); 30-parallel burst ⇒ pool exhausted within 2–3 in-flight auths ⇒ remaining `getconn()` block until the default 30 s pool timeout ⇒ `PoolTimeout` ⇒ 500. Predicted timeline: 30 s timeout + auth round-trip + forwardAuth overhead ≈ the observed ~45 s. Fix (PR [#90](https://github.com/FreeshardBase/freeshard/pull/90), commits 1e0e7c1 + 868e690): pool `max_size=20, timeout=10` (`shard_core/database/connection.py:28-29`) **and** in-process identity/app caches so steady-state auth is zero-DB-query. The cache-invalidation bug was caught and patched in a same-PR follow-up commit — capacity alone had been the first draft.
+
+**Failure mode of skipping it:** the symptom is opaque by construction (proxy 500s, upstream logs empty — only shard_core logs show `PoolTimeout`), so without the arithmetic you blame the app, the network, or Traefik. And a pool bump alone leaves 2–3 queries per request on a path hit by every request fleet-wide — the next-larger burst recreates the outage.
+
+---
+
+## Recipe 5 — Kill-signal forensics (before scaling resources)
+
+**When:** a container dies repeatedly and someone says OOM. RAM upgrades cost real money per month per shard; a wrong OOM diagnosis also masks a data-corruption bug that will follow the app to the bigger VM.
+
+**Steps:**
+1. Read the exit state before theorizing:
+   ```bash
+   docker inspect <container> \
+     --format '{{.State.ExitCode}} oom={{.State.OOMKilled}} restarts={{.RestartCount}} started={{.State.StartedAt}}'
+   ```
+   Exit code = 128 + signal: **137 = SIGKILL** (external: kernel OOM killer or docker), **134 = SIGABRT** (the process aborted *itself* — assertion, PANIC, corrupt extension).
+2. Corroborate externally: kernel OOM kills land in the kernel ring buffer (`journalctl -k | grep -i oom`), never in the app's own logs. Clean app logs + climbing restart count = external kill *signature*, but confirm the signal.
+3. Discriminate: SIGKILL+`OOMKilled=true` → genuinely out of memory → sizing/swap territory. SIGABRT → the app is broken internally → more RAM predicts **no change**.
+4. If you must test the OOM hypothesis, resizing RAM upward is a clean falsification experiment — write the prediction first (Recipe 8): OOM predicts the crash stops; SIGABRT predicts nothing changes.
+
+**Worked example — two Immich incidents that look identical and aren't.** (A) A size-S shard (3.8 GB RAM, swap=0): `immich_server` at 18 restarts, each boot clean then killed from outside; sibling containers untouched — classic per-app OOM kill; the user just saw "Immich keeps stopping" ([freeshard#120](https://github.com/FreeshardBase/freeshard/issues/120)). (B) July 2026, shard daf3qd: the app compose pinned Immich v2.7.5 but froze the DB image at VectorChord 0.3.0 when v2.7.5 needs 0.4.3 — uploads aborted, hard 502 crash-loop, and the platform's restart policy kept killing the minutes-long startup migration ([app-repository#29](https://github.com/FreeshardBase/app-repository/issues/29), [freeshard#121](https://github.com/FreeshardBase/freeshard/issues/121)). B *looked* like OOM; the crashes were SIGABRT — the DB extension aborting — and during the investigation the shard was resized upward as a falsification test and the crash persisted, exactly as the SIGABRT hypothesis predicted (the resize experiment is from the incident investigation; it is not recorded in the public threads). Recovery was DB surgery (`ALTER EXTENSION vchord UPDATE` + `REINDEX`), not RAM. Note the tooling gap this exposed: the read-only diagnostics probes could show restarts but not `ExitCode`/`OOMKilled`, forcing circumstantial reasoning — controller [#327](https://github.com/FreeshardBase/freeshard-controller/issues/327) tracks it; until fixed, get the inspect fields via a higher-level diagnostic or host access.
+
+**Failure mode of skipping it:** you double the customer's monthly price and the app still crashes — now with a confused diagnosis ("it can't be memory, we doubled it") and a corrupted vector index that no amount of RAM will reindex.
+
+---
+
+## Recipe 6 — Delivery-vs-execution guard analysis
+
+**When:** a guard exists (sentinel file, "already applied" flag, dedup check, idempotency marker) and correctness depends on it. The question to ask, verbatim: **what does this guard actually protect against — and what does it silently NOT protect against?**
+
+**Steps:**
+1. Name the guarded operation's two halves: *delivery* (does the work arrive where it must run?) and *execution* (does it run exactly once?). Most guards cover exactly one half.
+2. Enumerate the paths that bypass the unguarded half. For fleet mechanisms the classics are: freshly provisioned nodes (never received old deliveries) and version-skipping upgrades (intermediate deliveries never made).
+3. Prefer designs that make the guard unnecessary: idempotent reconcilers run on **every** converge beat run-once sentinels, because "did it ever run?" stops being a question.
+4. When auditing, don't check "is the sentinel present" — check "is the *effect* present" on a node that took the bypass path.
+
+**Worked example — cumulative core-host migrations (controller [#307](https://github.com/FreeshardBase/freeshard-controller/issues/307), June 2026).** Per-shard host migrations were version-scoped: `_put_core_files(version)` uploaded only that version's scripts, and the `.migrations_applied` sentinel prevented re-running. The sentinel guarded **execution**; nothing guarded **delivery**. Consequence: shards provisioned fresh at vN never ran earlier versions' migrations, and a v15→v17 upgrade silently skipped v16's — "bugs appear fixed in vN but are absent on real shards." This is precisely how the fd-exhaustion `nofile` migration turned out to have never run on a broken shard. Fix arc: deliver the cumulative union of all versions' scripts with globally-unique `vN-NN-description.sh` names and numeric ordering (PR [#308](https://github.com/FreeshardBase/freeshard-controller/pull/308)), then go further and replace run-once sentinels with idempotent reconcilers executed on every converge (PR [#323](https://github.com/FreeshardBase/freeshard-controller/pull/323)). Side-constraint that now exists: under the cumulative collector a duplicate script basename across versions fails collection — new core versions may rely on earlier reconcilers instead of copying them (see PR [#322](https://github.com/FreeshardBase/freeshard-controller/pull/322)'s notes). Same family, same repo: `systemctl reload docker` "applied" a daemon.json change that SIGHUP doesn't actually reload (log-opts, default-ulimits) — the guard-shaped step succeeded while the effect never happened; only a full `systemctl restart docker` in v17 made it real (PRs [#309](https://github.com/FreeshardBase/freeshard-controller/pull/309), [#312](https://github.com/FreeshardBase/freeshard-controller/pull/312)).
+
+**Failure mode of skipping it:** the guard gives you *confidence* exactly where you have no *coverage*. You mark the fleet "migrated" and stop looking — the un-delivered nodes fail months later with a bug you believe you already fixed.
+
+---
+
+## Recipe 7 — Cost-meter attribution (before optimizing spend)
+
+**When:** a cloud bill line is high and the instinct is "store less / compress / delete". Read the **meter breakdown** first — cloud providers bill operations, not just bytes, and ops can dominate.
+
+**Steps:**
+1. Pull the per-meter cost breakdown for the account/service — read-only `az costmanagement query` calls against the Freeshard subscription (the api-azure skill wraps these, if your session has it; otherwise use the `az` CLI directly with reader credentials). Identify the top meter by euros, not by intuition.
+2. Attribute the meter to a code path: which process issues that operation class, how many times, on what schedule? Multiply it out — ops/night × shards × 30 must reproduce the meter's magnitude.
+3. Fix the op *pattern*; leave the data alone if data wasn't the cost.
+4. **Validate the fix against the pinned tool version before shipping**, and re-read the meter after deployment to confirm the drop.
+
+**Worked example — Azure backup storage ([freeshard PR #106](https://github.com/FreeshardBase/freeshard/pull/106), June 2026).** On the shard-backup storage account, the top cost line was not stored data but the **"List and Create Container Operations" meter — roughly 3× the data-stored cost (~€15/mo), ~70% of the account's spend**. Attribution: `shard_core/service/backup.py` runs nightly `rclone sync` per shard per directory; without `--fast-list` rclone lists the destination hierarchically — one List Blobs op *per subdirectory* of a deep app-data tree (~3M ops/month fleet-wide); without `--azureblob-no-check-container` it also issued a redundant container check every invocation. Fix: add both flags; projected run-rate €41→~€26/mo. **The coda is half the lesson:** `--azureblob-no-check-container` did not exist in the rclone version pinned in the shipped image — core v18 rolled out and **all backups failed** ([#117](https://github.com/FreeshardBase/freeshard/issues/117), release blocker), fixed by dropping that flag in PR [#119](https://github.com/FreeshardBase/freeshard/pull/119) (commits d49f581, a4a80bc). As of 2026-07-03, `backup.py` on main carries `--fast-list` only. Any new rclone flag must be checked against the image's pinned rclone (`docker run --rm <image> rclone help flags | grep <flag>`), and whether the projected €26 run-rate materialized was still awaiting post-deploy meter confirmation.
+
+**Failure mode of skipping it:** you optimize the 25% (data) and ignore the 70% (ops) — or, as #117 shows, you optimize the meter and take down the backup system, which costs more than the meter ever did.
+
+---
+
+## Recipe 8 — Hypothesis-predicts-numbers (run inside every recipe above)
+
+**When:** always — before running any discriminating experiment or measurement. This is the discipline layer; freeshard-research-methodology covers the full evidence bar and idea lifecycle, this recipe is the operational core.
+
+**Steps:**
+1. State every live hypothesis.
+2. For each, **write down the number or observation it predicts** for the experiment you're about to run — before running it. Concrete values, not directions: not "the timeout will be long" but "30 s pool timeout + overhead ≈ 45 s".
+3. Run the experiment once. Compare against the pre-registered predictions. A hypothesis that predicted the number is proven against its rivals; one that "explains" the number only after seeing it proves nothing.
+4. Prefer experiments whose hypotheses predict **different** numbers (discriminating) over ones where all hypotheses predict "some failure".
+
+**Worked micro-examples from the recipes above:** [#89](https://github.com/FreeshardBase/freeshard/issues/89) — pool-exhaustion predicted failure at ~30 s + overhead and "simultaneous batch death"; observed: all uncached requests 500 together at ~45 s. Recipe 1 — "new-image ulimit" predicted `ulimit -n` = 1024 on failing shards and higher on survivors; measured exactly that (controller [#322](https://github.com/FreeshardBase/freeshard-controller/pull/322)). Recipe 5 — OOM predicted "crash stops after RAM resize", SIGABRT predicted "no change"; the resize produced no change. Contrast with the #267 double-encoding chase (Recipe 2), where a hypothesis was *fitted to* an observation post-hoc and cost two rounds of correction.
+
+**Failure mode of skipping it:** every observation confirms whatever you already believed — post-hoc, all hypotheses fit. The Content-Type investigation generated two confident wrong root causes precisely in the phase where observations were being explained rather than predicted.
+
+---
+
+## When NOT to use this skill
+
+- You have a symptom and want the fastest known triage path for it → **freeshard-debugging-playbook** (symptom→triage table, known traps with stories).
+- You want what happened in a specific past investigation — timeline, dead ends, status → **freeshard-failure-archaeology**.
+- You want the evidence bar, idea lifecycle, or how hunches become accepted results here → **freeshard-research-methodology** (this skill's Recipe 8 is its operational core, cross-referenced, not a replacement).
+- You need to run measurements/scripts against a live shard or the repo → **freeshard-diagnostics-and-tooling** (the how-to-measure toolbox; this skill is the how-to-*reason* toolbox).
+- You're classifying/gating/releasing a change → **freeshard-change-control**. Nothing in this skill authorizes skipping its gates; a proven root cause still ships through review.
+- You need theory background (crypto, signatures, forwardAuth, rclone crypt) → **freeshard-domain-reference**.
+
+## Provenance and maintenance
+
+Written 2026-07-03. Primary sources (all public): GitHub issues/PRs in FreeshardBase/{freeshard, freeshard-controller, web-terminal, app-repository} as linked inline; repo files `shard_core/web/internal/call_backend.py`, `shard_core/web/internal/auth.py`, `shard_core/database/connection.py`, `shard_core/service/backup.py`; controller files `freeshard_controller/service/pricing.py`, `data/core-versions/v18/docker-compose.yml`; commits 167d779, 1e0e7c1, 868e690, fd1d05b, d49f581, e2071cf; live `docker run … version` measurements dated inline.
+
+Drift-prone facts and how to re-verify each:
+
+| Fact (as of 2026-07-03) | Re-verify with |
+|---|---|
+| Fleet traefik pin is v2.11 (latest core version v18) | `gh api repos/FreeshardBase/freeshard-controller/contents/freeshard-controller-backend/data/core-versions --jq '.[].name'` then grep the newest vN's `docker-compose.yml` for `traefik:` |
+| traefik:v2.6 binary = go1.17.10; v2.11 = go1.25.x | `docker run --rm traefik:v2.6 version`, `docker run --rm traefik:v2.11 version` |
+| DB pool `max_size=20, timeout=10` | `grep -n 'max_size\|timeout' shard_core/database/connection.py` |
+| call_backend forwards Content-Type | `grep -n 'content-type' shard_core/web/internal/call_backend.py` |
+| backup.py: `--fast-list` present, `--azureblob-no-check-container` absent | `grep -n 'fast-list\|no-check-container' shard_core/service/backup.py` (on origin/main, not a stale local branch) |
+| Pricing formula `(base + gb*0.04)*1.5*1.19`, half-up `int(x*100+0.5)`; VM base XS 5.50 / S 11.00 / M 19.80 / L 51.00 / XL 102.00 | `gh api repos/FreeshardBase/freeshard-controller/contents/freeshard-controller-backend/freeshard_controller/service/pricing.py --jq .content \| base64 -d` |
+| Diagnostics probes still lack ExitCode/OOMKilled (gap open) | `gh issue view 327 --repo FreeshardBase/freeshard-controller --json state,title` |
+| #120 (OOM visibility) and #121 (no-interruption window) still open | `gh issue view 120 --repo FreeshardBase/freeshard --json state`; same for 121 |
+| Traefik-v3 migration still parked (stay-on-v2 decision holds) | read closing comment: `gh pr view 112 --repo FreeshardBase/freeshard --json comments --jq '.comments[].body'` |
+| Azure backup run-rate landed at ~€26/mo (was unconfirmed) | `az costmanagement query` (via the api-azure skill where available) on the shard-backup storage account, meter "List and Create Container Operations" |

--- a/.claude/skills/freeshard-research-frontier/SKILL.md
+++ b/.claude/skills/freeshard-research-frontier/SKILL.md
@@ -1,0 +1,248 @@
+---
+name: freeshard-research-frontier
+description: "Open research problems where Freeshard can advance the state of the art, led by the personal-agent-on-shard bet ('your apps are your agent's tools and memory'). Use when asked to explore, prototype, or evaluate frontier work: agent apps on shards, always_on apps, public webhook paths, apps-as-principals token scoping, invisible self-hosting UX, cold-start/PAUSED-PAGED economics (#81/#109/#26), or the self-developing-repo loop. TRIGGER on: 'agent app', 'AI on the shard', 'always_on', 'moat', 'Olares', 'Letta', 'Goose', 'personal agent', 'research direction', 'what makes Freeshard different', 'cold start', 'PAUSED tier', RFC issues #81 #109 #110 #26. SKIP when implementing the OIDC provider itself (use freeshard-oidc-identity-campaign), when doing routine issue work (freeshard-change-control), when you need auth/crypto theory (freeshard-domain-reference), or evidence/method discipline (freeshard-research-methodology)."
+---
+
+# Freeshard research frontier
+
+Open problems where this project can plausibly do something nobody else has done.
+Written 2026-07-03. **Everything in this file is open / candidate / marinating — none
+of it is roadmap.** Do not present any of it as committed work, and do not start
+building any of it without a triaged issue and (for anything novel) an approved spec —
+see freeshard-change-control. This skill exists so that frontier-flavored tasks start
+from the maintainer's actual thesis and the platform's *verified* capabilities instead
+of re-deriving them.
+
+**Terms** (defined once):
+
+| Term | Meaning |
+|---|---|
+| shard | A single-tenant customer VM running this repo's software (shard_core) + Traefik + Postgres + web-terminal, one per person |
+| shard_core | This repo: FastAPI control plane on each shard; installs/runs apps as Docker Compose projects |
+| app | A catalog entry from the app-repository sibling repo: `docker-compose.yml.template` + `app_meta.json`, installed onto a shard |
+| forwardAuth | Traefik middleware: every request to an app is first sent to shard_core `GET /internal/auth`, which allows or denies it |
+| pairing | How a browser becomes a trusted "terminal": pairing code → long-lived JWT cookie. On Freeshard, `private` means "only paired devices" |
+| controller | freeshard-controller (separate, **private** repo): central cloud management, billing, provisioning |
+| Max / max-tet | Owner, sole maintainer, only merge gate |
+| Olares, Letta, Goose | External projects discussed below as competitive context |
+
+Maturity labels used throughout: **[open]** = problem stated, no accepted approach.
+**[candidate]** = an approach exists, unproven here. **[marinating]** = deliberately
+not being built yet; strategic bet under discussion.
+
+---
+
+## Frontier 1 (LEAD): the personal agent on the shard — [marinating]
+
+**Thesis (maintainer's, per internal analysis 2026-06, discussed with co-founder):**
+a personal AI agent running *as an app on the user's own shard* is a defensible moat,
+because **your apps are your agent's tools and memory**. Paperless-ngx = document
+memory, Immich = photo/visual memory, Vaultwarden = secrets, File Browser = files —
+all already single-tenant, on hardware the user pays for, behind an identity the
+platform controls. This is deliberately **marinating**: pricing, BYO-key vs resold
+tokens, and productization are all undecided. Treat every task in this area as
+research, not feature work.
+
+### Why current state of the art fails here (competitive claims, as of 2026-07-03)
+
+| Player | What they prove | Why they don't own this |
+|---|---|---|
+| Hosted agents (ChatGPT/Claude-style assistants) | Demand for capable agents | They don't own the user's data plane; every integration is a per-service OAuth grant to a third party's cloud (assessment, unverified) |
+| Local-first agents (desktop apps, home-lab LLMs) | Demand for private AI | No always-on compute, no curated app ecosystem to act as tools/memory (assessment, unverified) |
+| Olares (beclab/Olares, AGPL-3.0, "An Open-Source Personal Cloud to Reclaim Your Data" — repo verified via `gh api repos/beclab/Olares`) | Consumer demand for sovereign personal-cloud AI exists; they ship a hardware box ("Olares One" — product details unverified this session) | Not agentic: apps are not wired up as an agent's tools (assessment as of 2026-07-03, unverified) |
+| Letta (letta-ai/letta, Apache-2.0, "Platform for stateful agents" — verified via `gh api`) | Embeddable open-source agent engine with memory | Engine without a platform: no user-owned box, no app catalog, no identity layer. Complement, not competitor — a candidate to embed |
+| Goose (block/goose → redirects to aaif-goose/goose, Apache-2.0 — verified via `gh api`) | Same: open, extensible agent engine | Same. Candidate to embed |
+
+The gap Freeshard sits in: **single-tenant always-on box + curated app catalog +
+platform-owned identity**. Nobody listed above has all three.
+
+### What the platform ALREADY supports (verified in this repo, zero core changes)
+
+An agent app can be built today as an ordinary catalog or custom app. Verified
+capabilities:
+
+| Capability | Mechanism | Verified at |
+|---|---|---|
+| Stay running (no idle-sleep) | `app_meta.json` → `lifecycle: {"always_on": true}`. Validator forbids combining with `idle_time_for_shutdown`; the periodic `control_apps` task (re)starts always_on apps if the VM size fits | `shard_core/data_model/app_meta.py:90-110`, `shard_core/service/app_lifecycle.py:59-61` |
+| Accept unauthenticated inbound (webhooks, agent API with its own token auth) | `app_meta.json` path with `"access": "public"`. Note: forwardAuth still *fires* on every request — public paths are **granted with anonymous auth state** (`X-Ptl-Client-Type: anonymous`), they don't bypass the middleware | `shard_core/data_model/app_meta.py:23-26,79-81`, `shard_core/web/internal/auth.py:88-111`; test `test_headers` in `tests/test_auth.py:45-63` asserts a `/public` path returns 200 with `X-Ptl-Client-Type: anonymous` |
+| Know who's calling | Per-path header templates inject `X-Ptl-Client-Type/-Id/-Name` (terminal / peer / anonymous) into proxied requests | `shard_core/web/internal/auth.py:102-105` |
+| Email the owner (and ONLY the owner) | App on the `portal` Docker network → `http://shard_core/internal/call_backend/api/email_relay` → shard-signed proxy → controller `POST /api/email_relay` (recipient fixed to shard's `owner_email`, per-shard hourly rate limit, default 10/h, audited). No general SMTP from shards, by design | `shard_core/web/internal/call_backend.py:24-49`; controller side `freeshard_controller/api/email_relay.py` (private repo, verified on remote main 2026-07-03) |
+| Be installed without catalog publication | `POST /core/protected/apps` accepts a custom app zip upload | `shard_core/web/protected/apps.py:107-108` (validation gaps tracked in P1 issue https://github.com/FreeshardBase/freeshard/issues/107) |
+| Be size-gated | `minimum_portal_size` vs shard VM size | `shard_core/data_model/app_meta.py:125`, `shard_core/service/app_tools.py:141-149` |
+
+**Cost model of `always_on`:** idle-sleep normally stops containers, freeing RAM;
+an always_on app's cost is *held RAM* on the smallest tiers. XS ≈ 2 GB RAM on current
+OVH flavors (unverified as of 2026-07-03 — the size→flavor mapping is a controller
+*runtime setting*, `settings.ovhcloud.vm_sizes` in the private controller repo's
+`service/cloud_adapter/ovh.py:67`, not committed config; measure, don't assume). This
+is the open pricing question (flat tier uplift vs metered) — undecided.
+
+**Security nuance worth knowing (moat-relevant):** `/internal/*` routes are not
+reachable through Traefik (only `/core/public|protected|management` and app hosts are
+routed — `shard_core/service/traefik_dynamic_config.py:45-66,168`), but any app on the
+`portal` Docker network can call `/internal/call_backend/...` and thereby act with the
+**shard's full authority** against the controller. There is no per-app identity today.
+That is exactly the hole apps-as-principals (below) is meant to close — and a reason
+the agent bet depends on the OIDC campaign.
+
+### The moat mechanism: apps as principals — [candidate], gated on OIDC campaign
+
+The embedded OIDC identity provider (see **freeshard-oidc-identity-campaign** — that
+skill owns all decisions there) would make each app a first-class OAuth client of the
+shard. Then the agent app gets **scoped tokens per app**: a token that can read
+Paperless documents but *cannot* touch Immich or Vaultwarden. The PoC already contains
+the hook: the spike's `OidcClient` model carries a per-client `scope` string and
+`get_allowed_scope()` filtering (`.worktrees/spike-oidc-poc/shard_core/service/oidc_provider.py:55-89`,
+branch `spike/oidc-provider-poc`, local worktree only, **not pushed to origin** as of
+2026-07-03). Nothing about agent-facing scoping is designed yet — do not invent scope
+taxonomy ahead of that campaign's decision gates.
+
+Adjacent idea parked with it **[open]**: shard as MCP client / AI-discovery-via-DNS
+(co-founder suggestion, 2026-06) — recorded, unexplored.
+
+### First three concrete steps IN THIS REPO (feasibility verified)
+
+1. **Prototype an agent app using the existing mock-app test pattern.** The test
+   fixture `mock_app_store(mocker)` (`tests/conftest.py:374-395`) installs apps from
+   `tests/mock_app_store/<name>/<name>.zip`; a mock app with `always_on: true` **and a
+   public path already exists** (`tests/mock_app_store/always_on/app_meta.json`) and is
+   exercised by `tests/test_app_lifecycle.py:80` (`test_always_on_app_starts`). Copy
+   that shape: always_on lifecycle + one `public` webhook path + one `private` UI path,
+   containers doing their own bearer-token check on the public path. Sanity check:
+   `.venv/bin/python -m pytest tests/test_app_lifecycle.py tests/test_auth.py --collect-only -q`
+   (5 tests collected as of 2026-07-03). Follow freeshard-testing-and-qa for fixture rules.
+2. **Define apps-as-principals token scoping on top of the OIDC client model** —
+   a written design mapping app → OIDC client → allowed scopes, building on
+   `OidcClient.scope` / `get_allowed_scope()` in the spike. This is a spec task
+   (a Max-approved spec posted on the issue — the freeshard-intent-capture skill
+   automates that flow where available), not a coding task, and must not front-run
+   freeshard-oidc-identity-campaign's gates.
+3. **Measure the always-on RAM envelope on the smallest tiers** to inform pricing.
+   Baseline the stack, then add an always_on app and diff:
+   `docker stats --no-stream --format '{{.Name}}\t{{.MemUsage}}'` on a dev compose
+   stack (see freeshard-run-and-operate) or, for a real customer-shaped number, an XS
+   shard via the diagnostics API (read-only, operator-activated).
+   Deliverable: MB held per app state (stopped /
+   idle-running / active), headroom left on XS/S. Use freeshard-diagnostics-and-tooling
+   for measurement discipline.
+
+### Falsifiable milestone
+
+You have a **result** (not before) when: *an agent app installed on a dev stack
+answers a natural-language question whose answer requires Paperless-ngx content, using
+a scoped token — and the same token, presented to Immich, is refused.* Weaker interim
+demo (phase-0, no OIDC dependency): same question answered using Paperless's own API
+token held by the agent app — proves tools/memory value, proves nothing about the moat.
+If the scoped-token demo can't be made to work on top of the OIDC campaign's client
+model, the moat mechanism as currently imagined is falsified and the thesis needs
+rework — say so plainly rather than shipping a demo with an unscoped token.
+
+---
+
+## Frontier 2: invisible self-hosting UX — [candidate]
+
+Thesis: self-hosting wins when it disappears — "one identity, one access" as *the*
+sovereignty feature. Freeshard's angle vs prior art (Sandstorm, Cloudron, Umbrel —
+**comparative claims unverified**, treat as hypotheses to check before repeating):
+**pairing is the auth boundary**. `private` = "only my paired devices", which is a
+*stronger* gate than app-level login, so apps with built-in auth can default to
+`access: private` + open registration, and login can be removed rather than added.
+Real flagship metas confirm the pattern (verified in app-repository sibling):
+paperless-ngx root `private` with `/share/` public; vaultwarden root `public` (does
+its own auth) with `/admin/` private; immich root `public`.
+
+The zero-click endgame is the OIDC campaign's seamless-SSO PoC (Immich login with no
+click, spike branch above). Open sub-problems: which flagship apps can honor
+OIDC-claims-based auto-provisioning (upstream PR dependency for Paperless — status
+unknown as of 2026-07-03); expectation management for non-flagship apps (two-tier
+store, RFC https://github.com/FreeshardBase/freeshard/issues/110, open, needs-Intent).
+
+## Frontier 3: cold-start economics — [open]
+
+The counterweight to `always_on`: idle apps hold nothing, but cold starts hurt UX, and
+always-on holds RAM that XS/S tiers don't have. Live threads, all open as of
+2026-07-03, all P3/needs-Intent (i.e. spec before code):
+
+| Issue | Idea |
+|---|---|
+| https://github.com/FreeshardBase/freeshard/issues/81 | PAUSED+PAGED app tier (tracker) — states between RUNNING and STOPPED |
+| https://github.com/FreeshardBase/freeshard/issues/109 | RFC: SQLite-first apps, container tuning, host-level zswap |
+| https://github.com/FreeshardBase/freeshard/issues/26 | Manage shard resources using slices (open since 2026-01) |
+
+Candidate mechanism under #81: `docker pause` + swapping frozen pages out (cost of a
+paused app → disk instead of RAM). **Cautionary prior:** an earlier swap-tuning
+experiment on another provider (Netcup) thrashed a server into an unrecoverable state.
+Any experiment here goes on a disposable OVH instance, never a customer shard, with a
+measured hypothesis first (freeshard-research-methodology). Related shipped groundwork:
+idle-sleep already exists (`shard_core/service/app_lifecycle.py`), and its known UX
+traps (PWA service workers lying to the splash screen, apps that 200 before ready) are
+chronicled in freeshard-failure-archaeology.
+
+## Frontier 4: the self-developing repo — [candidate, partially live]
+
+The development process itself is a research object: triage (board grooming) →
+overnight grind (one fresh headless agent session per issue, own worktree, branch from
+main) → human review as the only ship gate. It demonstrably ships real fixes end-to-end
+(e.g. https://github.com/FreeshardBase/freeshard/pull/106 and
+https://github.com/FreeshardBase/freeshard/pull/119 — authored by ClaydeCode, merged;
+verified via `gh pr view`). Mechanics and non-negotiables live in
+freeshard-change-control — this skill only states the frontier question:
+
+**Milestone:** identify an *issue class* (e.g. dependency refreshes, doc-drift fixes,
+test-gap fills) that ships end-to-end with **review-only** human time — no triage
+back-and-forth, no intent capture, no mid-flight correction — sustained over multiple
+instances. Until a class clears that bar repeatedly, claims of "self-developing" are
+oversell; the honest current state is "agent-developed, human-gated."
+
+---
+
+## Rules of engagement for frontier work
+
+1. **Nothing here bypasses change control.** Frontier prototypes live in worktrees /
+   spike branches, never merge without Max, and RFC-class ideas need a spec (Needs
+   Intent flow) first. freeshard-change-control wins every conflict with this file.
+2. **Label maturity in everything you write.** open / candidate / marinating, as
+   above. The agent bet especially: it is a *bet under discussion*, not a plan.
+3. **Competitor and market claims decay fast.** Anything about Olares/Letta/Goose or
+   hosted-agent capabilities must be re-verified (or re-labeled unverified) before it
+   leaves this repo — see freeshard-docs-and-positioning for external-claims discipline.
+4. **Hypotheses must predict numbers before you measure** (RAM envelopes, cold-start
+   latencies) — freeshard-research-methodology has the evidence bar.
+5. **Don't burn customer shards.** Experiments run on dev stacks or disposable OVH
+   instances; customer-shard inspection only through the read-only diagnostics flow.
+
+## When NOT to use this skill
+
+- Implementing or deciding anything about the OIDC provider → **freeshard-oidc-identity-campaign** (this file only consumes its outputs).
+- Ordinary assigned-issue work, PRs, releases → **freeshard-change-control**.
+- How pairing/JWT/signatures/forwardAuth actually work → **freeshard-domain-reference**.
+- Running the stack or a dev server to try something → **freeshard-run-and-operate**.
+- Writing the tests for a prototype → **freeshard-testing-and-qa**.
+- Turning a hunch into an accepted result (method, evidence bar) → **freeshard-research-methodology**; analysis recipes → **freeshard-proof-and-analysis-toolkit**.
+- History of why past ideas died → **freeshard-failure-archaeology**.
+- Cross-repo contracts (controller relay, app-repository metas) mechanics → **freeshard-ecosystem-contracts**.
+
+## Provenance and maintenance
+
+Written 2026-07-03 against shard_core working tree (branch `fix-profile-billing-fields`,
+v0.39.2 checkout; origin/main head `0a40684`). Primary public sources: this repo's
+source and tests at the cited file:line locations; app-repository sibling checkout;
+GitHub issues/PRs cited by URL; `gh api` reads of beclab/Olares, letta-ai/letta,
+block/goose. The maintainer-thesis and pricing/marinating status statements come from
+internal project analysis (2026-06) and are dated accordingly.
+
+Drift-prone facts — re-verify before relying:
+
+| Fact (as of 2026-07-03) | Re-verify with |
+|---|---|
+| `always_on` / `idle_time_for_shutdown` validator semantics | `grep -n "always_on" shard_core/data_model/app_meta.py shard_core/service/app_lifecycle.py` |
+| Public paths get anonymous grant (forwardAuth fires, doesn't 401) | `sed -n '74,112p' shard_core/web/internal/auth.py` |
+| Mock always_on app + its test exist | `ls tests/mock_app_store/always_on/ && grep -n always_on tests/test_app_lifecycle.py` |
+| Custom-app zip upload endpoint exists | `grep -n "install_custom_app" shard_core/web/protected/apps.py` |
+| `call_backend` proxy signs with full shard authority, no per-app auth | `sed -n '24,50p' shard_core/web/internal/call_backend.py` |
+| Controller email relay exists on main (private repo) | `gh api "repos/FreeshardBase/freeshard-controller/contents/freeshard-controller-backend/freeshard_controller/api/email_relay.py?ref=main" --jq .name` |
+| OIDC spike branch state (local-only worktree) | `git branch -a \| grep -i oidc; git ls-remote origin \| grep -i oidc` |
+| Issues #26/#81/#109/#110 still open | `for n in 26 81 109 110; do gh issue view $n --repo FreeshardBase/freeshard --json state,title --jq '"\(.state) \(.title)"'; done` |
+| ClaydeCode-authored merged PRs (#106/#119) | `gh pr view 106 --repo FreeshardBase/freeshard --json author,state` |
+| Olares/Letta/Goose license + description | `gh api repos/beclab/Olares --jq '{license: .license.spdx_id, desc: .description}'` (likewise letta-ai/letta, block/goose) |
+| Flagship app path/lifecycle patterns | `python3 -c "import json; m=json.load(open('../app-repository/apps/paperless-ngx/app_meta.json')); print(m['paths'], m['lifecycle'])"` |

--- a/.claude/skills/freeshard-research-methodology/SKILL.md
+++ b/.claude/skills/freeshard-research-methodology/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: freeshard-research-methodology
+description: The discipline that turns a hunch into an accepted result in the Freeshard project — evidence bar, idea lifecycle, documented retirement, where good ideas come from, and which artifact to write when. TRIGGER on "how do I propose X", "should I spike this", "is this hypothesis proven", "why did they reject/close/abandon Y", "where do ideas get decided", writing a root-cause analysis, closing an investigation, deciding between spike branch vs issue vs PR, or handling a vague issue. SKIP when you need the mechanics of the change pipeline (gates, review, release — use freeshard-change-control), the chronicle of a specific past investigation (use freeshard-failure-archaeology), or concrete measurement recipes (use freeshard-proof-and-analysis-toolkit).
+---
+
+# Freeshard Research Methodology
+
+How a hunch becomes an accepted result in this project — and how ideas die with a paper trail instead of silently. This is process discipline, not code knowledge.
+
+**Terms** (used throughout, defined once):
+- **shard** — a customer VM running `shard_core` (this repo: FastAPI + PostgreSQL + Docker Compose orchestration behind Traefik).
+- **controller** — the central management service (repo `FreeshardBase/freeshard-controller`).
+- **Max / max-tet** — owner and sole maintainer. His review+merge is the only acceptance gate. Nothing auto-merges.
+- **ClaydeCode** — the AI agent GitHub account that does much of the development.
+- **grind** — the overnight loop: one fresh headless agent session per GitHub issue, own git worktree, branch from main, ends in a PR for Max.
+- **Dev Board** — org GitHub Project 3 (`gh project item-list 3 --owner FreeshardBase`), the real triage system. Fields: `priority` (P0–P3), `stage` (Backlog/Refined/Done), `needs Intent` (yes/null). Labels are NOT the triage system.
+- **Needs Intent** — Dev Board flag meaning "issue too vague to implement; requires a spec from Max before anyone works it."
+
+## 1. The evidence bar
+
+Two rules separate an accepted root cause or fix from a plausible story. Both are enforced here because plausible-but-wrong analyses have burned the project before.
+
+### Rule 1: one mechanism must explain ALL observations — including the negatives
+
+If your explanation covers why broken things broke but not why unbroken things survived, it is not done. The negative observations are the strongest test.
+
+**Worked example — the fd-exhaustion outage (June 2026):** new shards went silently unreachable; Traefik logged `accept4: too many open files` in a hot loop. The socket leak (readTimeout=0 on an internet-scanned IP) existed on *every* shard, old and new — so why did only new shards die? The lazy answer "old shards are fine by luck" was explicitly assigned as a hypothesis so it could be refuted, and it was killed by measurement: `docker exec traefik sh -c 'ulimit -n'` showed old shards had a much higher fd ceiling. The accepted root cause had to be **two-factor**: Traefik pinned at v2.6 (built with a pre-1.19 Go — measured go1.17.10, see freeshard-proof-and-analysis-toolkit Recipe 1 — which does not self-raise RLIMIT_NOFILE; Go 1.19+ does) × new shards on a newer Ubuntu base image whose Docker per-container nofile soft limit was 1024. One mechanism, explains the broken shards *and* the survivors. Public artifacts: fix PR https://github.com/FreeshardBase/freeshard/pull/108 (finite readTimeout), decision record in closed PR https://github.com/FreeshardBase/freeshard/pull/112.
+
+Checklist before you claim a root cause:
+- [ ] List every observation, then mark each ✓ explained / ✗ unexplained by your mechanism. Zero ✗ allowed.
+- [ ] Include the negatives: systems that *should* have failed under your mechanism but didn't (or vice versa).
+- [ ] If you're tempted to write "coincidence" or "luck" for any observation, promote that to a named hypothesis and design a measurement to kill it.
+- [ ] Distinguish look-alike failure modes before acting — e.g. the Immich thumbnail problem had three distinct causes over two incidents (index corruption, extension-version drift, upstream regression); conflating them wastes a recovery.
+
+### Rule 2: a fix hypothesis must predict numbers before the experiment runs
+
+State the expected measurement *first*, then run it. If you can't say what number you expect, you don't have a hypothesis yet — you have a hope.
+
+**Worked example A (fd-exhaustion fix):** prediction — a Traefik v2.11 container (Go 1.25) will show `ulimit -n` self-raised to the hard limit (order 64k, per the investigation records), while v2.6 (pre-1.19 Go) stays at the 1024 soft limit. The Go version per Traefik tag was checked in the tag's `go.mod` before the upgrade was chosen. The measurement matched; the upgrade shipped as v2.11, and the "obvious" v3 migration was avoided (see §5).
+
+**Worked example B (pricing rounding):** Python `round()` is banker's rounding, JS `Math.round()` is half-up — under the new VAT-bearing formula they diverged by 1 cent on half-cent results, so the UI label could disagree with the PayPal charge. The fix (half-up `int(x*100 + 0.5)` in the backend) came with a prediction: **zero divergences across the entire size×disk pricing matrix**, and expected test values recomputed from the real function rather than hand-derived. Public artifact: https://github.com/FreeshardBase/freeshard-controller/pull/298 (merged 2026-06-09).
+
+Corollary: pinned test values are recomputed from the canonical implementation, never invented — a hand-derived expected value just encodes your possibly-wrong mental model twice.
+
+## 2. The idea lifecycle
+
+Every idea in this project moves through the same pipeline. Skipping a stage is how work gets orphaned (see PR #86 in §4).
+
+| Stage | Artifact | Rule | Real example |
+|---|---|---|---|
+| 1. Hunch | nothing, or an issue comment | Cheap to hold, cheap to drop | "personal agent as a native shard app" — deliberately marinating, no code |
+| 2. Spike (optional) | `spike/*` branch | Spikes are UNMERGED reference material; production impl starts on a fresh branch | `spike/oidc-provider-poc` (4 commits, local worktree only, not on origin, as of 2026-07-03) |
+| 3. Decision | issue comment, PR comment, or maintainer sync | May use the solution-neutral-brief method (below); decision gets written down where the next person will look | Embedded OIDC over Authelia, 2026-06-12 |
+| 4. Issue + intent | GitHub issue; Dev Board card | Vague issues get the `needs Intent` flag and are SKIPPED by implementers, never guessed at | #26, #81, #109, #110, #115 all flagged as of 2026-07-03 |
+| 5. Implementation | grind worktree, branch from main | One fresh agent session per issue | most of recent history |
+| 6. PR | pull request | Narrative description; reviewer = max-tet | — |
+| 7. Acceptance | Max's review + merge | The ONLY acceptance. See freeshard-change-control | — |
+| 8. Release | version bump + tag + GitHub Release | Merged ≠ shipped (issue #111 is the cautionary tale). See freeshard-change-control | — |
+
+### The solution-neutral-brief method (stage 3)
+
+When a design decision is contested or suspiciously comfortable, validate it by independent re-derivation:
+
+1. Write a requirements brief with **zero solution hints** — constraints only (for the identity decision: restart-free config, footprint on a 1 GB VM, passwordless onboarding, no-email constraint). No product names, no architecture sketch.
+2. Hand it to a **fresh agent session** with no context of the debate.
+3. Compare what it independently derives against your candidate.
+
+This is how the identity decision was made (2026-06-12): after weeks of Authelia spec churn (issue https://github.com/FreeshardBase/freeshard/issues/36, PR https://github.com/FreeshardBase/freeshard/pull/86), a fresh session given only the requirements re-derived Authelia as a candidate but recommended an **embedded OIDC provider inside shard_core** (Authlib). A same-day PoC (~740 LoC, 13 integration tests, zero-click Immich login) landed on `spike/oidc-provider-poc`. The counter-risks (crypto unknown-unknowns in a self-built IdP, AI-scannable public repo) were recorded, not ignored. Full campaign state: see freeshard-oidc-identity-campaign.
+
+If the fresh session derives something different from your candidate, that is signal, not noise — investigate before overriding.
+
+### Intent capture in practice (stage 4)
+
+The issue thread IS the spec medium. Pattern visible in issue #36: agent posts a preliminary plan with explicit open questions → Max answers in a comment → agent posts "Plan updated" naming what changed → repeat until no open questions → implement. If an issue is too vague even to draft questions, it gets `needs Intent` on the Dev Board and nobody touches it. Check the flag before starting any issue:
+
+```bash
+gh project item-list 3 --owner FreeshardBase --format json --limit 200 \
+  | jq -r '.items[] | select(.content.number==<N> and (.content.url // "" | startswith("https://github.com/FreeshardBase/freeshard/"))) | .["needs Intent"]'
+```
+
+(The URL prefix check matters — substring matching leaks controller-repo items with the same numbers.)
+
+## 3. Retirement is documented, not silent
+
+Dead ideas get a tombstone that states the reason and, where one exists, the successor direction. Three established patterns:
+
+| Pattern | Where | Example |
+|---|---|---|
+| Block record file | `blocked_apps/<name>.md` in `FreeshardBase/app-repository` | `blocked_apps/fizzy.md`: block date, exit code, reason (source-available O'Saasy license fails the FOSS gate), plus research notes so a recheck doesn't restart from zero |
+| Decision comment on the closed PR | the PR thread | https://github.com/FreeshardBase/freeshard/pull/112 closed with: staying on Traefik v2 (v2.11 = Go 1.25 self-raises nofile = the actual root cause), v3 migration folded into a needs-Intent backlog ticket |
+| Bulk-close with reasons | issue closing comments | 2026-06-29 backlog cleanup closed #18, #25, #33, #36, #37, #71, #72, #111 within minutes, each with a comment stating why (e.g. #36: "per-shard single-tenant isolation rather than multi-instance YAML-backend sharding") |
+
+Rules when YOU retire something:
+- Never close silently. One comment: why now, and what (if anything) supersedes it.
+- Never delete the evidence. Abandoned branches stay: `feature/sqlite` (the abandoned SQLite route) and `copilot/migrate-database-to-postgres` + `issue/25-replace-tinydb-with-postgres` (the two failed TinyDB→PostgreSQL attempts, PRs #29 and #34) still document the dead ends that made merged PR #56 possible.
+- Check for orphans your retirement creates. Counter-example to avoid: PR https://github.com/FreeshardBase/freeshard/pull/86 (Authelia core IAM) was still open when its driving issue #36 was closed and the embedded-OIDC decision superseded it — as of 2026-07-03 it dangles with no decision comment. Don't reproduce that state; close or annotate dependent PRs when the direction dies.
+- A settled investigation MUST land in freeshard-failure-archaeology (see §6).
+
+## 4. Where good ideas historically came from
+
+Know the sources; watch them deliberately.
+
+| Source | Mechanism | Evidence |
+|---|---|---|
+| Production incidents | Incident → runbook → generalizing feature/issue | The agentic shard-diagnostics feature (controller PR https://github.com/FreeshardBase/freeshard-controller/pull/303, merged 2026-06-16) grew out of real customer-shard troubleshooting and then proved itself root-causing the fd-exhaustion and Immich incidents. The July 2026 Immich incident directly spawned issues https://github.com/FreeshardBase/freeshard/issues/120 (make OOM kills visible) and https://github.com/FreeshardBase/freeshard/issues/121 (no-interruption window for migrations) |
+| Weekly maintainer syncs | Max + collaborator (Aaron) discuss; decisions and open questions get minuted; issues filed after | The semver-for-shard-core decision → https://github.com/FreeshardBase/freeshard/issues/118; the flagship-apps curation strategy → https://github.com/FreeshardBase/freeshard/issues/110 |
+| Adversarial review of first designs | Build v1, attack it next day, keep only what survives | The first agentic dev-loop (in-container agent, derived-phase state machine, review-packet pipeline) was retired the DAY after it went live as overbuilt; the surviving design is "dumb loop, smart per-issue agent" — dispatcher has no intelligence, GitHub is the only state store |
+| Solution-neutral re-derivation | §2, stage 3 | The embedded-OIDC decision |
+| Upstream/ecosystem watching | Track competitor products, upstream releases, license changes | Recheck procedures in `blocked_apps/`; the personal-agent product analysis names specific ecosystem projects as build-vs-embed candidates |
+
+## 5. Anti-patterns — each one has a story
+
+| Anti-pattern | The story | The rule |
+|---|---|---|
+| Shipping the obvious-but-risky fix | The "obvious" fd-exhaustion fix was migrating Traefik v2→v3 (new major, new rule syntax, unknown blast radius). Investigation showed the root cause was the *Go toolchain version* of the pinned build, so v2.11 (Go 1.25) fixed it with near-zero migration risk. v3 prep work was dropped (PR #112) | Ask: what is the *minimal* change that addresses the verified mechanism? Bigger migrations need their own justification, not a bug to hide behind |
+| Guessing at vague issues | The whole `needs Intent` machinery exists because a guessed implementation wastes a full agent session and a review slot, and anchors later discussion to the wrong design | If intent is unclear: flag, skip, move on. Never "probably they meant..." |
+| Trusting a mocked test where the real system differs | The grind loop's unit tests were green; its first *supervised real run* immediately surfaced infra bugs the mocks had hidden (expired auth token, git push auth, GitHub combined-status API returning `total_count=0` on Actions-only repos) | Mocks prove your code matches your model of the boundary, not the boundary. First run of any new automation is supervised. See freeshard-testing-and-qa for what counts as evidence |
+| Building elaborate orchestration before proving the dumb version fails | The v1 dev-loop had a state machine, in-container execution, and a planned review-packet pipeline. The dumb replacement (flat loop, fresh session per issue, GitHub as state) shipped the next day and is what actually runs | Build the dumb version first. Add machinery only when the dumb version demonstrably fails, and keep the failure evidence |
+| Letting a disagreement stall silently | PR https://github.com/FreeshardBase/freeshard/pull/92: maintainer requested a simpler approach; agent replied with a technical constraint (Traefik's errors middleware discards the upstream body); no movement since 2026-05-27 | When review reaches an architectural impasse, both positions belong in the thread (they are, here) — then the item needs an explicit decision or a `needs Intent`-style flag, not more commits and not silence |
+
+## 6. Which artifact do I write?
+
+| Situation | Artifact | Not |
+|---|---|---|
+| Exploring feasibility, code is throwaway | `spike/<slug>` branch; never merged; production work restarts on a fresh branch | a PR |
+| Root-cause found, fix known | Issue (symptom, mechanism, evidence incl. negatives) → PR referencing it | a PR with the analysis buried in commit messages |
+| Root-cause found, fix deferred/rejected | Issue comment or closing comment stating mechanism + why deferred | silence |
+| Design decision made | Comment on the driving issue/PR; if it retires other work, decision comments there too | only a private note |
+| Recurring operational knowledge (how to recover X) | Runbook / docs change — see freeshard-docs-and-positioning | re-deriving it next incident |
+| Investigation settled (root cause accepted, fix shipped or consciously rejected) | **Mandatory**: entry in freeshard-failure-archaeology (symptom → root cause → evidence → status), plus a symptom row in freeshard-debugging-playbook if it can recur | leaving it only in a PR thread |
+| Process/methodology lesson | Update to the relevant skill in `.claude/skills/` | a one-off comment nobody will find |
+
+## 7. When NOT to use this skill
+
+- You need the **change pipeline mechanics** — classification, gates, review expectations, release procedure, merged-vs-shipped: use **freeshard-change-control**.
+- You're **debugging a live symptom** and want the known-failure-mode triage table: use **freeshard-debugging-playbook**.
+- You want the **full chronicle of a past investigation** (fd-exhaustion, Immich, Content-Type 422s, ...): use **freeshard-failure-archaeology**.
+- You need a **measurement recipe** (how to actually get the numbers Rule 2 demands): use **freeshard-proof-and-analysis-toolkit** and **freeshard-diagnostics-and-tooling**.
+- You're working the **OIDC identity effort** specifically: use **freeshard-oidc-identity-campaign**.
+- You're looking for **open research problems** rather than the discipline for settling them: use **freeshard-research-frontier**.
+
+## Provenance and maintenance
+
+Written 2026-07-03. Primary public sources: this repo's git history and branch set; GitHub issues/PRs cited inline (freeshard #36, #86, #89–#94, #106, #108, #111, #112, #117–#121, #24/#88, #29/#34/#56, #92; controller #298, #303); `FreeshardBase/app-repository` `blocked_apps/`; the FreeshardBase Dev Board (org project 3). Some narrative details (the solution-neutral-brief walkthrough, grind-loop first-run bugs, weekly-sync origins) come from maintainer records without a public artifact; they are stated as history, not cited.
+
+Drift-prone facts — re-verify before relying on them:
+
+| Fact (as of 2026-07-03) | Re-verify with |
+|---|---|
+| `spike/oidc-provider-poc` is local-only, unmerged; production OIDC impl not started | `git branch -a \| grep -i oidc && git log --oneline spike/oidc-provider-poc \| head -5` |
+| PR #86 (Authelia) still open/orphaned | `gh pr view 86 --repo FreeshardBase/freeshard --json state` |
+| PR #92 still stalled at CHANGES_REQUESTED | `gh pr view 92 --repo FreeshardBase/freeshard --json state,reviewDecision` |
+| Dev Board = project 3; fields `priority`, `stage`, `needs Intent` | `gh project item-list 3 --owner FreeshardBase --format json --limit 5 \| jq '.items[0] \| keys'` |
+| Needs-Intent-flagged issue set (#26, #81, #109, #110, #115, ...) | the §2 stage-4 jq query, per issue |
+| `blocked_apps/` pattern exists with fizzy.md | `gh api repos/FreeshardBase/app-repository/contents/blocked_apps --jq '.[].name'` |
+| Traefik-stays-on-v2 decision unrevisited | `gh pr view 112 --repo FreeshardBase/freeshard --json comments --jq '.comments[].body'` and search issues for "traefik v3" |
+| Semver migration (#118) still open/unspecified | `gh issue view 118 --repo FreeshardBase/freeshard --json state` |
+| Abandoned DB-migration branches still present as reference | `git branch -r \| grep -E 'sqlite\|postgres'` |
+| Bulk-close comments intact on #36 etc. | `gh issue view 36 --repo FreeshardBase/freeshard --json comments --jq '.comments[-1]'` (NOT `--comments`, which errors on this org) |

--- a/.claude/skills/freeshard-run-and-operate/SKILL.md
+++ b/.claude/skills/freeshard-run-and-operate/SKILL.md
@@ -1,0 +1,246 @@
+---
+name: freeshard-run-and-operate
+description: "Running, deploying, and operating shard_core. Use when you need to start the app (dev server or full docker compose stack), pair a first device, find where data lands on disk (FREESHARD_DIR/core, user_data, postgres_data), run or restore a backup, cut a release, or understand hosted-vs-self-hosted behavior. TRIGGER on: 'just run-dev', 'docker compose up', .env / .env.template, pairing code, welcome log, FREESHARD_DIR, rclone / backup / restore / download_backup.sh, 'just set-version', release checklist, ghcr.io image tags, 'is this fix deployed?', self-hosting, Let's Encrypt / DISABLE_SSL. SKIP when: editing config values or env-override mechanics (use freeshard-config-and-flags), setting up the Python dev environment / uv / worktrees (use freeshard-build-and-env), writing or running tests (use freeshard-testing-and-qa), diagnosing a live failure (use freeshard-debugging-playbook), or changing CI workflows themselves (use freeshard-change-control)."
+---
+
+# Freeshard: Run and Operate
+
+Terms used throughout (defined once):
+
+- **shard** — one customer's personal cloud VM. Runs the 4-service Docker Compose stack in this repo.
+- **shard_core** — this repo's FastAPI app. Orchestrates apps (Docker Compose per app), writes Traefik config, talks to the controller.
+- **terminal** — a paired user device (browser). Pairing is the auth boundary.
+- **controller** — freeshard-controller, the central cloud service at `https://controller.freeshard.net` (separate repo). Provisions hosted shards, issues backup SAS URLs, holds billing.
+- **hosted shard** — a shard the controller knows about (Freeshard's fleet, on OVH). **self-hosted** — same image and compose file, but the controller returns 401 for it.
+- **FREESHARD_DIR** — host directory holding all shard state (set in `.env`).
+
+## 1. Two ways to run it
+
+| Mode | Command | Port | Data root | Apps startable? | Auth in front? |
+|---|---|---|---|---|---|
+| Dev server (bare FastAPI) | `just run-dev` | 8080 | `run/` in repo | **No** (no Traefik) | **No** — all routes open |
+| Full local stack | `docker compose up` | 80/443/8883 | `$FREESHARD_DIR` | Yes | Yes (Traefik forwardAuth) |
+
+## 2. Dev server: `just run-dev`
+
+What it does (justfile:47-48): `fastapi dev --port 8080 shard_core/app.py` with `local_config.toml` overlaying `config.toml` (that overlay is automatic whenever `local_config.toml` exists in CWD — run from repo root). Dev overrides: `path_root = "run/"`, `dns.zone = "localhost"`, debug logging (local_config.toml).
+
+Prerequisites:
+
+1. Python env synced (`uv sync` — see freeshard-build-and-env).
+2. A reachable PostgreSQL. `[db]` defaults are host `postgres`, port 5432, db/user/password all `shard_core` (config.toml) — that hostname only resolves inside the compose network, so for bare dev supply your own and override the host:
+
+```bash
+docker run -d --name shard-dev-postgres \
+  -e POSTGRES_DB=shard_core -e POSTGRES_USER=shard_core -e POSTGRES_PASSWORD=shard_core \
+  -p 5432:5432 postgres:17
+FREESHARD_DB__HOST=localhost just run-dev
+```
+
+(The repo documents no canonical dev-postgres recipe; the above follows from the `[db]` settings. Note the double underscore in `FREESHARD_DB__HOST` — single underscores are silently ignored; see freeshard-config-and-flags.)
+
+Then: API docs at http://localhost:8080/docs (README.md:170). State lands in `run/` (gitignored): `run/core/`, `run/user_data/`.
+
+Dev-server limits — know these before "testing" anything:
+
+- **Apps cannot start.** They rely on being reached through Traefik; without the reverse proxy, app install works but app HTTP access does not (README.md:174-176).
+- **No auth.** Traefik forwardAuth is the only auth layer in this system; the FastAPI routes themselves carry none. On :8080, `/protected/*` and `/management/*` are open to anyone who can reach the port.
+- **It calls the production controller at startup.** `refresh_profile()` does a signed GET to `https://controller.freeshard.net/api/shards/self`; the 401/connection error is caught and logged (app_factory.py:89-92), so boot proceeds with profile = None.
+
+### Second instance for controller development
+
+`just run-dev-for-freeshard-controller` (justfile:50-51) starts a second shard_core on port 8081, intended to point at a locally running controller on port 8080. **As of 2026-07-03 the recipe is broken**: it sets `FREESHARD_FREESHARD_CONTROLLER_BASE_URL` (single underscore before `BASE_URL`), which pydantic-settings silently ignores — the instance actually talks to the production controller. The working form is `FREESHARD_FREESHARD_CONTROLLER__BASE_URL`. Details and the verification one-liner: freeshard-config-and-flags.
+
+Also note: the `CONFIG=config.yml,local_config.yml` env var in both run-dev recipes is dead — no code reads it (freeshard-config-and-flags).
+
+## 3. Full local stack: `docker compose up`
+
+```bash
+cp .env.template .env
+# edit .env:
+#   FREESHARD_DIR=/absolute/path/for/shard/data
+#   DNS_ZONE=localhost          # or your real domain for a server deployment
+#   EMAIL=you@example.com       # Let's Encrypt account email
+#   DISABLE_SSL=true            # local testing ONLY; false in production
+docker compose up
+```
+
+.env variables map to `FREESHARD_*` env vars inside the shard_core container (docker-compose.yml:63-67). `FREESHARD_DIR`, `DNS_ZONE`, `EMAIL` are fail-fast (`${VAR:?}`); `DISABLE_SSL` is not — **leaving it out of `.env` makes Settings() crash on an empty-string boolean** (see freeshard-config-and-flags).
+
+The stack (docker-compose.yml, all on one docker network named `portal`):
+
+| Service | Image (origin/main as of 2026-07-03) | Role |
+|---|---|---|
+| postgres | postgres:17 | DB; data bind-mounted at `${FREESHARD_DIR}/postgres_data` |
+| shard_core | ghcr.io/freeshardbase/freeshard:0.39.4 | this repo; waits for postgres healthy |
+| traefik | traefik:v3.6 | reverse proxy, ports 80/443/8883; waits for shard_core **healthy** (shard_core writes traefik's static config before it starts) |
+| web-terminal | ghcr.io/freeshardbase/web-terminal:0.37.4 | Vue UI |
+
+### First contact: the welcome log and pairing
+
+On every startup shard_core prints an ASCII logo block to its stdout with the shard URL; **on first start only** (terminals table empty) it also contains a pairing link valid for 10 minutes (app_factory.py:160-181):
+
+```bash
+docker compose logs shard_core | grep -A5 -B25 "pair?code"
+# → https://<6-char-id>.<DNS_ZONE>/#/pair?code=XXXXXX
+```
+
+Missed the window? Get a fresh pairing code any time from inside the docker network (README.md:125):
+
+```bash
+docker run --rm -it --network portal curlimages/curl "http://shard_core/protected/terminals/pairing-code"
+```
+
+This works because auth is enforced only by Traefik forwardAuth — requests inside the `portal` network hit shard_core's port 80 directly and bypass all auth **by design**. Never publish shard_core's port to the host. (Route: GET `/protected/terminals/pairing-code`, web/protected/terminals.py:68; default validity 600 s.)
+
+### Self-hosting with real SSL (server deployment)
+
+Wildcard certs require a Let's Encrypt **DNS challenge**. Two changes, and the README only documents the first (README.md:138-154):
+
+1. Add your DNS provider's env vars to the **traefik** service in docker-compose.yml (the commented-out `AZURE_*` block at lines 38-42 is the template).
+2. The ACME `provider` is **hardcoded to `azure`** in the traefik static-config template `data/traefik.yml:40` (in-image). shard_core re-renders `${FREESHARD_DIR}/core/traefik.yml` from that template **on every startup** (app_factory.py:140-157), so editing the rendered file does not stick — for a non-Azure DNS provider you must change `data/traefik.yml` and rebuild the image (or bind-mount a patched copy over `/app/data/traefik.yml`). (Bind-mount approach unverified as of 2026-07-03.)
+
+## 4. What lands where on disk
+
+Everything below `FREESHARD_DIR` on the host; the same tree is `/` inside the container (`path_root`). Rule: `path_root` for anything shard_core reads/writes itself; `path_root_host` only for volume paths rendered into app compose templates (host docker daemon resolves those) — see freeshard-architecture-contract.
+
+| Path (host) | Contents | Written by |
+|---|---|---|
+| `$FREESHARD_DIR/core/traefik.yml` | Traefik static config | rendered at every shard_core start (app_factory.py:140-157) |
+| `$FREESHARD_DIR/core/traefik_dyn/traefik_dyn.yml` | per-app routers + forwardAuth middlewares | startup and every app (un)install |
+| `$FREESHARD_DIR/core/acme.json` | Let's Encrypt state | traefik |
+| `$FREESHARD_DIR/core/installed_apps/<name>/` | app's docker-compose.yml + template + assets | app installation |
+| `$FREESHARD_DIR/user_data/app_data/<name>/` | app's persistent data | apps |
+| `$FREESHARD_DIR/user_data/shared/` | cross-app shared files | apps |
+| `$FREESHARD_DIR/postgres_data/` | **the database**: identities (private keys!), terminals, installed_apps, kv_store, backups | postgres container |
+
+Operational threshold: a background task measures free space on `{path_root}/user_data` every 30 s; **below 1 GiB free, ALL apps are stopped** (disk.py:22-30, app_lifecycle).
+
+## 5. First-start behavior (idempotence rules)
+
+On a fresh `FREESHARD_DIR` + empty DB, the lifespan (app_factory.py:78-99) does, in order:
+
+1. yoyo migrations + DB pool + one-time TinyDB→Postgres import (if a pre-0.38 `core/shard_core_db.json` exists, it is imported and renamed `.json.backup` — database/tinydb_migration.py).
+2. **Identity generation**: if the identities table is empty, creates the default identity — RSA-4096 key (agents.md wrongly says Ed25519; the code is RSA-PSS, shard_core/service/crypto.py). Shard domain = first 6 chars of the identity id, lowercased, + `.` + `dns.zone` (data_model/identity.py:59-64). **The domain is derived from the key** — lose the DB, lose the identity and the domain.
+3. Traefik dyn config, app compose re-render, `docker login` for registries.
+4. **initial_apps install** — `filebrowser`, `immich`, `paperless-ngx` (config.toml `[apps] initial_apps`) are queue-installed **on first boot only**, guarded by kv_store flag `initial_apps_installed` (app_installation/__init__.py:102-120). Deleting one later does not resurrect it on restart.
+5. Backup passphrase: 10-word EFF-wordlist passphrase generated into kv_store key `backup_passphrase` if absent (backup.py:203-212).
+6. Profile refresh (failure-tolerant), background tasks start, welcome log prints.
+
+## 6. Backup operations
+
+### How production backup works
+
+- **Trigger**: CronTask `0 3 * * *` (container time, UTC in practice) plus a random delay of up to 3600 s (config.toml `[services.backup.timing]`), or manually via POST `/protected/backup/start`.
+- **Flow**: shard asks the controller for an Azure SAS URL (`GET api/shard_backup/backup_sas_url`, service/portal_controller.py:39-42) → rclone **crypt** sync of `core/` and `user_data/` (config.toml `directories`) to `:crypt:{container}/{dir}` on Azure Blob, encrypted with the kv_store passphrase → `BackupReport` row in the `backups` table → a `_last_backup` marker blob is uploaded; its Last-Modified timestamp is the recency signal the controller monitors (backup.py).
+- rclone flags as of 2026-07-03: `--fast-list` yes; `--azureblob-no-check-container` was added for Azure-cost reasons (PR https://github.com/FreeshardBase/freeshard/pull/106) then **removed** because the fleet's rclone didn't support it and all v18 backups failed (https://github.com/FreeshardBase/freeshard/issues/117, fix PR https://github.com/FreeshardBase/freeshard/pull/119). Check `COMMAND_TEMPLATE` in shard_core/service/backup.py before assuming flags.
+- **Self-hosted shards cannot back up, by design**: no controller profile → no SAS URL → `BackupStartFailedError` (backup.py:57-60). Self-hosters must snapshot `$FREESHARD_DIR` themselves.
+- **Passphrase retrieval** (needed for any restore): GET `/protected/backup/passphrase` — externally `https://<shard-domain>/core/protected/backup/passphrase` from a paired terminal, or from inside the docker network:
+
+```bash
+docker run --rm -it --network portal curlimages/curl \
+  -H "X-Ptl-Client-Id: cli" "http://shard_core/protected/backup/passphrase"
+```
+
+  (The header is required — 400 without; every access is recorded in kv_store, web/protected/backup.py:50-55.)
+
+### THE backup gap: Postgres is not in it
+
+The backup set is `['core', 'user_data']` only. `postgres_data/` is a sibling directory and is **not backed up** — and since the 0.38.0 TinyDB→Postgres migration, identities (private keys), terminals, installed-app rows, and the backup passphrase itself live only in Postgres. **A backup taken by any release >= 0.38.0 cannot restore a shard's identity.** Open issue: https://github.com/FreeshardBase/freeshard/issues/122. Pre-0.38 backups still contain `core/shard_core_db.json`, which auto-imports on first boot. Whether hosted infra separately snapshots `postgres_data` is a controller-side question — not answerable from this repo.
+
+### Restore-for-debugging runbook (run a customer backup locally)
+
+1. Get the shard's backup container name, a read SAS URL (controller-side), and the passphrase (route above, or ask the owner).
+2. Fill the three variables at the top of `download_backup.sh` (repo root) and run it — it rclone-decrypts the whole container into `./$CONTAINER/` (containing `core/` and `user_data/`).
+3. Zip it so `core/` and `user_data/` sit at the zip root, then load it into the dev data dir:
+
+```bash
+(cd "$CONTAINER" && zip -r ../backup.zip core user_data)
+just run-from-backup backup.zip   # rm -rf run && unzip into run/
+just run-dev                      # dev server now runs against the restored files
+```
+
+(`run-from-backup`: justfile:9-11. The zip step is not documented in-repo; the layout requirement follows from `path_root = "run/"`.)
+
+4. Expect a **fresh** identity/DB: the restored files contain no Postgres state (gap above), so the dev instance generates a new identity and the restored `installed_apps/` rows won't exist in its DB.
+
+## 7. Release checklist
+
+**This checklist is the maintainer's.** Agents: at most prepare a version-bump PR when explicitly asked (after fetching — see freeshard-change-control §5); never push to main, never publish a Release.
+
+Versioning is a linear X.Y.Z sequence today; migration to real semver is decided in principle but not implemented (https://github.com/FreeshardBase/freeshard/issues/118, open as of 2026-07-03).
+
+1. **Sync first — never version-bump from a stale checkout**:
+   ```bash
+   git fetch origin && git checkout main && git pull
+   grep '^version' pyproject.toml   # confirm current version before choosing the next
+   ```
+2. `just set-version X.Y.Z` — rewrites `version` in pyproject.toml **and** the `ghcr.io/freeshardbase/freeshard:` tag in docker-compose.yml, then commits "set version to X.Y.Z" (justfile:25-45; needs `.venv`).
+3. `git push`
+4. Create a GitHub Release whose **tag is exactly `X.Y.Z`** (e.g. `gh release create X.Y.Z --title X.Y.Z --generate-notes`). The Release event drives `.github/workflows/release.yml`: a version-check job fails the build if tag != pyproject version ("Run 'just set-version' and commit first"), then the full test workflow, then buildx pushes `ghcr.io/freeshardbase/freeshard:X.Y.Z`.
+5. **Fleet rollout is a separate, controller-side step.** Hosted shards run the pinned tag from their compose file; rolling the fleet means a core-version/compose bump in the freeshard-controller repo (see freeshard-ecosystem-contracts). Nothing in this repo deploys anything.
+
+**MERGED IS NOT SHIPPED.** Every push already publishes a snapshot image tagged with the branch slug (`.github/workflows/snapshot.yml`, e.g. `ghcr.io/freeshardbase/freeshard:main`), but production shards only ever run **release tags**. Incident: the fd-leak fix (PR https://github.com/FreeshardBase/freeshard/pull/108) was merged while shards kept failing, because no release tag contained it — tracked as https://github.com/FreeshardBase/freeshard/issues/111, resolved by releasing 0.39.4 (2026-06-24). When asked "is fix X live?", the answer requires: (a) merged to main, (b) contained in a release tag (`git tag --contains <sha>`), AND (c) that tag rolled out by the controller.
+
+Release gating and what may ship at all: freeshard-change-control. This checklist is mechanics only.
+
+## 8. Hosted vs self-hosted differences
+
+Same image, same compose file. The only fork is whether `GET {controller}/api/shards/self` recognizes the shard's signature (401 → `profile = None`, service/portal_controller.py:21-36).
+
+| Axis | Hosted (fleet) | Self-hosted |
+|---|---|---|
+| Controller profile | populated from controller | `None` |
+| VM-size gates on app install | enforced (`profile.vm_size` vs app `minimum_portal_size`) | **none** — `size_is_compatible()` returns True when profile is None (app_tools.py:141-149) |
+| Backups | daily rclone crypt to Azure via controller SAS URL | **fail by design** (`BackupStartFailedError`) — bring your own `$FREESHARD_DIR` snapshot |
+| Management API (`/management`: install apps, notify, pairing-code) | called by controller, authed via shared secret forwardAuth | inert (nobody holds the secret) |
+| SSL | wildcard via DNS-01, Azure DNS creds provided by fleet tooling | must add provider env vars **and** patch the hardcoded `provider: azure` (section 3) |
+| DNS zone | `freeshard.cloud` (config.toml default) | `DNS_ZONE` in `.env` |
+| Billing/resize passthrough (`/protected/management/{rest}`) | proxies signed requests to controller | returns controller 401s |
+
+## 9. Production ops invariants (fleet knowledge)
+
+Operational rules learned in production, stated here so nobody relearns them (fleet-side facts; not verifiable from this repo alone):
+
+- **`docker daemon.json` changes to `log-driver`/`log-opts`/`default-ulimits` require `systemctl restart docker`, not `reload`.** SIGHUP reloads only a whitelisted subset; containers keep stale in-memory values even when recreated after a reload. Restart bounces all containers — schedule it in a maintenance window. Fleet default logging: json-file, max-size 10m, max-file 3.
+- **Hosted shards run on OVH** (as of 2026-07-03; Azure is EOL for shard VMs).
+- **Pin LTS base images only.** OVH rotated out a non-LTS Ubuntu image without notice and broke provisioning; interim releases die in months.
+- **Traefik entrypoints must keep a finite `readTimeout`** (`300s` in data/traefik.yml on main). readTimeout=0 plus internet scanners = fd leak → EMFILE → shard "Up" but unreachable (PR https://github.com/FreeshardBase/freeshard/pull/108). Don't remove it when touching the template.
+- **Keep >1 GiB free on the user_data volume** — below that, shard_core stops all apps (section 4).
+
+## 10. When NOT to use this skill
+
+| You are trying to… | Use instead |
+|---|---|
+| Add/change a config option, understand env overrides, `FREESHARD_*` vars | freeshard-config-and-flags |
+| Set up Python env, uv, worktrees, type-sync from controller | freeshard-build-and-env |
+| Run or write tests, interpret CI test failures | freeshard-testing-and-qa |
+| Debug a misbehaving shard or app (symptom → cause) | freeshard-debugging-playbook |
+| Decide whether a change may ship, review gates, release policy | freeshard-change-control |
+| Understand crypto/signatures/forwardAuth/backup theory | freeshard-domain-reference |
+| Cross-repo contracts (controller compose bump, web-terminal, app-repository) | freeshard-ecosystem-contracts |
+| Why the architecture is shaped this way; invariants | freeshard-architecture-contract |
+| Measure performance / run diagnostic scripts | freeshard-diagnostics-and-tooling |
+
+## Provenance and maintenance
+
+Written 2026-07-03 against origin/main `0a40684` (version 0.39.4). Primary sources: justfile, docker-compose.yml, .env.template, README.md (Hosting/Development sections), shard_core/app_factory.py, shard_core/service/{backup,portal_controller,disk,identity,app_tools}.py, shard_core/web/protected/{backup,terminals}.py, data/traefik.yml, download_backup.sh, .github/workflows/{release,snapshot}.yml, config.toml, local_config.toml; GitHub issues/PRs #106, #108, #111, #117, #118, #119, #122.
+
+Note: the working tree you find yourself in may be a stale branch — verify volatile facts against `origin/main`, not the checkout.
+
+Drift-prone facts — re-verify before relying on them:
+
+| Fact (as of 2026-07-03) | Re-verify with |
+|---|---|
+| Latest release = 0.39.4 | `gh release list --limit 1` |
+| Compose pins freeshard:0.39.4, traefik:v3.6, web-terminal:0.37.4, postgres:17 | `git show origin/main:docker-compose.yml \| grep image:` |
+| ACME provider hardcoded `azure`; readTimeout 300s | `git show origin/main:data/traefik.yml \| grep -n 'provider\|readTimeout'` |
+| Backup dirs = core, user_data (no postgres_data) | `grep -A1 '\[services.backup\]' config.toml` |
+| rclone flags (`--fast-list`, no `--azureblob-no-check-container`) | `git show origin/main:shard_core/service/backup.py \| grep -A9 '^COMMAND_TEMPLATE'` |
+| initial_apps = filebrowser, immich, paperless-ngx | `grep initial_apps config.toml` |
+| Backup cron 03:00 + ≤3600s jitter | `grep -A2 'backup.timing' config.toml` |
+| Postgres-not-in-backup still open | `gh issue view 122 --json state` |
+| Semver migration still pending | `gh issue view 118 --json state` |
+| run-dev-for-freeshard-controller env var still broken (single `_`) | `grep FREESHARD_FREESHARD_CONTROLLER justfile` (broken if not `CONTROLLER__BASE_URL`) |
+| Release tag==version gate exists | `grep -n 'does not match pyproject' .github/workflows/release.yml` |
+| Pairing route + 10-min first-start code | `grep -n 'pairing-code' shard_core/web/protected/terminals.py; grep -n '10 \* 60' shard_core/app_factory.py` |

--- a/.claude/skills/freeshard-testing-and-qa/SKILL.md
+++ b/.claude/skills/freeshard-testing-and-qa/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: freeshard-testing-and-qa
+description: "How to run, write, and trust tests in the freeshard (shard_core) repo. Use when running pytest, adding or modifying tests, choosing between the api_client/app_client/db fixtures, overriding config in tests, diagnosing a flaky or hanging test, or deciding what evidence a fix needs before a PR. TRIGGER on: 'run the tests', 'add a test', tests/conftest.py, tests/util.py, pytest-docker, LifespanManager, 'test hangs', 'CI-only failure', 'flaky test', port 5433, 'docker network portal', wait_until_app_installed, TimeoutError in CI. SKIP when: recreating the dev environment / uv sync / worktrees (use freeshard-build-and-env), debugging production behavior rather than tests (use freeshard-debugging-playbook), editing .github/workflows themselves (use freeshard-change-control for gates; this skill only describes what CI runs), or cataloguing config options outside tests (use freeshard-config-and-flags)."
+---
+
+# Freeshard testing and QA
+
+This repo is **shard_core**: the FastAPI + PostgreSQL + Docker Compose application that runs on a "shard" (a user's personal cloud VM). The test suite is unusual in two ways: (1) it runs against a **real PostgreSQL container** (never a mocked DB), and (2) its heavyweight tier performs **real Docker operations** — creating networks, pulling images, and installing real apps. Knowing which tier your test belongs in is the core discipline here.
+
+All commands assume CWD = repo root and a synced venv (`uv sync --extra dev` — see freeshard-build-and-env). All facts verified on 2026-07-03 against origin/main (0a40684); suite size then: 137 tests across 36 test modules (134 verified by `--collect-only` at e55ce51, plus the 3 tests in tests/test_backup.py merged since via PR https://github.com/FreeshardBase/freeshard/pull/119).
+
+## Running tests
+
+| Task | Command |
+|---|---|
+| Full suite | `.venv/bin/pytest tests` |
+| Single file | `.venv/bin/pytest tests/test_profile.py` |
+| Single test | `.venv/bin/pytest tests/test_app_installation.py::test_install_app` |
+| By pattern | `.venv/bin/pytest tests -k 'tours'` |
+| Collect only (sanity check, no Docker needed) | `.venv/bin/pytest tests --collect-only -q` |
+| Lint exactly as CI does | `.venv/bin/ruff check .` |
+| Auto-fix + format (run after any code change) | `just cleanup` |
+
+`just cleanup` runs `ruff check --fix` plus `black` on `shard_core` and `tests` (justfile:4-7). black is not a declared dev dependency but arrives transitively via `datamodel-code-generator` in the dev extra, so it is present after `uv sync --extra dev`.
+
+### Prerequisites
+
+- **Docker daemon with compose v2 plugin.** pytest-docker auto-starts `tests/docker-compose.yml` (postgres:17, db/user/password all `shard_core_test`, host port fixed at **5433**) under compose project name `shard-core-test` (tests/conftest.py:91-98) and tears it down at session end.
+- **Internet access.** A session-scoped autouse fixture runs a REAL `docker login` against the registries in root `config.toml` (conftest.py:129-131 → shard_core/service/app_installation/__init__.py:123). The credentials for `portalapps.azurecr.io` are committed at config.toml:30-33. `api_client` tests then really pull `portalapps.azurecr.io/ptl-apps/filebrowser:master` (the filebrowser mock-app zip references it; the other mock apps use `nginx:alpine`). If that ACR credential is ever rotated, every `api_client` test breaks with image-pull failures — that is the first thing to check on a sudden mass failure.
+- **No concurrent runs.** Port 5433, compose project name `shard-core-test`, the docker network `portal`, and app container names (e.g. `filebrowser`) are all global on the host. Two worktrees running pytest at once, or pytest next to a locally running dev shard, will collide. There is no pytest-xdist; do not parallelize.
+
+### Cleanup after a hung or crashed run
+
+```bash
+# hung/leftover test postgres:
+docker compose -p shard-core-test -f tests/docker-compose.yml down -v
+# leftover app network (api_client teardown normally removes it):
+docker network rm portal
+```
+
+If `docker network rm portal` fails with "active endpoints", disconnect containers first — that exact failure mode is why tests/util.py:150-172 force-disconnects every container before removing the network (commit 28964fd "Fix flaky CI: portal network not torn down between tests").
+
+## Fixture decision rule (the core discipline)
+
+Three tiers, defined in tests/conftest.py. **Always pick the cheapest tier that can observe your behavior.** History shows flaky integration tests get demoted to the cheap tier eventually (commits 7e1922e "Fix #45: Convert integration tests to lightweight unit tests", aad605a) — start there.
+
+| Fixture | What it gives you | Cost | Use for |
+|---|---|---|---|
+| `app_client` (conftest.py:212-238) | FastAPI app via httpx `ASGITransport`, **no lifespan**, no Docker, DB initialized directly + default identity created | Fast | Route + DB tests. The default choice for any endpoint test. |
+| `api_client` (conftest.py:183-209) | Full app under `LifespanManager` (startup/shutdown timeout 20s), real docker network `portal`, app-store downloads mocked from `tests/mock_app_store/`, then **really installs the 3 `initial_apps`** (filebrowser, immich, paperless-ngx — root config.toml:39; tests/config.toml does not override it) and waits for them | Slow (tens of seconds each) | ONLY when you need background tasks, real app installation/lifecycle, or the Docker network. |
+| `db` (conftest.py:173-180) | `database.init_database()` / `shutdown_database()` only, no HTTP app | Fast | Service-layer / database-layer tests with no HTTP surface. |
+
+Both client fixtures start at `base_url="https://init"`, call `GET /public/meta/whoareyou`, and switch `base_url` to the shard's real domain — so your test requests look like they arrive at `https://<shard-domain>/...`.
+
+### The importlib.reload trap
+
+`api_client` and `app_client` both do `importlib.reload()` on `shard_core.service.websocket`, `shard_core.service.app_installation.worker`, and `shard_core.service.telemetry` because those modules hold global state (conftest.py:186-190, 218-220). **Any mock you create on those modules BEFORE the fixture runs is silently wiped by the reload.** The conftest comment at line 190 says it explicitly: "Mocks must be set up after modules are reloaded or else they will be overwritten." Practical rule: request the client fixture first, patch inside the test body (or in a fixture that depends on the client fixture), never in an earlier-ordered autouse fixture.
+
+## Database semantics in tests
+
+- The postgres container is **session-scoped**; yoyo migrations run once per container lifetime (`_yoyo*` tables are preserved by the truncation).
+- An autouse function-scoped fixture **TRUNCATEs all public tables (except `_yoyo*`) with `RESTART IDENTITY CASCADE` BEFORE each test** — not after (conftest.py:145, 159-170). Consequences:
+  - A failing test leaves its DB state behind — inspect it post-mortem via `psql "host=localhost port=5433 dbname=shard_core_test user=shard_core_test password=shard_core_test"`.
+  - Tests must NEVER depend on rows created by a prior test; that dependency is silently order-sensitive and will break under reordering.
+  - Tests do not need to clean up DB state after themselves.
+
+## Config overrides in tests
+
+Settings in tests are `_TestSettings`: root `config.toml` overlaid **per-field** by `tests/config.toml` (conftest.py:54-59). Anything tests/config.toml does not override (initial_apps, registries, app-store URL, management/controller URLs) leaks in from production config — this is intentional but surprising. tests/config.toml speeds things up: app lifecycle `refresh_interval = 2`, last-access `max_update_frequency = 3`, every-second usage-tracking cron.
+
+Three override mechanisms, applied on top of that:
+
+| Mechanism | Scope | How |
+|---|---|---|
+| Module-level `config_override = {...}` dict | whole test module | conftest reads `request.module.config_override` (conftest.py:139). Supported but currently unused by any test module (as of 2026-07-03). |
+| `@pytest.mark.config_override({...})` | one test | See tests/test_docker_prune.py:8-11. The marker is unregistered, so collection emits a `PytestUnknownMarkWarning` — known cosmetic noise, not your bug. |
+| `settings_override({...})` context manager | a block inside a test | `from tests.conftest import settings_override` — see tests/test_telemetry.py:46, tests/test_service_init_apps.py. Restores old settings on exit. |
+
+All three take nested dicts mirroring the TOML structure, e.g. `{"apps": {"pruning": {"enabled": False}}}`. Env-var override rules for production config are out of scope here — see freeshard-config-and-flags.
+
+## HTTP mocking of external services
+
+No test talks to the real controller or management API. The `requests_mock` fixture (conftest.py:338-341, built on the `responses` library) repoints settings at `https://management-mock` and `https://freeshard-controller-mock` and fakes: `GET /api/shards/self` (returns `mock_shard`: size XS, max M), `POST /api/shards/self/resize` (returns 409 for sizes l/xl, 204 otherwise), `POST /api/feedback`, `GET sharedSecret`, `POST /app_usage`. To serve a custom shard/subscription payload, use `requests_mock_context(shard=..., subscription=...)` directly (conftest.py:280-327).
+
+`peer_mock_requests` (conftest.py:344-371) fakes a remote peer shard: its `whoareyou` identity endpoint plus wildcard GET/POST on a mock app subdomain — use it for peer-to-peer signed-call tests (see tests/test_call_peer.py, tests/test_signed_call.py).
+
+Both mocks call `rsps.add_passthru("")`, so unmatched requests (e.g. real ACR pulls in `api_client` tests) still pass through.
+
+## How to add a test
+
+1. **File**: `tests/test_<topic>.py`. Async tests are plain `async def test_...` — `asyncio_mode = "auto"` (pyproject.toml:71), no marker needed.
+2. **Pick the fixture tier** using the table above. Route test → `app_client`. Only escalate to `api_client` if the assertion genuinely needs installed apps, background workers, or Docker.
+3. **App-related tests**: mock apps live in `tests/mock_app_store/<name>/<name>.zip` (available: `filebrowser`, `immich`, `paperless-ngx`, `always_on`, `large_app`, `mock_app`, `quick_stop`). The `api_client` fixture patches `_download_app_zip` and `app_exists_in_store` to serve from there (conftest.py:374-395). A new mock app = new directory + zip containing `app_meta.json`, `docker-compose.yml.template`, `icon.svg`; use `nginx:alpine` as the image (`tests/util.py:20` `WAITING_DOCKER_IMAGE`) so no registry auth is needed.
+4. **Controller/management HTTP**: use the `requests_mock` fixture, or `requests_mock_context(...)`/`responses` directly for custom payloads.
+5. **Helpers** in tests/util.py: `pair_new_terminal(client)` (pairing-code flow, asserts 201), `install_app(client, name)`, `wait_until_app_installed(client, name, timeout=60)` (2s poll), `wait_until_app_uninstalled`, `retry_async(f, timeout=90, frequency=3)` (retries `AssertionError` by default), `verify_signature_auth` + `modify_request_like_traefik_forward_auth` for HTTP-message-signature tests (RSA_PSS_SHA512 — see freeshard-domain-reference).
+6. **Timing**: never assert immediately after triggering a background action. Poll with `retry_async` or the `wait_until_*` helpers; pick timeouts generous for loaded CI runners (see flaky playbook below).
+7. Run `just cleanup`, then the affected file, then the full suite if you touched conftest/util (conftest.py is historically the #1 fix-commit file in the repo — changes there ripple everywhere).
+
+## Flaky-test playbook
+
+**Symptom: a test times out in CI but passes locally.** CI runners are slower than your machine. Precedent fixes, in escalation order:
+
+| Fix | Precedent |
+|---|---|
+| Bump the wait/poll timeout | c824636 "increase app install wait timeout to reduce CI flakiness" — 20s was too tight on loaded GitHub runners; `test_peer_auth_basic` hit TimeoutError in the release pipeline while the PR pipeline passed (PR https://github.com/FreeshardBase/freeshard/pull/64) |
+| Set/raise `LifespanManager` shutdown_timeout | dc45ced "set shutdown_timeout on LifespanManager to prevent teardown flakiness" |
+| Force-disconnect containers before removing the `portal` network | 28964fd — the current tests/util.py:150-172 logic |
+| Demote the test to `app_client`/unit level | aad605a (test_telemetry_recording), 7e1922e (Fix https://github.com/FreeshardBase/freeshard/issues/45) |
+| Wait for app install before asserting | f96076f "wait for app installation before auth check in test_headers" |
+
+**Symptom: whole suite hangs in CI.** Precedent: 358a908 "Fix CI test hang: commit migration SQL and guard pool cleanup" (during the Postgres migration). Check migration state and connection-pool teardown first.
+
+**First suspects on a slow runner** — the timing-sensitive tests (all verified to contain real sleeps or tight polling against tests/config.toml intervals):
+
+| Test file | Timing dependency |
+|---|---|
+| tests/test_app_last_access.py | bare `time.sleep(3)` against `max_update_frequency = 3` |
+| tests/test_async_util_periodic.py | asserts counts after `asyncio.sleep(2-3)` |
+| tests/test_throttle.py | `time.sleep(0.2)` |
+| tests/test_app_lifecycle.py | `retry_async` ceilings vs the 2s lifecycle `refresh_interval` |
+
+There are currently **no skip/xfail markers anywhere in the suite** (a 2022-era skip, dcf6207, was later re-enabled). Do not add `skip` to silence flakiness — fix it with the playbook above or demote the test; freeshard-change-control treats disabled tests as a red flag.
+
+**Symptom: everything with `api_client` fails at image pull.** Check the committed ACR credential (config.toml:30-33) and general internet access before debugging your change.
+
+## Coverage gaps (as of 2026-07-03)
+
+Verified by grepping origin/main's tests/ for module names and routes:
+
+| Gap | Why it matters |
+|---|---|
+| shard_core/web/protected/backup.py (backup routes) — untested; shard_core/service/backup.py got its FIRST unit tests only in July 2026 (tests/test_backup.py, 3 tests, PR https://github.com/FreeshardBase/freeshard/pull/119) | The backup subsystem is the repo's worst tests-vs-incidents ratio: rclone output/flag handling broke production THREE times (9666db5 in 2024; b9dfcfd rclone-stats validation and 935250b JSONB datetime in 0.38.x, 2026 — neither shipped with a test; then issue https://github.com/FreeshardBase/freeshard/issues/117, all v18 backups failing on an rclone flag missing from the bundled 1.60.1 binary, which finally brought the guard tests). Any change here MUST extend those tests. |
+| shard_core/service/portal_controller.py | Legacy backend client, zero coverage. |
+| shard_core/service/websocket.py + shard_core/web/protected/ws.py | Websocket routes; conftest reloads the module but nothing exercises it. |
+
+Also flagged in-tree: tests/test_app_lifecycle.py:101-103 has todos for `test_large_app_does_not_start` and an app-size-comparison test (the `large_app` mock app exists for this).
+
+The new tests/test_backup.py is the template for testing subprocess-driven code cheaply: mock `asyncio.create_subprocess_exec` with an `AsyncMock` process, no fixture tier needed at all.
+
+There is **no coverage tooling** (no pytest-cov in deps) — "has tests" is judged by grep, not by a percentage.
+
+## CI: what actually runs
+
+- **snapshot.yml** — triggers on push to `**` AND pull_request to `**`. Runs test.yml (two jobs: ruff, and pytest; both on ubuntu-latest / Python 3.13, installing via `uv sync --frozen --extra dev` and running `uv run ruff check .` / `uv run pytest tests` — as of origin/main 0a40684; older branches still carry the previous `pip install ".[dev]"` variant), then builds and pushes `ghcr.io/freeshardbase/freeshard:<branch-slug>`. Because both events fire for a PR branch, **every PR effectively runs the whole suite twice**.
+- The `TEST_ENV` sparse/full input threaded through snapshot.yml → test.yml:42 is **DEAD**: nothing in shard_core or tests reads it (the consuming decorator was removed; last straggler cleaned in 639ba77). Likewise `CONFIG: tests/config.yml` in test.yml:41 is dead — nothing reads `CONFIG` (full evidence: freeshard-config-and-flags). Don't build on either; don't "fix" them in a drive-by either (see freeshard-change-control).
+- **release.yml** — triggers on GitHub release created. Gate: release tag must equal `pyproject.toml` version, else the job fails and tells you to run `just set-version <tag>` first. Then tests, then builds in container `ghcr.io/freeshardbase/cicd-image:1.0.3` and pushes `ghcr.io/freeshardbase/freeshard:<tag>`. Two commented-out jobs (`pages` redoc docs, `json-schema` Azure upload) are dead since the GitLab→GitHub migration (skipped in d309113, Feb 2025). Release procedure itself: freeshard-run-and-operate and freeshard-change-control.
+- Only secret used anywhere: `secrets.GITHUB_TOKEN` (packages:write for ghcr).
+
+CI green ≠ shipped: merged code reaches shards only via the release flow (see freeshard-change-control, "merged-is-not-shipped").
+
+## What counts as evidence
+
+House discipline for claiming something is fixed or working:
+
+1. **A fix for a failure mode needs a test that reproduces the failure class** — write it, watch it fail, then make it pass. Report both observations. The backup subsystem shows what happens otherwise: the same rclone-handling failure class shipped to production three times over two years (9666db5 → b9dfcfd → issue #117) because no regression test pinned it; the pattern only stopped when the fix for #117 landed together with guard tests (0d42299, tests/test_backup.py).
+2. **"Tests pass" means you ran them and read the output**, not that the code looks right. Paste the pytest summary line into your PR description.
+3. **A CI-only flake fix needs the CI evidence**, not just a local pass — link the failing run and the passing run after your change (precedent: the c824636 commit message names the exact failing test and pipeline).
+4. New work in an untested subsystem (backup routes, portal_controller, websocket) must bring the first tests with it — reviewers will ask.
+5. When a test's absence is deliberate (genuinely unmockable external dependency), say so explicitly in the PR rather than staying silent.
+
+## When NOT to use this skill
+
+- Setting up the venv, uv, worktrees, type-sync from freeshard-controller → **freeshard-build-and-env**
+- Running the dev server or compose stack, deploying, backup/restore operations → **freeshard-run-and-operate**
+- A production symptom (not a test failure) needs triage → **freeshard-debugging-playbook**
+- Config/flag catalog, env-override rules outside tests → **freeshard-config-and-flags**
+- What may be changed, gates, release rules, PR review expectations → **freeshard-change-control**
+- Cross-repo contract changes (controller API shapes the mocks mirror) → **freeshard-ecosystem-contracts**
+- Measuring performance instead of asserting correctness → **freeshard-diagnostics-and-tooling**
+
+## Provenance and maintenance
+
+Written 2026-07-03. Verified against origin/main at 0a40684 (confirmed equal to the live remote head via `gh api repos/FreeshardBase/freeshard/branches/main`) plus the local working tree at e55ce51; tests/conftest.py, tests/util.py, tests/config.toml, tests/docker-compose.yml, justfile, config.toml, snapshot.yml, and release.yml are byte-identical between the two, while test.yml and tests/test_backup.py facts were taken from origin/main. Primary sources: those files plus git history and GitHub PRs/issues (hashes and URLs cited inline; all checked with `git log`/`git show`/`gh`).
+
+Drift-prone facts — re-verify before relying on them:
+
+| Fact | Re-verify with |
+|---|---|
+| 137 tests / 36 modules | `.venv/bin/pytest tests --collect-only -q \| tail -1` |
+| postgres:17 on host port 5433, project `shard-core-test` | `cat tests/docker-compose.yml; grep -n shard-core-test tests/conftest.py` |
+| initial_apps = filebrowser, immich, paperless-ngx (not overridden in tests) | `grep -n initial_apps config.toml tests/config.toml` |
+| ACR creds committed and used by setup_all | `grep -n -A3 'apps.registries' config.toml; grep -n login_docker_registries tests/conftest.py` |
+| Reloaded-by-fixture module list (websocket, app_installation.worker, telemetry) | `grep -n 'importlib.reload' tests/conftest.py` |
+| Truncate-BEFORE-each-test, `_yoyo*` preserved | `grep -n -B2 -A12 '_truncate_all_tables' tests/conftest.py` |
+| TEST_ENV / CONFIG env vars still dead | `grep -rn 'TEST_ENV\|environ\[.CONFIG' shard_core/ tests/ .github/` |
+| portal_controller / websocket still untested; backup routes still untested | `grep -rln 'portal_controller\|websocket\|protected/backup' tests/ --include='*.py'` |
+| Suite runs twice per PR (push + pull_request triggers) | `head -12 .github/workflows/snapshot.yml` |
+| No skip/xfail markers in suite | `grep -rn 'pytest.mark.skip\|pytest.mark.xfail\|pytest.skip' tests/ --include='*.py'` |
+| wait_until_app_installed default timeout 60s / 2s poll | `grep -n -A8 'def wait_until_app_installed' tests/util.py` |
+| module-level config_override dict still unused | `grep -rn '^config_override' tests/` |


### PR DESCRIPTION
## What

A 16-skill project knowledge library under `.claude/skills/`, written for zero-context contributors and headless agent sessions (the grind loop). Docs only — no runtime code touched. One commit, 21 files, ~4300 lines.

## Why

A fresh agent session per issue means no project memory. These skills encode what currently lives only in git history, closed issues, and the maintainer's head: the failure archaeology, the non-negotiables, the traps that cost real time (single-underscore env vars, stale sibling checkouts, rclone stats parsing, merged-is-not-shipped), and the verified runbooks for build/test/run/release.

## How it was built

1. **Discovery**: full pass over the repo, git history (all 784 commits / 100 tags), open+closed issues and PRs, CI, config, and cross-repo contracts.
2. **Authoring**: one agent per skill, with a ground-truth rule — every command, path, commit hash, config key, and issue reference verified against the repo or GitHub before being written down.
3. **Review**: three independent passes (factual re-verification, doctrine/consistency, usability) produced 28 findings; 22 blocking/important fixes applied. Notable catch: a claim verified against the stale local web-terminal checkout instead of its origin/main — exactly the trap the library warns about.

Each skill ends with a **Provenance and maintenance** section: a table of drift-prone facts with one-line re-verification commands, so staleness is checkable rather than silent.

## Contents

| Skill | Covers |
|---|---|
| freeshard-change-control | Dev Board flow, branch/PR conventions, non-negotiables, release discipline |
| freeshard-debugging-playbook | Symptom→triage for the known failure modes, with discriminating experiments |
| freeshard-failure-archaeology | Every major incident/dead-end/revert: symptom → root cause → evidence → status |
| freeshard-architecture-contract | Load-bearing decisions, invariants, honest weak points |
| freeshard-domain-reference | HTTP Message Signatures (RSA-PSS — corrects the agents.md Ed25519 claim), forwardAuth, rclone crypt, transaction semantics |
| freeshard-config-and-flags | Full config catalog, env-override rules, dead config, add-option checklist |
| freeshard-build-and-env | Fresh machine → productive; worktrees; justfile anatomy |
| freeshard-run-and-operate | Dev server, compose stack, backup/restore, release checklist, hosted vs self-hosted |
| freeshard-testing-and-qa | Fixture decision rules, flaky-test playbook, coverage gaps |
| freeshard-diagnostics-and-tooling | Measurement techniques + 5 runnable scripts (type-drift check, env-override proof, todo scan, test cleanup, churn hotspots) |
| freeshard-ecosystem-contracts | Cross-repo contracts, get-types staleness discipline, pricing duplication invariant |
| freeshard-docs-and-positioning | Docs of record, known-stale list, naming discipline, external claims bar |
| freeshard-oidc-identity-campaign | Decision-gated campaign for the embedded OIDC provider, spike inventory included |
| freeshard-proof-and-analysis-toolkit | 8 root-cause proof recipes, each with a worked example from project history |
| freeshard-research-frontier | Agent-on-shard and other open problems, with falsifiable milestones |
| freeshard-research-methodology | Evidence bar, idea lifecycle, documented retirement |

## Recommended reading order

1. `freeshard-change-control/SKILL.md` — the rules everything else defers to
2. `freeshard-architecture-contract/SKILL.md` — the system model
3. `freeshard-build-and-env`, `freeshard-run-and-operate`, `freeshard-testing-and-qa` — the daily runbooks
4. `freeshard-config-and-flags`, `freeshard-domain-reference`, `freeshard-ecosystem-contracts` — reference tier
5. `freeshard-debugging-playbook`, `freeshard-diagnostics-and-tooling` (+ scripts/), `freeshard-failure-archaeology`, `freeshard-proof-and-analysis-toolkit` — incident tier
6. `freeshard-docs-and-positioning`, `freeshard-oidc-identity-campaign`, `freeshard-research-frontier`, `freeshard-research-methodology` — strategy tier

## Notes for review

- Volatile facts are date-stamped "as of 2026-07-03"; re-verification commands are in each skill's provenance table.
- Known open items are labeled as such (e.g. the repo-compose traefik:v3.6 vs fleet v2.11 divergence is recorded as an unresolved inconsistency, not design).
- Related: the backup gap documented in the library was filed as #122.

🤖 Generated with [Claude Code](https://claude.com/claude-code)