### PR TITLE
fix: make uninstall crash-safe (resume interrupted uninstalls on boot)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,7 @@ core/
 
 .pytest_cache
 .ruff_cache
+
+# local agent state
+.serena/
+.worktrees/

--- a/agents.md
+++ b/agents.md
@@ -102,6 +102,20 @@ Blinker-based async signals defined in `util/signals.py`. DB-writing handlers ar
 4. `docker-compose up -d` via subprocess
 5. Status updated in PostgreSQL
 
+The task queue is in-memory only, so a restart loses whatever it held. Uninstall is
+made crash-safe by `reconcile_interrupted_uninstalls()`, a lifespan step that
+re-enqueues an uninstall for every row still in `UNINSTALLATION_QUEUED` or
+`UNINSTALLING`. `_uninstall_app` asserts no status and tolerates missing files, so
+resuming it is idempotent — the row is the tombstone. The step only enqueues; the
+worker starts later in the lifespan, and awaiting task completion before then
+deadlocks. Install and reinstall have no equivalent reconciliation yet.
+
+Apps in `NOT_ROUTABLE_STATUS` (`app_installation/util.py`) get no Traefik router:
+`INSTALLATION_QUEUED`, `ERROR`, `UNINSTALLATION_QUEUED`, `UNINSTALLING`. Their files
+are either not there yet or already being removed, and `write_traefik_dyn_config`
+runs inside the lifespan — an unfiltered status whose metadata is missing raises
+`MetadataNotFound` and takes down the boot.
+
 ### Async Fire-and-Forget
 Long operations use `asyncio.create_task()` with done callbacks. No thread pools.
 

--- a/shard_core/app_factory.py
+++ b/shard_core/app_factory.py
@@ -84,6 +84,7 @@ async def lifespan(_):
     await render_all_docker_compose_templates()
     await app_installation.login_docker_registries()
     await migration.migrate()
+    await app_installation.reconcile_interrupted_uninstalls()
     await app_installation.refresh_init_apps()
     await backup.ensure_backup_passphrase()
     try:

--- a/shard_core/service/app_installation/__init__.py
+++ b/shard_core/service/app_installation/__init__.py
@@ -99,6 +99,25 @@ async def reinstall_app(name: str):
     log.info(f"created {reinstallation_task}")
 
 
+async def reconcile_interrupted_uninstalls():
+    """Re-enqueue uninstalls that a previous process did not finish.
+
+    The task queue only lives in memory, so a stop between the status flip and the
+    row delete strands the row in UNINSTALLING with nothing left to resume it.
+    Enqueue only — the worker is started later in the lifespan.
+    """
+    async with db_conn() as conn:
+        all_apps = await db_installed_apps.get_all(conn)
+
+    for app in all_apps:
+        if app["status"] not in (Status.UNINSTALLATION_QUEUED, Status.UNINSTALLING):
+            continue
+        worker.installation_worker.enqueue(
+            worker.InstallationTask(app_name=app["name"], task_type="uninstall")
+        )
+        log.info(f"resuming interrupted uninstallation of {app['name']}")
+
+
 async def refresh_init_apps():
     try:
         await database.get_value(STORE_KEY_INITIAL_APPS_INSTALLED)

--- a/shard_core/service/app_installation/util.py
+++ b/shard_core/service/app_installation/util.py
@@ -20,6 +20,16 @@ from shard_core.util import signals
 
 log = logging.getLogger(__name__)
 
+# Apps in these statuses get no traefik router. Their files are either not in place
+# yet or already being removed, so get_app_metadata() may raise — and an app that is
+# half-installed or on its way out should not receive traffic anyway.
+NOT_ROUTABLE_STATUS = {
+    Status.INSTALLATION_QUEUED,
+    Status.ERROR,
+    Status.UNINSTALLATION_QUEUED,
+    Status.UNINSTALLING,
+}
+
 
 async def get_app_from_db(app_name: str) -> InstalledApp:
     async with db_conn() as conn:
