### PR TITLE
chore: sync data_model types from freeshard-controller

### DIFF
--- a/shard_core/data_model/backend/diagnostic_model.py
+++ b/shard_core/data_model/backend/diagnostic_model.py
@@ -1,0 +1,80 @@
+# DO NOT MODIFY - copied from freeshard-controller
+
+import uuid
+from datetime import datetime
+from enum import StrEnum, auto
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class DiagnosticStatus(StrEnum):
+    ACTIVE = auto()
+    CLOSED = auto()
+    EXPIRED = auto()
+
+
+class DiagnosticEventType(StrEnum):
+    PROBE = auto()
+    NOTE = auto()
+    PROMOTE = auto()
+
+
+MIN_LEVEL = 1
+MAX_LEVEL = 3
+
+
+class DiagnosticEvent(BaseModel):
+    timestamp: datetime
+    event_type: DiagnosticEventType
+    payload: dict[str, Any]
+
+
+class DiagnosticDb(BaseModel):
+    id: uuid.UUID
+    shard_id: int
+    opened_by: int
+    level: int
+    status: DiagnosticStatus
+    opened_at: datetime
+    expires_at: datetime
+    closed_at: datetime | None = None
+    findings: str | None = None
+
+
+class DiagnosticResponse(DiagnosticDb):
+    events: list[DiagnosticEvent] = Field(default_factory=list)
+
+
+class OpenDiagnosticRequest(BaseModel):
+    level: int = Field(ge=MIN_LEVEL, le=MAX_LEVEL)
+    ttl_minutes: int = Field(ge=1, le=720)
+
+
+class PromoteRequest(BaseModel):
+    level: int = Field(ge=MIN_LEVEL, le=MAX_LEVEL)
+
+
+class NoteRequest(BaseModel):
+    text: str = Field(min_length=1, max_length=4000)
+
+
+class FindingsRequest(BaseModel):
+    markdown: str = Field(min_length=1)
+
+
+class ProbeRequest(BaseModel):
+    name: str
+    params: dict[str, Any] = Field(default_factory=dict)
+
+
+class MenuEntry(BaseModel):
+    name: str
+    description: str
+    required_level: int
+    available: bool  # required_level <= diagnostic.level
+
+
+class ProbeResult(BaseModel):
+    name: str
+    output: str

--- a/shard_core/data_model/backend/permission_model.py
+++ b/shard_core/data_model/backend/permission_model.py
@@ -23,6 +23,8 @@ class Permission(StrEnum):
     MODIFY_SETTING = auto()
     SUPPORT_SHARD = auto()
     SSH_SHARD = auto()
+    OPEN_DIAGNOSTIC = auto()
+    RUN_DIAGNOSTIC = auto()
 
 
 class PermissionHolder(BaseModel):

--- a/shard_core/data_model/backend/settings_model.py
+++ b/shard_core/data_model/backend/settings_model.py
@@ -12,6 +12,7 @@ from .shard_model import Cloud
 class SettingKey(StrEnum):
     MIN_NR_OF_STANDBY_SHARDS = auto()
     NEW_INSTANCE_SIZE = auto()
+    NEW_INSTANCE_IMAGE = auto()
     AUTO_PROVISIONING_ENABLED = auto()
     NEW_SHARD_CORE_VERSION = auto()
     TRIAL_MAX_VM_SIZE = auto()

--- a/shard_core/data_model/backend/subscription_model.py
+++ b/shard_core/data_model/backend/subscription_model.py
@@ -61,7 +61,7 @@ class SubscribeResponse(BaseModel):
 
 
 class ResizeResponse(BaseModel):
-    approval_url: str | None = None
     expected_price_cents: int | None = None
     current_price_cents: int | None = None
     subscription_id: str | None = None
+    plan_id: str | None = None


### PR DESCRIPTION
## What

Re-syncs `shard_core/data_model/backend/` from freeshard-controller main (0.23.0) via `just get-types`. These files are `# DO NOT MODIFY - copied from freeshard-controller`.

## Why

The controller shipped its diagnostic system (`open_diagnostic`, `run_diagnostic` permissions) and shard_core's vendored copy was stale. At boot, `refresh_profile()` strict-validates the `/api/shards/self` response into `ShardResponse`; the two unknown permission enum values made pydantic reject it, so **`refresh_profile()` fell back to `profile=None`** — observed live:

```
ERROR shard_core.app_factory - could not refresh profile: 2 validation errors for ShardResponse
permissions.5  Input should be '...' [input_value='run_diagnostic']
permissions.14 Input should be '...' [input_value='open_diagnostic']
```

On a **hosted** shard `profile=None` silently breaks daily backups (no controller SAS URL → `BackupStartFailedError`) and opens VM-size gates. shard_core never reads `profile.permissions` itself — the field is parse-only — so no logic change is needed beyond accepting the values.

## Changes (all mechanical sync)

| File | Change |
|---|---|
| `permission_model.py` | +`OPEN_DIAGNOSTIC`, +`RUN_DIAGNOSTIC` |
| `settings_model.py` | +`NEW_INSTANCE_IMAGE` setting key |
| `subscription_model.py` | `ResizeResponse`: drop `approval_url`, add `plan_id` |
| `diagnostic_model.py` | new — diagnostic system types |

Verified `ResizeResponse.approval_url` is unused in shard_core; all backend modules import cleanly; `test_model.py` passes.

## Follow-up

- **Merged ≠ shipped.** Reaches shards only via a release + controller rollout; fold into the pending pause-tier release.
- A CI drift-guard for these vendored types (like the controller's `checkson-drift.yml`) needs a read token for the private controller repo — proposed separately.
- Robustness: strict enum means the *next* controller permission breaks profile refresh again. Worth a controller-side change to tolerate unknown permission values (shard ignores them). Separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)