### PR TITLE
Phase 1 identity substrate: users table, owner user, terminal user binding

### DIFF
--- a/migrations/shard-core-0002-users.sql
+++ b/migrations/shard-core-0002-users.sql
@@ -1,0 +1,15 @@
+-- shard-core-0002-users
+-- depends: shard-core-0001-init
+
+CREATE TABLE IF NOT EXISTS users (
+    id TEXT PRIMARY KEY,
+    username TEXT UNIQUE NOT NULL,
+    display_name TEXT NOT NULL,
+    email TEXT,
+    role TEXT NOT NULL DEFAULT 'member',
+    password_hash TEXT,
+    disabled BOOLEAN NOT NULL DEFAULT FALSE,
+    created TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE terminals ADD COLUMN IF NOT EXISTS user_id TEXT REFERENCES users (id);

--- a/migrations/shard-core-0002-users.sql
+++ b/migrations/shard-core-0002-users.sql
@@ -1,15 +1,28 @@
 -- shard-core-0002-users
 -- depends: shard-core-0001-init
 
-CREATE TABLE IF NOT EXISTS users (
-    id TEXT PRIMARY KEY,
+-- Keep in sync with Role in shard_core/data_model/user.py
+CREATE TYPE user_role AS ENUM ('owner', 'member');
+
+CREATE TABLE users (
+    id BIGSERIAL PRIMARY KEY,
     username TEXT UNIQUE NOT NULL,
     display_name TEXT NOT NULL,
     email TEXT,
-    role TEXT NOT NULL DEFAULT 'member',
+    role user_role NOT NULL DEFAULT 'member',
     password_hash TEXT,
     disabled BOOLEAN NOT NULL DEFAULT FALSE,
     created TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
-ALTER TABLE terminals ADD COLUMN IF NOT EXISTS user_id TEXT REFERENCES users (id);
+-- Existing shards have their default identity at migration time; create the
+-- owner user and bind existing terminals right here so user_id can be
+-- NOT NULL from the start. Fresh shards have empty tables — the owner user
+-- is created at startup (service.user.ensure_owner_user) before any pairing.
+INSERT INTO users (username, display_name, email, role)
+SELECT 'owner', COALESCE(name, 'Shard Owner'), email, 'owner'
+FROM identities WHERE is_default = TRUE;
+
+ALTER TABLE terminals ADD COLUMN user_id BIGINT REFERENCES users (id);
+UPDATE terminals SET user_id = (SELECT id FROM users WHERE role = 'owner');
+ALTER TABLE terminals ALTER COLUMN user_id SET NOT NULL;

--- a/shard_core/app_factory.py
+++ b/shard_core/app_factory.py
@@ -25,6 +25,7 @@ from .service import (
     backup,
     disk,
     telemetry,
+    user,
 )
 from .service.app_installation.util import (
     write_traefik_dyn_config,
@@ -79,6 +80,7 @@ def configure_logging():
 async def lifespan(_):
     await database.init_database()
     await identity.init_default_identity()
+    await user.ensure_owner_user()
 
     await write_traefik_dyn_config()
     await render_all_docker_compose_templates()

--- a/shard_core/data_model/terminal.py
+++ b/shard_core/data_model/terminal.py
@@ -21,16 +21,18 @@ class Terminal(BaseModel):
     name: str
     icon: Icon = Icon.UNKNOWN
     last_connection: Optional[datetime] = None
+    user_id: Optional[str] = None
 
     def __str__(self):
         return f"Terminal[{self.id}, {self.name}]"
 
     @classmethod
-    def create(cls, name: str) -> "Terminal":
+    def create(cls, name: str, user_id: Optional[str] = None) -> "Terminal":
         return Terminal(
             id=human_encoding.random_string(6),
             name=name,
             last_connection=datetime.now(timezone.utc),
+            user_id=user_id,
         )
 
 

--- a/shard_core/data_model/terminal.py
+++ b/shard_core/data_model/terminal.py
@@ -21,13 +21,13 @@ class Terminal(BaseModel):
     name: str
     icon: Icon = Icon.UNKNOWN
     last_connection: Optional[datetime] = None
-    user_id: Optional[str] = None
+    user_id: Optional[int] = None
 
     def __str__(self):
         return f"Terminal[{self.id}, {self.name}]"
 
     @classmethod
-    def create(cls, name: str, user_id: Optional[str] = None) -> "Terminal":
+    def create(cls, name: str, user_id: Optional[int] = None) -> "Terminal":
         return Terminal(
             id=human_encoding.random_string(6),
             name=name,

--- a/shard_core/data_model/user.py
+++ b/shard_core/data_model/user.py
@@ -1,0 +1,24 @@
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class Role(str, Enum):
+    # Keep in sync with the user_role enum in migrations/shard-core-0002-users.sql
+    OWNER = "owner"
+    MEMBER = "member"
+
+
+class User(BaseModel):
+    id: int
+    username: str
+    display_name: str
+    email: Optional[str] = None
+    role: Role = Role.MEMBER
+    disabled: bool = False
+    created: Optional[datetime] = None
+
+    def __str__(self):
+        return f"User[{self.id}, {self.username}]"

--- a/shard_core/database/db_snapshot.py
+++ b/shard_core/database/db_snapshot.py
@@ -96,7 +96,8 @@ async def restore_db_snapshot():
         snapshot = json.loads(path.read_text())
         log.info(f"found DB snapshot at {path}, restoring")
         restored = 0
-        for table, rows in snapshot.items():
+        for table in await _referenced_first(conn, list(snapshot)):
+            rows = snapshot[table]
             if not rows:
                 continue
             col_types = await _column_types(conn, table)
@@ -118,6 +119,38 @@ async def _list_data_tables(conn: AsyncConnection) -> list[str]:
             (f"%{_YOYO_TABLE_MARKER}%",),
         )
         return [r[0] for r in await cur.fetchall()]
+
+
+async def _referenced_first(conn: AsyncConnection, tables: list[str]) -> list[str]:
+    """Order tables so a foreign key's target is inserted before its source.
+
+    Snapshot files carry tables in whatever order they were dumped, so the
+    ordering is derived from the live schema at restore time rather than trusted
+    from the file. Tables in a reference cycle keep their original position.
+    """
+    async with conn.cursor() as cur:
+        await cur.execute(
+            """SELECT src.relname, tgt.relname
+               FROM pg_constraint c
+               JOIN pg_class src ON src.oid = c.conrelid
+               JOIN pg_class tgt ON tgt.oid = c.confrelid
+               WHERE c.contype = 'f'""",
+        )
+        edges = [(s, t) for s, t in await cur.fetchall() if s in tables and t in tables]
+
+    ordered: list[str] = []
+    remaining = list(tables)
+    while remaining:
+        free = [
+            t
+            for t in remaining
+            if not any(s == t and tgt in remaining and tgt != t for s, tgt in edges)
+        ]
+        if not free:
+            free = remaining
+        ordered.extend(free)
+        remaining = [t for t in remaining if t not in free]
+    return ordered
 
 
 async def _db_already_populated(conn: AsyncConnection) -> bool:

--- a/shard_core/database/terminals.py
+++ b/shard_core/database/terminals.py
@@ -36,11 +36,6 @@ async def insert(conn: AsyncConnection, terminal: dict) -> dict:
         return await cur.fetchone()
 
 
-async def set_user_id_where_null(conn: AsyncConnection, user_id: str):
-    sql: LiteralString = "UPDATE terminals SET user_id = %s WHERE user_id IS NULL"
-    await conn.execute(sql, (user_id,))
-
-
 async def update(conn: AsyncConnection, id: str, data: dict) -> dict | None:
     set_clauses = []
     params = {"_id": id}

--- a/shard_core/database/terminals.py
+++ b/shard_core/database/terminals.py
@@ -28,12 +28,17 @@ async def get_by_name(conn: AsyncConnection, name: str) -> dict | None:
 
 
 async def insert(conn: AsyncConnection, terminal: dict) -> dict:
-    sql: LiteralString = """INSERT INTO terminals (id, name, icon, last_connection)
-        VALUES (%(id)s, %(name)s, %(icon)s, %(last_connection)s)
+    sql: LiteralString = """INSERT INTO terminals (id, name, icon, last_connection, user_id)
+        VALUES (%(id)s, %(name)s, %(icon)s, %(last_connection)s, %(user_id)s)
         RETURNING *"""
     async with conn.cursor(row_factory=dict_row) as cur:
         await cur.execute(sql, terminal)
         return await cur.fetchone()
+
+
+async def set_user_id_where_null(conn: AsyncConnection, user_id: str):
+    sql: LiteralString = "UPDATE terminals SET user_id = %s WHERE user_id IS NULL"
+    await conn.execute(sql, (user_id,))
 
 
 async def update(conn: AsyncConnection, id: str, data: dict) -> dict | None:

--- a/shard_core/database/tinydb_migration.py
+++ b/shard_core/database/tinydb_migration.py
@@ -72,8 +72,9 @@ async def migrate_tinydb_data():
     async with db_conn() as conn:
         await _migrate_kv_store(conn, data.get("_default", {}))
         await _migrate_identities(conn, data.get("identities", {}))
+        owner_id = await _ensure_owner_user(conn)
         await _migrate_installed_apps(conn, data.get("installed_apps", {}))
-        await _migrate_terminals(conn, data.get("terminals", {}))
+        await _migrate_terminals(conn, data.get("terminals", {}), owner_id)
         await _migrate_peers(conn, data.get("peers", {}))
         await _migrate_backups(conn, data.get("backups", {}))
         await _migrate_tours(conn, data.get("tours", {}))
@@ -121,15 +122,32 @@ async def _migrate_installed_apps(conn: AsyncConnection, records: dict):
     log.info(f"migrated {len(records)} installed apps")
 
 
-async def _migrate_terminals(conn: AsyncConnection, records: dict):
+async def _ensure_owner_user(conn: AsyncConnection) -> int | None:
+    """Terminals require a user (NOT NULL); create the owner from the just-
+    migrated default identity, mirroring the 0002 migration's backfill."""
+    cur = await conn.execute("SELECT id FROM users WHERE role = 'owner'")
+    row = await cur.fetchone()
+    if row:
+        return row[0]
+    cur = await conn.execute("""INSERT INTO users (username, display_name, email, role)
+           SELECT 'owner', COALESCE(name, 'Shard Owner'), email, 'owner'
+           FROM identities WHERE is_default = TRUE
+           RETURNING id""")
+    row = await cur.fetchone()
+    return row[0] if row else None
+
+
+async def _migrate_terminals(
+    conn: AsyncConnection, records: dict, owner_id: int | None
+):
     for record in records.values():
         filtered = _filter_keys(record, _TERMINAL_COLUMNS)
         filtered.setdefault("icon", "unknown")
         await conn.execute(
-            """INSERT INTO terminals (id, name, icon, last_connection)
-               VALUES (%(id)s, %(name)s, %(icon)s, %(last_connection)s)
+            """INSERT INTO terminals (id, name, icon, last_connection, user_id)
+               VALUES (%(id)s, %(name)s, %(icon)s, %(last_connection)s, %(user_id)s)
                ON CONFLICT (id) DO NOTHING""",
-            filtered,
+            {**filtered, "user_id": owner_id},
         )
     log.info(f"migrated {len(records)} terminals")
 

--- a/shard_core/database/users.py
+++ b/shard_core/database/users.py
@@ -1,35 +1,37 @@
 from typing import LiteralString
 
 from psycopg import AsyncConnection
-from psycopg.rows import dict_row
+from psycopg.rows import class_row
+
+from shard_core.data_model.user import User
 
 _UPDATABLE_COLUMNS = {"username", "display_name", "email", "role", "disabled"}
 
 
-async def get_by_id(conn: AsyncConnection, id: int) -> dict | None:
+async def get_by_id(conn: AsyncConnection, id: int) -> User | None:
     sql: LiteralString = "SELECT * FROM users WHERE id = %s"
-    async with conn.cursor(row_factory=dict_row) as cur:
+    async with conn.cursor(row_factory=class_row(User)) as cur:
         await cur.execute(sql, (id,))
         return await cur.fetchone()
 
 
-async def get_owner(conn: AsyncConnection) -> dict | None:
+async def get_owner(conn: AsyncConnection) -> User | None:
     sql: LiteralString = "SELECT * FROM users WHERE role = 'owner'"
-    async with conn.cursor(row_factory=dict_row) as cur:
+    async with conn.cursor(row_factory=class_row(User)) as cur:
         await cur.execute(sql)
         return await cur.fetchone()
 
 
-async def insert(conn: AsyncConnection, user: dict) -> dict:
+async def insert(conn: AsyncConnection, user: dict) -> User:
     sql: LiteralString = """INSERT INTO users (username, display_name, email, role)
         VALUES (%(username)s, %(display_name)s, %(email)s, %(role)s)
         RETURNING *"""
-    async with conn.cursor(row_factory=dict_row) as cur:
+    async with conn.cursor(row_factory=class_row(User)) as cur:
         await cur.execute(sql, user)
         return await cur.fetchone()
 
 
-async def update(conn: AsyncConnection, id: int, data: dict) -> dict | None:
+async def update(conn: AsyncConnection, id: int, data: dict) -> User | None:
     set_clauses = []
     params = {"_id": id}
     for key, value in data.items():
@@ -40,7 +42,7 @@ async def update(conn: AsyncConnection, id: int, data: dict) -> dict | None:
     if not set_clauses:
         return await get_by_id(conn, id)
     sql = f"UPDATE users SET {', '.join(set_clauses)} WHERE id = %(_id)s RETURNING *"
-    async with conn.cursor(row_factory=dict_row) as cur:
+    async with conn.cursor(row_factory=class_row(User)) as cur:
         await cur.execute(sql, params)
         return await cur.fetchone()
 

--- a/shard_core/database/users.py
+++ b/shard_core/database/users.py
@@ -3,8 +3,10 @@ from typing import LiteralString
 from psycopg import AsyncConnection
 from psycopg.rows import dict_row
 
+_UPDATABLE_COLUMNS = {"username", "display_name", "email", "role", "disabled"}
 
-async def get_by_id(conn: AsyncConnection, id: str) -> dict | None:
+
+async def get_by_id(conn: AsyncConnection, id: int) -> dict | None:
     sql: LiteralString = "SELECT * FROM users WHERE id = %s"
     async with conn.cursor(row_factory=dict_row) as cur:
         await cur.execute(sql, (id,))
@@ -19,11 +21,27 @@ async def get_owner(conn: AsyncConnection) -> dict | None:
 
 
 async def insert(conn: AsyncConnection, user: dict) -> dict:
-    sql: LiteralString = """INSERT INTO users (id, username, display_name, email, role)
-        VALUES (%(id)s, %(username)s, %(display_name)s, %(email)s, %(role)s)
+    sql: LiteralString = """INSERT INTO users (username, display_name, email, role)
+        VALUES (%(username)s, %(display_name)s, %(email)s, %(role)s)
         RETURNING *"""
     async with conn.cursor(row_factory=dict_row) as cur:
         await cur.execute(sql, user)
+        return await cur.fetchone()
+
+
+async def update(conn: AsyncConnection, id: int, data: dict) -> dict | None:
+    set_clauses = []
+    params = {"_id": id}
+    for key, value in data.items():
+        if key not in _UPDATABLE_COLUMNS:
+            raise ValueError(f"Invalid column: {key}")
+        set_clauses.append(f"{key} = %({key})s")
+        params[key] = value
+    if not set_clauses:
+        return await get_by_id(conn, id)
+    sql = f"UPDATE users SET {', '.join(set_clauses)} WHERE id = %(_id)s RETURNING *"
+    async with conn.cursor(row_factory=dict_row) as cur:
+        await cur.execute(sql, params)
         return await cur.fetchone()
 
 

--- a/shard_core/database/users.py
+++ b/shard_core/database/users.py
@@ -1,0 +1,34 @@
+from typing import LiteralString
+
+from psycopg import AsyncConnection
+from psycopg.rows import dict_row
+
+
+async def get_by_id(conn: AsyncConnection, id: str) -> dict | None:
+    sql: LiteralString = "SELECT * FROM users WHERE id = %s"
+    async with conn.cursor(row_factory=dict_row) as cur:
+        await cur.execute(sql, (id,))
+        return await cur.fetchone()
+
+
+async def get_owner(conn: AsyncConnection) -> dict | None:
+    sql: LiteralString = "SELECT * FROM users WHERE role = 'owner'"
+    async with conn.cursor(row_factory=dict_row) as cur:
+        await cur.execute(sql)
+        return await cur.fetchone()
+
+
+async def insert(conn: AsyncConnection, user: dict) -> dict:
+    sql: LiteralString = """INSERT INTO users (id, username, display_name, email, role)
+        VALUES (%(id)s, %(username)s, %(display_name)s, %(email)s, %(role)s)
+        RETURNING *"""
+    async with conn.cursor(row_factory=dict_row) as cur:
+        await cur.execute(sql, user)
+        return await cur.fetchone()
+
+
+async def count(conn: AsyncConnection) -> int:
+    sql: LiteralString = "SELECT COUNT(*) FROM users"
+    async with conn.cursor() as cur:
+        await cur.execute(sql)
+        return (await cur.fetchone())[0]

--- a/shard_core/service/user.py
+++ b/shard_core/service/user.py
@@ -1,19 +1,22 @@
 import logging
 
 from shard_core.data_model.identity import Identity
+from shard_core.data_model.user import Role, User
 from shard_core.database.connection import db_conn
 from shard_core.database import identities as db_identities
-from shard_core.database import terminals as db_terminals
 from shard_core.database import users as db_users
 
 log = logging.getLogger(__name__)
 
 
-async def ensure_owner_user():
-    """Ensure the shard owner exists as a user and all terminals are bound to a user.
+async def ensure_owner_user() -> User:
+    """Ensure the shard owner exists as a user.
 
-    The owner user is derived from the default identity; its id doubles as the
-    OIDC subject. Idempotent — called on every startup.
+    The owner user is created by the 0002 migration on shards that already
+    have an identity; on fresh shards it is created here, right after the
+    default identity. Also backfills the email for migration-created owners —
+    OIDC clients need an email-shaped identifier to auto-provision accounts.
+    Idempotent — called on every startup, before any pairing can happen.
     """
     async with db_conn() as conn:
         owner = await db_users.get_owner(conn)
@@ -23,12 +26,17 @@ async def ensure_owner_user():
             owner = await db_users.insert(
                 conn,
                 {
-                    "id": identity.id,
                     "username": "owner",
                     "display_name": identity.name,
                     "email": identity.email or f"owner@{identity.domain}",
-                    "role": "owner",
+                    "role": Role.OWNER.value,
                 },
             )
             log.info(f"created owner user {owner['id']}")
-        await db_terminals.set_user_id_where_null(conn, owner["id"])
+        elif owner["email"] is None:
+            identity_row = await db_identities.get_default(conn)
+            identity = Identity(**identity_row)
+            owner = await db_users.update(
+                conn, owner["id"], {"email": f"owner@{identity.domain}"}
+            )
+    return User(**owner)

--- a/shard_core/service/user.py
+++ b/shard_core/service/user.py
@@ -1,0 +1,34 @@
+import logging
+
+from shard_core.data_model.identity import Identity
+from shard_core.database.connection import db_conn
+from shard_core.database import identities as db_identities
+from shard_core.database import terminals as db_terminals
+from shard_core.database import users as db_users
+
+log = logging.getLogger(__name__)
+
+
+async def ensure_owner_user():
+    """Ensure the shard owner exists as a user and all terminals are bound to a user.
+
+    The owner user is derived from the default identity; its id doubles as the
+    OIDC subject. Idempotent — called on every startup.
+    """
+    async with db_conn() as conn:
+        owner = await db_users.get_owner(conn)
+        if owner is None:
+            identity_row = await db_identities.get_default(conn)
+            identity = Identity(**identity_row)
+            owner = await db_users.insert(
+                conn,
+                {
+                    "id": identity.id,
+                    "username": "owner",
+                    "display_name": identity.name,
+                    "email": identity.email or f"owner@{identity.domain}",
+                    "role": "owner",
+                },
+            )
+            log.info(f"created owner user {owner['id']}")
+        await db_terminals.set_user_id_where_null(conn, owner["id"])

--- a/shard_core/service/user.py
+++ b/shard_core/service/user.py
@@ -32,11 +32,11 @@ async def ensure_owner_user() -> User:
                     "role": Role.OWNER.value,
                 },
             )
-            log.info(f"created owner user {owner['id']}")
-        elif owner["email"] is None:
+            log.info(f"created owner user {owner.id}")
+        elif owner.email is None:
             identity_row = await db_identities.get_default(conn)
             identity = Identity(**identity_row)
             owner = await db_users.update(
-                conn, owner["id"], {"email": f"owner@{identity.domain}"}
+                conn, owner.id, {"email": f"owner@{identity.domain}"}
             )
-    return User(**owner)
+    return owner

--- a/shard_core/web/public/pair.py
+++ b/shard_core/web/public/pair.py
@@ -42,7 +42,7 @@ async def add_terminal(code: str, terminal: InputTerminal, response: Response):
     async with db_conn() as conn:
         # the owner user always exists here — created at startup, before pairing
         owner = await db_users.get_owner(conn)
-        new_terminal = Terminal.create(terminal.name, user_id=owner["id"])
+        new_terminal = Terminal.create(terminal.name, user_id=owner.id)
         await db_terminals.insert(conn, new_terminal.model_dump())
         is_first_terminal = await db_terminals.count(conn) == 1
 

--- a/shard_core/web/public/pair.py
+++ b/shard_core/web/public/pair.py
@@ -40,10 +40,9 @@ async def add_terminal(code: str, terminal: InputTerminal, response: Response):
         ) from e
 
     async with db_conn() as conn:
+        # the owner user always exists here — created at startup, before pairing
         owner = await db_users.get_owner(conn)
-        new_terminal = Terminal.create(
-            terminal.name, user_id=owner["id"] if owner else None
-        )
+        new_terminal = Terminal.create(terminal.name, user_id=owner["id"])
         await db_terminals.insert(conn, new_terminal.model_dump())
         is_first_terminal = await db_terminals.count(conn) == 1
 

--- a/shard_core/web/public/pair.py
+++ b/shard_core/web/public/pair.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, HTTPException, status, Response
 from shard_core.database.connection import db_conn
 from shard_core.database import terminals as db_terminals
 from shard_core.database import identities as db_identities
+from shard_core.database import users as db_users
 from shard_core.data_model.identity import Identity
 from shard_core.data_model.terminal import Terminal, InputTerminal
 from shard_core.service import pairing
@@ -38,8 +39,11 @@ async def add_terminal(code: str, terminal: InputTerminal, response: Response):
             detail="This pairing code is not valid.",
         ) from e
 
-    new_terminal = Terminal.create(terminal.name)
     async with db_conn() as conn:
+        owner = await db_users.get_owner(conn)
+        new_terminal = Terminal.create(
+            terminal.name, user_id=owner["id"] if owner else None
+        )
         await db_terminals.insert(conn, new_terminal.model_dump())
         is_first_terminal = await db_terminals.count(conn) == 1
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -218,9 +218,10 @@ async def app_client(mocker) -> AsyncGenerator[AsyncClient]:
     # Initialize the database (migrations + pool) and create default identity
     await database.init_database()
     try:
-        from shard_core.service import identity
+        from shard_core.service import identity, user
 
         await identity.init_default_identity()
+        await user.ensure_owner_user()
 
         app = app_factory.create_app()
 

--- a/tests/test_db_snapshot.py
+++ b/tests/test_db_snapshot.py
@@ -12,7 +12,7 @@ from shard_core.database.db_snapshot import (
 from tests.conftest import settings_override
 
 _APP_TABLES = (
-    "identities, terminals, installed_apps, peers, backups, tours, "
+    "identities, users, terminals, installed_apps, peers, backups, tours, "
     "app_usage_tracks, kv_store"
 )
 
@@ -27,8 +27,16 @@ async def _seed_shard_state():
     async with db_conn() as conn:
         await conn.execute("""INSERT INTO identities (id, name, private_key, is_default)
                VALUES ('shard-id-abc', 'default', 'PRIVATE-KEY-PEM', TRUE)""")
+        owner_id = await (
+            await conn.execute(
+                """INSERT INTO users (username, display_name, email, role)
+               VALUES ('owner', 'Shard Owner', 'owner@shard.test', 'owner')
+               RETURNING id"""
+            )
+        ).fetchone()
         await conn.execute(
-            "INSERT INTO terminals (id, name, icon) VALUES ('term-1', 'laptop', 'x')"
+            "INSERT INTO terminals (id, name, icon, user_id) VALUES ('term-1', 'laptop', 'x', %s)",
+            (owner_id[0],),
         )
         await conn.execute(
             """INSERT INTO installed_apps (name, installation_reason, status)

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,6 +1,6 @@
 from httpx import AsyncClient
 
-from shard_core.data_model.terminal import Terminal
+from shard_core.data_model.user import Role, User
 from shard_core.database.connection import db_conn
 from shard_core.database import identities as db_identities
 from shard_core.database import terminals as db_terminals
@@ -12,16 +12,15 @@ from tests.util import pair_new_terminal
 async def test_ensure_owner_user_creates_owner_from_default_identity(db):
     default_identity = await identity.init_default_identity()
 
-    await user.ensure_owner_user()
+    owner = await user.ensure_owner_user()
 
-    async with db_conn() as conn:
-        owner = await db_users.get_owner(conn)
-    assert owner["id"] == default_identity.id
-    assert owner["role"] == "owner"
-    assert owner["username"] == "owner"
-    assert owner["display_name"] == default_identity.name
-    assert owner["email"] == f"owner@{default_identity.domain}"
-    assert owner["disabled"] is False
+    assert isinstance(owner, User)
+    assert isinstance(owner.id, int)
+    assert owner.role == Role.OWNER
+    assert owner.username == "owner"
+    assert owner.display_name == default_identity.name
+    assert owner.email == f"owner@{default_identity.domain}"
+    assert owner.disabled is False
 
 
 async def test_ensure_owner_user_keeps_identity_email(db):
@@ -31,35 +30,40 @@ async def test_ensure_owner_user_keeps_identity_email(db):
             conn, default_identity.id, {"email": "max@freeshard.net"}
         )
 
-    await user.ensure_owner_user()
+    owner = await user.ensure_owner_user()
 
-    async with db_conn() as conn:
-        owner = await db_users.get_owner(conn)
-    assert owner["email"] == "max@freeshard.net"
+    assert owner.email == "max@freeshard.net"
 
 
 async def test_ensure_owner_user_is_idempotent(db):
     await identity.init_default_identity()
 
-    await user.ensure_owner_user()
-    await user.ensure_owner_user()
+    first = await user.ensure_owner_user()
+    second = await user.ensure_owner_user()
 
+    assert first.id == second.id
     async with db_conn() as conn:
         assert await db_users.count(conn) == 1
 
 
-async def test_ensure_owner_user_backfills_terminal_user_id(db):
-    await identity.init_default_identity()
-    legacy_terminal = Terminal.create("legacy")
+async def test_ensure_owner_user_backfills_missing_email(db):
+    """Migration-created owners (existing shards) start without a synthesized
+    email; ensure_owner_user fills it on the next startup."""
+    default_identity = await identity.init_default_identity()
     async with db_conn() as conn:
-        await db_terminals.insert(conn, legacy_terminal.model_dump())
+        await db_users.insert(
+            conn,
+            {
+                "username": "owner",
+                "display_name": default_identity.name,
+                "email": None,
+                "role": Role.OWNER.value,
+            },
+        )
 
-    await user.ensure_owner_user()
+    owner = await user.ensure_owner_user()
 
-    async with db_conn() as conn:
-        owner = await db_users.get_owner(conn)
-        row = await db_terminals.get_by_id(conn, legacy_terminal.id)
-    assert row["user_id"] == owner["id"]
+    assert owner.email == f"owner@{default_identity.domain}"
 
 
 async def test_pairing_binds_terminal_to_owner(app_client: AsyncClient):

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,0 +1,71 @@
+from httpx import AsyncClient
+
+from shard_core.data_model.terminal import Terminal
+from shard_core.database.connection import db_conn
+from shard_core.database import identities as db_identities
+from shard_core.database import terminals as db_terminals
+from shard_core.database import users as db_users
+from shard_core.service import identity, user
+from tests.util import pair_new_terminal
+
+
+async def test_ensure_owner_user_creates_owner_from_default_identity(db):
+    default_identity = await identity.init_default_identity()
+
+    await user.ensure_owner_user()
+
+    async with db_conn() as conn:
+        owner = await db_users.get_owner(conn)
+    assert owner["id"] == default_identity.id
+    assert owner["role"] == "owner"
+    assert owner["username"] == "owner"
+    assert owner["display_name"] == default_identity.name
+    assert owner["email"] == f"owner@{default_identity.domain}"
+    assert owner["disabled"] is False
+
+
+async def test_ensure_owner_user_keeps_identity_email(db):
+    default_identity = await identity.init_default_identity()
+    async with db_conn() as conn:
+        await db_identities.update(
+            conn, default_identity.id, {"email": "max@freeshard.net"}
+        )
+
+    await user.ensure_owner_user()
+
+    async with db_conn() as conn:
+        owner = await db_users.get_owner(conn)
+    assert owner["email"] == "max@freeshard.net"
+
+
+async def test_ensure_owner_user_is_idempotent(db):
+    await identity.init_default_identity()
+
+    await user.ensure_owner_user()
+    await user.ensure_owner_user()
+
+    async with db_conn() as conn:
+        assert await db_users.count(conn) == 1
+
+
+async def test_ensure_owner_user_backfills_terminal_user_id(db):
+    await identity.init_default_identity()
+    legacy_terminal = Terminal.create("legacy")
+    async with db_conn() as conn:
+        await db_terminals.insert(conn, legacy_terminal.model_dump())
+
+    await user.ensure_owner_user()
+
+    async with db_conn() as conn:
+        owner = await db_users.get_owner(conn)
+        row = await db_terminals.get_by_id(conn, legacy_terminal.id)
+    assert row["user_id"] == owner["id"]
+
+
+async def test_pairing_binds_terminal_to_owner(app_client: AsyncClient):
+    await pair_new_terminal(app_client, "T1")
+
+    async with db_conn() as conn:
+        owner = await db_users.get_owner(conn)
+        terminal = await db_terminals.get_by_name(conn, "T1")
+    assert terminal["user_id"] == owner["id"]

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -59,7 +59,7 @@ async def test_ensure_owner_user_backfills_missing_email(db):
                 "email": None,
                 "role": Role.OWNER.value,
             },
-        )
+        )  # simulates the 0002 SQL backfill (no synthesized email)
 
     owner = await user.ensure_owner_user()
 
@@ -72,4 +72,4 @@ async def test_pairing_binds_terminal_to_owner(app_client: AsyncClient):
     async with db_conn() as conn:
         owner = await db_users.get_owner(conn)
         terminal = await db_terminals.get_by_name(conn, "T1")
-    assert terminal["user_id"] == owner["id"]
+    assert terminal["user_id"] == owner.id


### PR DESCRIPTION
Phase 1 of the multi-user identity rollout ([design docs in the KB](https://github.com/FreeshardBase/freeshard/), PoC verdict 2026-06-12): the invisible identity substrate that the embedded OIDC provider (phase 2, follow-up PR) builds on.

## What this does

- **New `users` table** (numeric BIGSERIAL ids, `user_role` enum, `User` model in `data_model/user.py`) — every shard now has an owner user derived from the default identity. The stringified numeric id becomes the OIDC `sub` in phase 2a; the shard's identity hash id stays what it is — the shard's identity, not the person's.
- **`terminals.user_id` (NOT NULL)** — every terminal session is bound to a user. The migration itself creates the owner and binds existing terminals; new pairings bind at creation.
- **`ensure_owner_user()`** runs at every startup (after `init_default_identity()`, before serving): creates the owner on fresh shards (where the migration ran against empty tables) and backfills the synthesized email for migration-created owners. Idempotent.
- **Email**: owner email = identity email, or synthesized `owner@<shard-domain>` — OIDC clients (e.g. Immich) require an email-shaped identifier to auto-provision accounts (PoC finding).

No UX or API behavior change. Existing sessions stay valid (cookie/JWT mechanism untouched).

## Not in this PR

- OIDC provider endpoints (phase 2a, next PR — stacked on this one)
- Client registration at app install + template vars (phase 2b)
- Login page, members, grants (phases 3–4)

## Recommended reading order

1. `migrations/shard-core-0002-users.sql` — schema
2. `shard_core/database/users.py` — new DB module (conn-first pattern)
3. `shard_core/database/terminals.py` — insert gains `user_id`, backfill helper
4. `shard_core/data_model/terminal.py` — `Terminal.user_id` (optional, backward compatible)
5. `shard_core/service/user.py` — `ensure_owner_user()`
6. `shard_core/web/public/pair.py` — new terminals bind to owner
7. `shard_core/app_factory.py` — lifespan wiring
8. `tests/conftest.py`, `tests/test_users.py` — fixture wiring + coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Test status

Full suite on the stacked branch (this + phase 2a): **190 passed, 1 failed** — `test_app_lifecycle.py::test_app_starts_and_stops`, which fails identically on clean `main` on this machine (pre-existing, container-start timing), not a regression from this branch.


---
Review round 1 addressed: numeric ids, role enum, NOT NULL binding, `User` data model, strict owner lookup in pairing.