@@ -105,12 +115,10 @@ async def write_traefik_dyn_config():
     async with db_conn() as conn:
         all_apps = await db_installed_apps.get_all(conn)
     installed_apps = [
-        InstalledApp(**a) for a in all_apps if a["status"] != Status.INSTALLATION_QUEUED
+        InstalledApp(**a) for a in all_apps if a["status"] not in NOT_ROUTABLE_STATUS
     ]
     app_infos = [
-        AppInfo(get_app_metadata(a.name), installed_app=a)
-        for a in installed_apps
-        if a.status != Status.ERROR
+        AppInfo(get_app_metadata(a.name), installed_app=a) for a in installed_apps
     ]
 
     async with db_conn() as conn:

--- a/tests/test_app_installation.py
+++ b/tests/test_app_installation.py
@@ -4,6 +4,10 @@ from docker.errors import NotFound
 from fastapi import status
 from httpx import AsyncClient
 
+from shard_core.data_model.app_meta import InstallationReason, InstalledApp, Status
+from shard_core.database import installed_apps as db_installed_apps
+from shard_core.database.connection import db_conn
+from shard_core.service.app_tools import get_installed_apps_path
 from tests.util import (
     wait_until_app_installed,
     mock_app_store_path,
@@ -110,6 +114,26 @@ async def test_uninstall_running_app(api_client: AsyncClient):
 
     with pytest.raises(NotFound):
         docker_client.containers.get(app_name)
+
+
+async def test_uninstall_app_without_compose_file(api_client: AsyncClient):
+    app_name = "mock_app"
+    async with db_conn() as conn:
+        await db_installed_apps.insert(
+            conn,
+            InstalledApp(
+                name=app_name,
+                installation_reason=InstallationReason.CUSTOM,
+                status=Status.ERROR,
+            ).model_dump(),
+        )
+    (get_installed_apps_path() / app_name).mkdir(parents=True, exist_ok=True)
+
+    response = await api_client.delete(f"protected/apps/{app_name}")
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+
+    await wait_until_app_uninstalled(api_client, app_name)
+    assert not (get_installed_apps_path() / app_name).exists()
 
 
 async def test_install_custom_app(api_client: AsyncClient):

--- a/tests/test_app_uninstall_crash_recovery.py
+++ b/tests/test_app_uninstall_crash_recovery.py
@@ -1,0 +1,63 @@
+import importlib
+
+import pytest
+from asgi_lifespan import LifespanManager
+
+from shard_core import app_factory
+from shard_core.data_model.app_meta import InstallationReason, InstalledApp, Status
+from shard_core.database import database
+from shard_core.database import installed_apps as db_installed_apps
+from shard_core.database.connection import db_conn
+from shard_core.service import app_installation, telemetry, websocket
+from tests.util import docker_network_portal, retry_async
+
+pytest_plugins = ("pytest_asyncio",)
+pytestmark = pytest.mark.asyncio
+
+config_override = {"apps": {"initial_apps": []}}
+
+APP_NAME = "mock_app"
+
+
+async def _seed_interrupted_uninstall(status: Status):
+    """Leave behind exactly what a stop mid-uninstall leaves: a row in an
+    uninstalling status, no files on disk, and nothing in the task queue."""
+    await database.init_database()
+    try:
+        async with db_conn() as conn:
+            await db_installed_apps.insert(
+                conn,
+                InstalledApp(
+                    name=APP_NAME,
+                    installation_reason=InstallationReason.CUSTOM,
+                    status=status,
+                ).model_dump(),
+            )
+    finally:
+        await database.shutdown_database()
+
+
+@pytest.mark.parametrize("status", [Status.UNINSTALLATION_QUEUED, Status.UNINSTALLING])
+async def test_interrupted_uninstall_is_finished_on_next_boot(
+    requests_mock, mocker, status
+):
+    importlib.reload(websocket)
+    importlib.reload(app_installation.worker)
+    importlib.reload(telemetry)
+
+    async def noop():
+        pass
+
+    mocker.patch("shard_core.service.app_installation.login_docker_registries", noop)
+
+    await _seed_interrupted_uninstall(status)
+
+    async with docker_network_portal():
+        app = app_factory.create_app()
+        async with LifespanManager(app, startup_timeout=20, shutdown_timeout=20):
+
+            async def app_row_is_gone():
+                async with db_conn() as conn:
+                    assert not await db_installed_apps.contains(conn, APP_NAME)
+
+            await retry_async(app_row_is_gone, timeout=20, frequency=1)

--- a/tests/test_traefik_dyn_spec.py
+++ b/tests/test_traefik_dyn_spec.py
@@ -1,8 +1,37 @@
+import shutil
 from pathlib import Path
 
+import pytest
 import yaml
 
+from shard_core.data_model.app_meta import Status
+from shard_core.database.connection import db_conn
+from shard_core.database import installed_apps as db_installed_apps
+from shard_core.service.app_installation.util import write_traefik_dyn_config
+from shard_core.service.app_tools import get_installed_apps_path
 from shard_core.settings import settings
+
+pytestmark = pytest.mark.asyncio
+
+
+def _read_traefik_dyn() -> dict:
+    with open(
+        Path(settings().path_root) / "core" / "traefik_dyn" / "traefik_dyn.yml", "r"
+    ) as f:
+        return yaml.safe_load(f)
+
+
+@pytest.mark.parametrize("status", [Status.UNINSTALLATION_QUEUED, Status.UNINSTALLING])
+async def test_app_being_uninstalled_gets_no_router(api_client, status):
+    async with db_conn() as conn:
+        await db_installed_apps.update_status(conn, "filebrowser", status)
+    shutil.rmtree(get_installed_apps_path() / "filebrowser")
+
+    await write_traefik_dyn_config()
+
+    output = _read_traefik_dyn()
+    assert "filebrowser_http" not in output["http"]["routers"]
+    assert "filebrowser_http" not in output["http"]["services"]
 
 
 async def test_template_is_written(api_client):


### PR DESCRIPTION
Fixes #159

## What

Uninstall was not crash-safe. The task queue is in-memory and the DB row is deleted **last**, after the slow docker teardown, so stopping core in between stranded the row in `UNINSTALLING` with nothing left to resume it — and the next boot then crashed in `write_traefik_dyn_config`. A pilot user hit exactly this and the row had to be removed by hand via `psql`.

Two changes:

1. **Traefik config skips apps being uninstalled.** `write_traefik_dyn_config` called `get_app_metadata()` on every non-`INSTALLATION_QUEUED`/non-`ERROR` app, including ones whose files were already deleted → `MetadataNotFound` raised inside the lifespan → core never boots. `UNINSTALLATION_QUEUED` and `UNINSTALLING` now join the filter, which is collected into one `NOT_ROUTABLE_STATUS` set. Routing an app that is on its way out was wrong regardless.
2. **Startup resumes interrupted uninstalls.** New lifespan step `reconcile_interrupted_uninstalls()` re-enqueues an uninstall for every row still in `UNINSTALLATION_QUEUED` or `UNINSTALLING`. It only enqueues, so it stays clear of the deadlock between `refresh_init_apps` and the worker starting later in the lifespan.

Plus one test, and no production change, for acceptance criterion 2 — see below.

## ⚠️ Overlaps with the #158 branch — please read before merging

While finishing this I found an unpushed local branch `fix/clayde/traefik-config-skip-broken-apps` (for #158, no PR yet) that edits **the same lines of `write_traefik_dyn_config`**. Two parallel agents converged on the same function. It does two things:

1. a `_NOT_ROUTED_STATUS` set — `{INSTALLATION_QUEUED, UNINSTALLING, ERROR}`, nearly identical to my `NOT_ROUTABLE_STATUS` but **missing `UNINSTALLATION_QUEUED`**;
2. a per-app `try/except` around `AppInfo(...)` so *any* unloadable app is skipped rather than killing the boot.

Its (2) is strictly better than anything here and I did not duplicate it. The two are complementary, not competing: a status filter is *correctness* (an app being removed should get no router even while its metadata still exists mid-uninstall, which the `try/except` would not catch), the `try/except` is the *safety net*.

I kept my filter because this PR has to stand on its own — #159's acceptance requires core to boot, and I cannot depend on an unpushed branch with no PR. **Whichever lands second needs a trivial conflict resolution; the wanted end state is the union:** both statuses sets merged (including `UNINSTALLATION_QUEUED`) plus the `try/except`. If #158 lands first, this PR reduces to adding `UNINSTALLATION_QUEUED` to its set.

## The "hang" in the issue is actually #160, and #161 already fixes it

The issue asks to "bound / tolerate `compose stop`/`down` when the app has no valid compose file (don't let teardown hang the worker)". **I could not reproduce a hang, and I think the premise is wrong.** `docker compose stop` in a directory with no compose file exits in **0.16s**, and that error was already swallowed by the surrounding `except Exception`.

What actually happened is #160: compose walks *up* the tree when `cwd` has no compose file, so an app teardown resolved to `/core/docker-compose.yml`, project `core`, and stopped `shard_core` **itself**. That is almost certainly why "core was stopped ~11s later" in this issue's own impact report — the uninstall killed core, which then stranded the row. The two issues are one causal chain.

#161 fixes that properly at the subprocess layer by pinning every app compose invocation and refusing to run when the app's compose file is missing. **So I deliberately did not add a guard in `_uninstall_app`** — it would be a second mechanism checking the same condition one layer up, and #161's version is strictly better (all call sites, plus a `core` project-name check). `worker.py` is untouched by this PR.

I kept `test_uninstall_app_without_compose_file` as an acceptance test for the criterion, but flagging honestly that **it does not prove #161**: in a tmp `path_root` there is no parent compose file to walk up to, so it passes either way.

**Reviewer decision:** if #161 might not land soon, say so and I will add the narrow guard here as a stopgap.

## Design note: the row is the tombstone

The issue floated "delete or tombstone the row so a half-done uninstall never leaves a live row". That turned out to be unnecessary: `_uninstall_app` already asserts no status and tolerates missing files, so re-running it is idempotent, and `UNINSTALLING` already *is* a durable tombstone — it survives in Postgres. The only thing missing was someone to read it at boot. So the fix is a reader, not a new state. No migration, no new status, no changes to the six status allow-lists.

## Verification

Both fixes were confirmed to fail without them, not just pass with them:

- `test_app_being_uninstalled_gets_no_router` — reverting the filter reproduces the exact boot crash: `MetadataNotFound: filebrowser`.
- `test_interrupted_uninstall_is_finished_on_next_boot` — seeds the real crash state (row in an uninstalling status, no files, empty queue), boots the actual lifespan, asserts the row is gone. Disabling the reconcile step fails both parametrisations.

Ruff clean. Full suite: **178 passed, 1 failed** — `test_app_lifecycle.py::test_app_starts_and_stops` fails with `Bind for 0.0.0.0:80 failed: port is already allocated`. That is my dev box (another container holds host port 80), not this change: **it fails identically on a clean `origin/main` worktree**, which I checked rather than assuming. It should pass on CI.

## Acceptance

- [x] Killing core mid-uninstall and restarting leaves no row stuck in `UNINSTALLING`; core boots and the app is fully removed.
- [x] Uninstalling an app with no valid compose file completes without hanging — covered by a test here; the underlying teardown fix belongs to #161.

## Out of scope / noticed

- **Install and reinstall have no equivalent reconciliation.** A crash mid-install still strands a row in `INSTALLING` forever. That row is manually escapable (uninstall asserts nothing), so it does not brick the boot the way `UNINSTALLING` did, but it is the same class of bug. Not fixed here — say the word and I will file it.
- `uv.lock` on `main` is stale: `pyproject.toml` says `0.40.0`, the lock still says `0.39.5`. Any `uv sync` regenerates it. CI uses `--frozen` so it does not fail. Left alone as unrelated; flagging it since `just set-version` is supposed to keep them in sync.
- `.serena/` and `.worktrees/` were untracked agent state that `git add -A` swept into a commit (they are in #161's file list too). Added to `.gitignore` in the first commit here.

## Recommended reading order

1. `shard_core/service/app_installation/util.py` — the `NOT_ROUTABLE_STATUS` filter (the boot crash)
2. `shard_core/service/app_installation/__init__.py` — `reconcile_interrupted_uninstalls()`
3. `shard_core/app_factory.py` — where the reconcile step sits in the lifespan
4. `tests/test_traefik_dyn_spec.py`, `tests/test_app_installation.py`, `tests/test_app_uninstall_crash_recovery.py`
5. `agents.md`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
