### PR TITLE
fix(pair): specific error detail for expired vs invalid pairing code

### DIFF
--- a/shard_core/web/public/pair.py
+++ b/shard_core/web/public/pair.py
@@ -25,9 +25,18 @@ router = APIRouter(
 async def add_terminal(code: str, terminal: InputTerminal, response: Response):
     try:
         await pairing.redeem_pairing_code(code)
-    except (KeyError, pairing.InvalidPairingCode, pairing.PairingCodeExpired) as e:
+    except pairing.PairingCodeExpired as e:
         log.info(e)
-        raise HTTPException(status.HTTP_401_UNAUTHORIZED) from e
+        raise HTTPException(
+            status.HTTP_401_UNAUTHORIZED,
+            detail="This pairing code has expired. Generate a new code on your shard and try again.",
+        ) from e
+    except pairing.InvalidPairingCode as e:
+        log.info(e)
+        raise HTTPException(
+            status.HTTP_401_UNAUTHORIZED,
+            detail="This pairing code is not valid.",
+        ) from e
 
     new_terminal = Terminal.create(terminal.name)
     async with db_conn() as conn:

--- a/tests/test_terminals.py
+++ b/tests/test_terminals.py
@@ -103,6 +103,7 @@ async def test_pairing_two_with_same_name(app_client: AsyncClient):
 async def test_pairing_no_code(app_client: AsyncClient):
     response = await add_terminal(app_client, "somecode", "T1")
     assert response.status_code == 401
+    assert response.json()["detail"] == "This pairing code is not valid."
 
     response = await app_client.get("protected/terminals")
     assert len(response.json()) == 0
@@ -113,9 +114,19 @@ async def test_pairing_wrong_code(app_client: AsyncClient):
 
     response = await add_terminal(app_client, f'wrong{pairing_code["code"][5:]}', "T1")
     assert response.status_code == 401
+    assert response.json()["detail"] == "This pairing code is not valid."
 
     response = await app_client.get("protected/terminals")
     assert len(response.json()) == 0
+
+
+async def test_pairing_wrong_code_does_not_leak_valid_code(app_client: AsyncClient):
+    pairing_code = await get_pairing_code(app_client)
+
+    wrong_code = f'{(int(pairing_code["code"][0]) + 1) % 10}{pairing_code["code"][1:]}'
+    response = await add_terminal(app_client, wrong_code, "T1")
+    assert response.status_code == 401
+    assert pairing_code["code"] not in response.text
 
 
 async def test_pairing_expired_code(app_client: AsyncClient):
@@ -123,8 +134,12 @@ async def test_pairing_expired_code(app_client: AsyncClient):
 
     sleep(1.1)
 
-    response = await add_terminal(app_client, pairing_code, "T1")
+    response = await add_terminal(app_client, pairing_code["code"], "T1")
     assert response.status_code == 401
+    assert response.json()["detail"] == (
+        "This pairing code has expired. Generate a new code on your shard and try again."
+    )
+    assert pairing_code["code"] not in response.text
 
     response = await app_client.get("protected/terminals")
     assert len(response.json()) == 0


### PR DESCRIPTION
Closes #156 (backend half — the frontend half is FreeshardBase/web-terminal#38).

## Problem

`POST /public/pair/terminal` collapsed every pairing failure into a bare `HTTPException(401)` with no `detail`, so FastAPI emitted a generic `{"detail": "Unauthorized"}` and the web terminal could only render `AxiosError: Received HTTP status 401`. The service layer already distinguishes `InvalidPairingCode` from `PairingCodeExpired`; that information was thrown away at the API boundary.

## Change

Split the handler and attach a fixed `detail` per case, both still 401:

- `PairingCodeExpired` → "This pairing code has expired. Generate a new code on your shard and try again."
- `InvalidPairingCode` → "This pairing code is not valid."

`InvalidPairingCode` deliberately covers both "no code issued yet" and "code does not match". Distinguishing them would be an oracle for whether a code is currently outstanding.

### The detail strings are hard-coded on purpose

The service-layer exception messages embed the **valid** pairing code (`f"code ({incoming_code}) does not match existing code ({existing_pairing_code.code})"`). This is an unauthenticated public endpoint, so passing `str(e)` through would hand the valid code to any caller who submits a wrong one. `log.info(e)` keeps the verbose form in the server log, where it belongs.

Also dropped `KeyError` from the `except` tuple — it was unreachable, since `redeem_pairing_code` catches it from `database.get_value` and re-raises as `InvalidPairingCode`.

## Tests

`test_pairing_expired_code` passed the whole pairing-code **dict** instead of its `code` field. The dict stringified into the query, so the test exercised the invalid-code path and **never covered expiry at all**. Fixed, and it now asserts the expiry-specific detail.

Added `test_pairing_wrong_code_does_not_leak_valid_code`: submits a wrong code while a valid one is outstanding and asserts the valid code appears nowhere in the raw response body. This is the check that catches the leak — a correct-code test cannot fail this way.

Verified the tests have teeth by reverting the handler and re-running: 3 of 4 fail without the fix.

```
4 passed, 12 deselected, 1 warning in 18.51s
```

Server log during the run confirms the verbose message survives:
`INFO shard_core.web.public.pair:pair.py:29 issued code (110799) is expired`

## Recommended reading order

1. `shard_core/web/public/pair.py` — the fix
2. `tests/test_terminals.py` — detail assertions + the leak guard

No `agents.md` update: no architecture, config, or convention changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
