### PR TITLE
ci: drift check for vendored controller data models

### DIFF
--- a/.github/workflows/types-drift.yml
+++ b/.github/workflows/types-drift.yml
@@ -1,0 +1,43 @@
+name: Backend types drift check
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/types-drift.yml'
+      - 'shard_core/data_model/backend/**'
+      - 'justfile'
+  schedule:
+    # Daily: surface drift when freeshard-controller advances with no PR here.
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+jobs:
+  drift-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout shard_core
+        uses: actions/checkout@v4
+
+      - name: Checkout freeshard-controller (source of truth)
+        uses: actions/checkout@v4
+        with:
+          repository: FreeshardBase/freeshard-controller
+          ref: main
+          token: ${{ secrets.CONTROLLER_RO_TOKEN }}
+          path: freeshard-controller
+
+      - name: Install just
+        uses: extractions/setup-just@v2
+
+      - name: Resync vendored models from controller main
+        run: |
+          just --set SOURCE_DIR \
+            "freeshard-controller/freeshard-controller-backend/freeshard_controller/data_model" \
+            get-types
+
+      - name: Fail on drift
+        run: |
+          if ! git diff --exit-code shard_core/data_model/backend; then
+            echo "::error::shard_core/data_model/backend is out of sync with freeshard-controller main. Run 'just get-types' (with ../freeshard-controller checked out) and commit the result."
+            exit 1
+          fi

--- a/.github/workflows/types-drift.yml
+++ b/.github/workflows/types-drift.yml
@@ -1,14 +1,10 @@
 name: Backend types drift check
 
 on:
+  # All PRs, not path-filtered: the release/version-bump PR does not touch
+  # backend/, so a path filter would skip exactly the PR that ships. Running
+  # on every PR guarantees main is drift-free at each merge.
   pull_request:
-    paths:
-      - '.github/workflows/types-drift.yml'
-      - 'shard_core/data_model/backend/**'
-      - 'justfile'
-  schedule:
-    # Daily: surface drift when freeshard-controller advances with no PR here.
-    - cron: '0 6 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## What

Adds `.github/workflows/types-drift.yml` — CI guard that fails when `shard_core/data_model/backend/` drifts from its source in the private freeshard-controller repo.

Companion to #150 (the manual resync that this check would have forced earlier).

## Why

`shard_core/data_model/backend/` is `# DO NOT MODIFY - copied from freeshard-controller` via `just get-types`. Nothing catches a stale copy today, so a controller-side model addition silently breaks `refresh_profile()` at boot (strict pydantic rejects unknown enum values → `profile=None` → backups fail on hosted shards). That's exactly the incident #150 fixes.

## How it works

Mirrors the controller's own `checkson-drift.yml`, adapted for the **cross-repo** case (source is a separate private repo, not co-located):

1. Checkout shard_core + checkout `FreeshardBase/freeshard-controller@main` (via token).
2. Re-run `get-types` against the controller checkout (`just --set SOURCE_DIR …`).
3. `git diff --exit-code shard_core/data_model/backend` — fail on any diff.

Triggers: **every PR** (no path filter — the release/version-bump PR does not touch `backend/`, so a path filter would skip exactly the PR that ships) plus manual `workflow_dispatch`. Compares against controller `main` HEAD. No scheduled run: a failed cron on `main` is low-visibility noise; PRs are the path every release goes through and are actionable.

Verified locally: a faithful `get-types` run against controller `main` (0.23.0) is byte-identical to #150's synced tree, so this check goes green the moment #150 merges.

## ⚠️ Action required before this can merge — @max-tet

Needs an Actions secret **`CONTROLLER_RO_TOKEN`**: a fine-grained PAT (or GitHub App token) with **`contents: read`** on `FreeshardBase/freeshard-controller`. The private-repo checkout — and therefore this job — **fails until the secret exists**. That's why this PR is a **draft**: add the secret, re-run the check, then it's mergeable.

Order: land #150 first (fixes current drift), add the secret, then this guard goes green and stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
