### PR TITLE
chore(tooling): sync uv.lock on set-version + document drift-check recipe

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -125,6 +125,7 @@ Host-side: `settings().path_root_host` (typically `/home/shard`).
 - `@field_validator` for single-field, `@model_validator(mode="after")` for cross-field
 - `@computed_field` @property for derived values (e.g., `Identity.domain`, `Identity.public_key`)
 - Models in `data_model/backend/` are copied from freeshard-controller — do not edit directly, use `just get-types`
+  - The CI `drift-check` job re-runs `get-types` against controller **`origin/main`** and fails if the diff is non-empty. To fix drift: check out the controller at `origin/main` (a local `main` may be many commits behind — `git fetch` first), then run `just SOURCE_DIR=<abs path to controller>/freeshard-controller-backend/freeshard_controller/data_model get-types` from this repo and commit only the regenerated files. Never hand-edit them.
 
 ## Important Notes
 

--- a/justfile
+++ b/justfile
@@ -24,7 +24,8 @@ get-types:
 
 @set-version version:
     just _set-version-files {{version}}
-    git add .
+    uv lock
+    git add pyproject.toml docker-compose.yml uv.lock
     git commit -m "set version to {{version}}"
     echo "Version set to {{version}} and committed"
 


### PR DESCRIPTION
Two small maintenance fixes to the `just` tooling and its docs, both surfaced while working on #152.

## 1. `just set-version` leaves `uv.lock` stale (`justfile`)

`_set-version-files` bumps the version in `pyproject.toml` (and the `docker-compose.yml` image tag) but not `uv.lock`, which embeds the `shard-core` package's own version. The recipe's follow-up `git add .` then commits the stale lock, so the lockfile trails one version behind on **every** bump — reappearing as one-line churn the next time anyone runs `uv`.

- Add `uv lock` before staging so the lock tracks `pyproject.toml` in the same commit (`uv lock` rewrites only lockfile metadata — no venv install, unlike `uv sync`).
- Scope the commit to the three files `set-version` actually touches instead of `git add .`, so stray untracked local state (worktree dirs, `.claude/`, scratch files) can't be swept into a version commit.

## 2. Document the `drift-check` fix procedure (`agents.md`)

The CI `drift-check` job fails when `shard_core/data_model/backend/` diverges from freeshard-controller `main`. Fixing it correctly is non-obvious: the job compares against controller **`origin/main`**, but a local controller checkout is often many commits behind, and `just get-types` reads a hardcoded `SOURCE_DIR`. One bullet under the existing `data_model/backend/` note records the recipe.

Docs + tooling only. No shard_core code or CI change.

## Recommended reading order

1. `justfile` — the `set-version` lockfile fix
2. `agents.md` — the drift-check procedure note

🤖 Generated with [Claude Code](https://claude.com/claude-code)
