### PR TITLE
Config & docs hygiene sweep: remove dead config and fix misleading docs

### DIFF
--- a/.claude/skills/freeshard-architecture-contract/SKILL.md
+++ b/.claude/skills/freeshard-architecture-contract/SKILL.md
@@ -69,8 +69,8 @@ endpoint, new mutating internal route), flag it in the PR.
 
 ## 2. Identity and session crypto
 
-**The signing scheme is RSA, not Ed25519.** agents.md claims Ed25519 — that is wrong;
-do not propagate it.
+**The signing scheme is RSA, not Ed25519.** agents.md claimed Ed25519 until issue #128
+corrected it; if you meet that claim anywhere else, the code wins.
 
 - Keys: RSA-4096, exponent 65537 (shard_core/service/crypto.py:52-57). Raw sign/verify uses PSS padding with MGF1(SHA256)+SHA256 (crypto.py:34-46,79-86).
 - Identity id = human-encoded SHA512 of the public key PEM (crypto.py:29-32). The encoding is 5-bits-per-char over the 32-char alphabet `abcdefghjklnpqrstvwxyz0123456789` (shard_core/service/human_encoding.py:102), giving a **103-char id** (512 bits / 5, zero-padded — verified by computation; some docs say 96, that is wrong).

--- a/.claude/skills/freeshard-build-and-env/SKILL.md
+++ b/.claude/skills/freeshard-build-and-env/SKILL.md
@@ -101,8 +101,8 @@ Verified against `justfile` as of 2026-07-03. `just` (no args) lists recipes.
 
 | Recipe | What it actually does | Gotchas |
 |---|---|---|
-| `just run-dev` | `fastapi dev --port 8080 shard_core/app.py` via `.venv/bin/fastapi`, with `PYTHONUNBUFFERED=1` | The `CONFIG=config.yml,local_config.yml` it also sets is **dead** — nothing reads `CONFIG`, and those `.yml` files don't exist (real files are `.toml`, picked up by settings.py automatically). Usage details: freeshard-run-and-operate. |
-| `just run-dev-for-freeshard-controller` | second dev instance on port 8081, *intended* to point at a local controller on 8080 | Dead-CONFIG caveat PLUS the `FREESHARD_FREESHARD_CONTROLLER_BASE_URL` var it sets is single-underscore-broken (inert) — the instance actually talks to the **production** controller. Working form: `FREESHARD_FREESHARD_CONTROLLER__BASE_URL`. See freeshard-config-and-flags. |
+| `just run-dev` | `fastapi dev --port 8080 shard_core/app.py` via `.venv/bin/fastapi`, with `PYTHONUNBUFFERED=1` | Config comes from `config.toml` plus `local_config.toml` if present, picked up by settings.py automatically. Usage details: freeshard-run-and-operate. |
+| `just run-dev-for-freeshard-controller` | second dev instance on port 8081, *intended* to point at a local controller on 8080 | Sets `FREESHARD_FREESHARD_CONTROLLER__BASE_URL=http://127.0.0.1:8080`. Until issue #128 this was a single underscore, which pydantic-settings silently ignored — the instance talked to the **production** controller. See freeshard-config-and-flags. |
 | `just cleanup` | `ruff check . --fix` then `black shard_core` and `black tests` | **Run after every code change** — it is the house formatting gate. Requires the dev extra installed (black is transitive). |
 | `just get-types` | **DESTRUCTIVE**: `rm -rf shard_core/data_model/backend`, then `cp -r` from the **LOCAL** sibling checkout `../freeshard-controller/freeshard-controller-backend/freeshard_controller/data_model`, prepending `# DO NOT MODIFY` to every file | Syncs from whatever your local controller checkout happens to be at. **You MUST `git -C ../freeshard-controller checkout main && git -C ../freeshard-controller pull` first.** A stale checkout has caused real bugs before (silently dropped billing fields — commits 6d4b101, e55ce51). As of 2026-07-03 the local controller checkout on the dev VM was verified BEHIND origin/main. Full procedure and drift checks: freeshard-ecosystem-contracts. |
 | `just set-version X.Y.Z` | rewrites `version` in pyproject.toml and the `ghcr.io/freeshardbase/freeshard:` tag in docker-compose.yml, then **`git add .` and `git commit`** | It stages EVERYTHING (`git add .`) — never run with a dirty tree. Release procedure: freeshard-change-control / freeshard-run-and-operate. |
@@ -134,18 +134,16 @@ uv run pytest tests            # CI test job (needs Docker + internet)
 
 `uv sync` without `--frozen` will also *update* uv.lock if pyproject.toml changed — fine during development, but a lockfile diff you didn't intend belongs out of your PR.
 
-Two workflow variables are dead but still present (do not cargo-cult them): `TEST_ENV=full/sparse` (its consumer was removed; push and PR runs are identical) and `CONFIG=tests/config.yml` (nothing reads `CONFIG`; the file doesn't even exist).
+One workflow variable is dead but still present (do not cargo-cult it): `TEST_ENV=full/sparse` — its consumer was removed, so push and PR runs are identical. A companion dead `CONFIG=tests/config.yml` was removed by issue #128.
 
 ## Known traps
 
 | Trap | Reality | Evidence |
 |---|---|---|
-| `CONFIG` env var looks load-bearing | It is dead — justfile, CI, tests, and the README all set it; nothing reads it (config is hardcoded: `config.toml` + `local_config.toml` if present + `FREESHARD_*` env). Full evidence and history: freeshard-config-and-flags. | `grep -rn '"CONFIG"' shard_core/` → no hits |
 | `local_config.toml` silently not applied | It is resolved via `Path("local_config.toml").exists()` — **relative to CWD**. Run the server/tests from the repo (or worktree) root, or your dev overlay (path_root=`run/`, dns.zone=localhost) vanishes and the app tries production paths. Also listed in `.dockerignore`, so it can never leak into the image — don't try to configure the container with it. | settings.py:148-152; .dockerignore |
 | Tests "just need pytest" | They need a running Docker daemon, compose v2, and internet: a session fixture does a **real `docker login`** to `portalapps.azurecr.io` using credentials committed in `config.toml:30-33`, and app-installation tests really pull images from that registry. If those credentials are ever rotated, api_client-based tests fail on pulls — that is an infra failure, not your bug. | tests/conftest.py:129-131 |
 | Concurrent test runs collide | tests/docker-compose.yml pins host port **5433** and conftest pins compose project name **`shard-core-test`**. Two worktrees running pytest simultaneously fight over both. Run suites serially across worktrees. | tests/docker-compose.yml:9; tests/conftest.py:96-98 |
 | Docker network `portal` and container names are host-global | The production compose stack, a locally running dev shard, and the test suite all use the network name `portal` and fixed container names (`postgres`, `traefik`, `shard_core`, app names like `filebrowser`). Test teardown force-removes the `portal` network — it will rip it out from under a dev shard running on the same host. | docker-compose.yml:1-3; tests/util.py:139-147 |
-| agents.md crypto claim | agents.md says Ed25519. The code is **RSA-4096 with PSS padding** (`shard_core/service/crypto.py`), and HTTP Message Signatures use `RSA_PSS_SHA512` (`shard_core/service/signed_call.py:27`). Trust the code. | crypto.py:54-56; signed_call.py:27 |
 | `scripts/generate_traefik_dyn_config_model.py` | Raises `Exception("Do no use! ...")` at import, deliberately: its output model was hand-patched (`authResponseHeadersRegex`) and regenerating would drop that field. Do not "fix" the script. | scripts/generate_traefik_dyn_config_model.py |
 | Leftover test infra after a crash | A killed pytest run leaves the test postgres and/or `portal` network behind; the next run fails on port/name conflicts. | Cleanup: `docker compose -p shard-core-test -f tests/docker-compose.yml down -v` and `docker network rm portal` |
 
@@ -196,11 +194,10 @@ Drift-prone facts — re-verify before trusting:
 | Version 0.39.2 / image tag in compose | `grep '^version' pyproject.toml && grep 'freeshardbase/freeshard:' docker-compose.yml` |
 | 137 tests collected (origin/main; 134 at e55ce51) | `.venv/bin/pytest tests --collect-only -q \| tail -1` |
 | CI installs via `uv sync --frozen --extra dev` | `git fetch origin && git show origin/main:.github/workflows/test.yml \| grep -A3 'Install dependencies'` |
-| `CONFIG` env var still dead | `grep -rn '"CONFIG"' shard_core/` (expect no hits) |
 | dev extra contents / black still transitive | `grep -A12 'dev = \[' pyproject.toml` |
 | Test postgres port 5433 / project `shard-core-test` | `grep 5433 tests/docker-compose.yml && grep -n 'shard-core-test' tests/conftest.py` |
 | ACR creds still committed & logged into | `grep -n 'azurecr' config.toml && grep -n 'login_docker_registries' tests/conftest.py shard_core/service/app_installation/__init__.py` |
 | Local controller checkout current before get-types | `git -C ../freeshard-controller rev-parse HEAD && git -C ../freeshard-controller ls-remote origin main` (hashes must match) |
 | `.worktrees/` excluded locally | `grep worktrees .git/info/exclude` |
-| Crypto still RSA-4096/PSS, not Ed25519 | `grep -n 'generate_private_key\|key_size\|RSA_PSS' shard_core/service/crypto.py shard_core/service/signed_call.py` |
+| Crypto still RSA-4096/PSS | `grep -n 'generate_private_key\|key_size\|RSA_PSS' shard_core/service/crypto.py shard_core/service/signed_call.py` |
 | tini/docker/rclone still in runtime image | `grep -n 'tini\|get.docker.com\|rclone' Dockerfile` |

--- a/.claude/skills/freeshard-config-and-flags/SKILL.md
+++ b/.claude/skills/freeshard-config-and-flags/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: freeshard-config-and-flags
-description: "Catalog of every shard_core configuration axis and how overrides actually work. Use when adding/changing/reading a config option, wiring a FREESHARD_* env var, editing config.toml / local_config.toml / tests/config.toml / .env.template / docker-compose.yml environment mappings, checking whether a feature flag exists, or debugging 'my override does nothing' / 'Settings() crashes at boot'. TRIGGER on shard_core/settings.py, pydantic-settings, env_nested_delimiter, FREESHARD_ env vars, DISABLE_SSL, telemetry.enabled, apps.pruning, CONFIG env var, settings_override, config_override. SKIP when the question is about running/deploying the stack (use freeshard-run-and-operate), test fixture design beyond config overrides (use freeshard-testing-and-qa), or why a config decision was made (use freeshard-architecture-contract)."
+description: "Catalog of every shard_core configuration axis and how overrides actually work. Use when adding/changing/reading a config option, wiring a FREESHARD_* env var, editing config.toml / local_config.toml / tests/config.toml / .env.template / docker-compose.yml environment mappings, checking whether a feature flag exists, or debugging 'my override does nothing' / 'Settings() crashes at boot'. TRIGGER on shard_core/settings.py, pydantic-settings, env_nested_delimiter, FREESHARD_ env vars, DISABLE_SSL, telemetry.enabled, apps.pruning, settings_override, config_override. SKIP when the question is about running/deploying the stack (use freeshard-run-and-operate), test fixture design beyond config overrides (use freeshard-testing-and-qa), or why a config decision was made (use freeshard-architecture-contract)."
 ---
 
 # Freeshard config and flags
@@ -10,8 +10,9 @@ configuration flows through one pydantic-settings class: `Settings` in
 `shard_core/settings.py:109`. This skill is the complete catalog of every option, the override
 rules, the dead config you must not trust, and the checklist for adding an option.
 
-All file:line references and command outputs verified against the repo on 2026-07-03
-(branch state at commit e55ce51).
+Command outputs verified against the repo on 2026-07-03, and re-verified for the config surface
+on 2026-07-15 (issue #128). Line numbers in file:line references drift with every commit and are
+not re-checked on each update — treat them as a starting point and grep for the symbol.
 
 ## Precedence chain and file map
 
@@ -53,12 +54,11 @@ value falls back to the TOML files. This caused a production incident: commit 5d
 (2026-04-13) fixed `docker-compose.yml`, where single-underscore names made every self-hosted
 shard silently fall back to the hardcoded zone `freeshard.cloud` and hardcoded ACME email.
 
-**The same bug class is still live as of 2026-07-03**: the justfile recipe
-`run-dev-for-freeshard-controller` (`justfile:51`) sets
-`FREESHARD_FREESHARD_CONTROLLER_BASE_URL=http://127.0.0.1:8080` — one underscore short before
-`BASE_URL`. Verified inert: with that var set, `Settings().freeshard_controller.base_url` is
-still `https://controller.freeshard.net`. That recipe silently talks to the **production**
-controller. The working form is `FREESHARD_FREESHARD_CONTROLLER__BASE_URL`.
+The same bug class hit the justfile recipe `run-dev-for-freeshard-controller`, which set
+`FREESHARD_FREESHARD_CONTROLLER_BASE_URL` — one underscore short before `BASE_URL` — and so
+silently talked to the **production** controller. Fixed 2026-07-15 (issue #128); the recipe now
+uses `FREESHARD_FREESHARD_CONTROLLER__BASE_URL`. Both incidents were name-shape bugs that no
+error message reported, which is why the verify-one-liner below is not optional.
 
 ### Verify-an-override one-liner
 
@@ -109,7 +109,6 @@ kwarg (`tests/conftest.py:149`).
 | Option | Type | Default | Prod | Consumer |
 |---|---|---|---|---|
 | `directories` | list[str] | REQUIRED | `["core", "user_data"]` | `service/backup.py:52` — the rclone-crypt sync set. Note: Postgres data is NOT in it. |
-| `included_globs` | list[str] | `[]` | set in config.toml | **DEAD — no consumer** (see Dead config) |
 | `timing.base_schedule` | cron str | REQUIRED | `0 3 * * *` | `app_factory.py:131` (CronTask start_backup) |
 | `timing.max_random_delay` | int (s) | REQUIRED | `3600` | `app_factory.py:132`, jitter applied `util/async_util.py:93-94` |
 
@@ -143,12 +142,11 @@ kwarg (`tests/conftest.py:149`).
 | `enabled` | bool | `False` | `false` | `true` | `service/telemetry.py:19,27` — gates both request counting and sending |
 | `send_interval_seconds` | int | `300` | `300` | | `app_factory.py:136`; sends to controller `api/telemetry` (`telemetry.py:38-39`) |
 
-### [management], [portal_controller], [freeshard_controller]
+### [management], [freeshard_controller]
 
 | Section.option | Default | Prod | Consumer |
 |---|---|---|---|
 | `management.api_url` | REQUIRED | `https://ptlfunctionapp.azurewebsites.net/api/management` (legacy Azure function app) | ONLY `service/app_usage_reporting.py:54` (monthly `/app_usage` POST). `management_mock.py` mocks this API for local dev — point at it with `FREESHARD_MANAGEMENT__API_URL`. |
-| `portal_controller.base_url` | Optional (settings.py:124) | Azure Container Apps URL in config.toml | **DEAD — zero consumers** (see Dead config) |
 | `freeshard_controller.base_url` | REQUIRED | `https://controller.freeshard.net` | `service/freeshard_controller.py:14`, `service/portal_controller.py:15` (yes — the *portal_controller module* reads the *freeshard_controller setting*), `web/protected/feedback.py:23`, `web/internal/call_backend.py:26` |
 
 ### [log] and [terminal]
@@ -161,21 +159,25 @@ kwarg (`tests/conftest.py:149`).
 
 `[terminal]` appears in NO TOML file — defaults only. Override via env if ever needed.
 
-## Dead config — parsed but consumed by NOTHING
+## Dead config — removed 2026-07-15
 
-Do not "fix" behavior by editing these; do not copy them into new code as if live.
+The three items below used to parse fine and do nothing. Issue #128 removed all of them; they
+are recorded here so the names are recognisable in old branches, old backups, and reviews.
 
-| Item | Where it lurks | Evidence it's dead (re-run to confirm) |
+| Item | What it was | Why it was dead |
 |---|---|---|
-| `CONFIG` env var | `justfile:48,51` (`CONFIG=config.yml,local_config.yml`), CI `.github/workflows/test.yml:41` (`CONFIG: tests/config.yml`), `tests/conftest.py:3`, README "Development" section | No code reads it: `grep -rn "environ" shard_core/ \| grep CONFIG` → empty. Vestige of the old gconf loader, replaced by pydantic-settings in commit e2c06a7. The `.yml` filenames in justfile/CI are doubly wrong (config files are `.toml`); conftest.py:3 points at the real `tests/config.toml` — equally dead, just not a phantom filename. Config loading works anyway because `local_config.toml` auto-loads when present. |
-| `services.backup.included_globs` | `settings.py:23`, populated in `config.toml:17` | `grep -rn included_globs shard_core/` hits only the settings field definition. Never wired into the rclone command. Intent (planned selective backup vs leftover) unverified as of 2026-07-03. |
-| `[portal_controller] base_url` | `settings.py:84-85,124`, `config.toml:60-61` | `grep -rn "settings().portal_controller" shard_core/ tests/` → empty. Legacy of the portal→freeshard-controller migration. `service/portal_controller.py` actually uses `settings().freeshard_controller.base_url`. |
+| `CONFIG` env var | Set in both justfile run-dev recipes, CI `test.yml`, `tests/conftest.py`, and the README | Vestige of the gconf loader that commit e2c06a7 replaced with pydantic-settings; no code ever read it. The justfile/CI values named `.yml` files that had not existed since the TOML migration. Config loading always worked anyway, because `config.toml` is unconditional and `local_config.toml` auto-overlays when present. |
+| `services.backup.included_globs` | A `BackupSettings` field, populated in `config.toml` | Never wired into the rclone command; `service/backup.py` syncs the `directories` list only. |
+| `[portal_controller] base_url` | A `PortalControllerSettings` model + optional `Settings` field, set in `config.toml` | Legacy of the portal→freeshard-controller migration. `service/portal_controller.py` — the module still exists and is still live — reads `settings().freeshard_controller.base_url`. |
+
+The general lesson outlives the specific items: a config option is only real if something reads
+it. Before trusting an option, grep for its consumer.
 
 ## Feature-flag inventory
 
 | Flag | Default | Prod | What it gates | Bypass / caveat |
 |---|---|---|---|---|
-| `traefik.disable_ssl` | `false` | unset (false) | Static-config template `traefik_no_ssl.yml` vs `traefik.yml` (`app_factory.py:142-145`); http vs https scheme in shard URL and Traefik dynamic config (`app_factory.py:163`, `service/traefik_dynamic_config.py:42,166,216,225,233-234`) | Dev/testing only. Self-hosted exposure: `DISABLE_SSL` in `.env.template:4`. See boot-crash trap below. |
+| `traefik.disable_ssl` | `false` | unset (false) | Static-config template `traefik_no_ssl.yml` vs `traefik.yml` (`app_factory.py:142-145`); http vs https scheme in shard URL and Traefik dynamic config (`app_factory.py:163`, `service/traefik_dynamic_config.py:42,166,216,225,233-234`) | Dev/testing only. Self-hosted exposure: `DISABLE_SSL` in `.env.template:4`. |
 | `telemetry.enabled` | `false` | `false` | Both request counting and sending (`service/telemetry.py:19,27`) | `true` in tests. Sends request counts to the freeshard controller. |
 | `apps.pruning.enabled` | `false` | `false` | The *scheduled* docker image prune short-circuits when disabled (`service/app_tools.py:175-176`) | Manual `POST /protected/settings/prune-images` (`web/protected/settings.py:14-19`) calls `docker_prune_images(apply_filter=False)` — it runs regardless of the flag AND ignores `max_age`. |
 | Peer-to-peer | **NO FLAG EXISTS** | always active | Nothing — peers router included unconditionally (`web/protected/__init__.py:26`), `update_all_peer_pubkeys` PeriodicTask runs every 60 s (`app_factory.py:116`) | README's "peer-to-peer is disabled" means "no app uses it / not surfaced in UI", not config-gated. Don't search for a flag; there isn't one. |
@@ -189,13 +191,13 @@ Do not "fix" behavior by editing these; do not copy them into new code as if liv
 | `DNS_ZONE` | `FREESHARD_DNS__ZONE=${DNS_ZONE:?}` | fail-fast if unset |
 | `EMAIL` | `FREESHARD_TRAEFIK__ACME_EMAIL=${EMAIL:?}` | fail-fast |
 | `FREESHARD_DIR` | `FREESHARD_PATH_ROOT_HOST=${FREESHARD_DIR:?}` (also raw in volume mounts) | fail-fast |
-| `DISABLE_SSL` | `FREESHARD_TRAEFIK__DISABLE_SSL=${DISABLE_SSL}` | **NO guard, no default** |
+| `DISABLE_SSL` | `FREESHARD_TRAEFIK__DISABLE_SSL=${DISABLE_SSL:-false}` | defaults to `false` when unset |
 
-### Trap: empty DISABLE_SSL crashes boot
+### Trap: an unguarded boolean crashes boot
 
-Because `${DISABLE_SSL}` has no `:?` guard and no default, a self-hoster who omits the line
-from `.env` gets an **empty string** passed as `FREESHARD_TRAEFIK__DISABLE_SSL`, and
-`Settings()` raises at startup:
+Until 2026-07-15 (issue #128), `DISABLE_SSL` was interpolated bare as `${DISABLE_SSL}`. A
+self-hoster who omitted the line from `.env` passed an **empty string** to
+`FREESHARD_TRAEFIK__DISABLE_SSL`, and `Settings()` raised at startup:
 
 ```
 pydantic_core._pydantic_core.ValidationError: 1 validation error for Settings
@@ -203,9 +205,10 @@ traefik.disable_ssl
   Input should be a valid boolean, unable to interpret input [type=bool_parsing, input_value='', ...]
 ```
 
-(Reproduced 2026-07-03 with `FREESHARD_TRAEFIK__DISABLE_SSL= python -c "...Settings()"`.)
-If you touch this mapping, either add a default (`${DISABLE_SSL:-false}`) or a `:?` guard —
-and use `${VAR:?}` guards for any NEW compose env mapping you add.
+It now carries a `:-false` default, so an unset var behaves like an absent one. The trap
+generalises to every NEW compose env mapping you add: an empty string is not the same as
+unset, so give the var a `${VAR:-default}` or a `${VAR:?}` guard. Bare `${VAR}` on a
+non-string field is a boot crash waiting for the first person who skips the line.
 
 ## Committed registry credentials
 
@@ -253,9 +256,9 @@ exercised.
    unguarded `${VAR}` crashes `Settings()` on empty string (see trap above).
 5. **Verify the env path** with the one-liner (see "Verify-an-override one-liner").
 6. **Wire a consumer** via `settings().<section>.<field>` and grep to confirm it's actually
-   read — this repo already has two parsed-but-dead options; don't add a third.
-7. **Before trusting an EXISTING option**, grep for its consumer first: `included_globs` and
-   `portal_controller.base_url` parse fine and do nothing.
+   read — this repo carried two parsed-but-dead options for years; don't add a third.
+7. **Before trusting an EXISTING option**, grep for its consumer first. Parsing is not proof of
+   use: an option with no reader validates, documents itself, and changes nothing.
 
 ## When NOT to use this skill
 
@@ -273,12 +276,12 @@ exercised.
 
 ## Provenance and maintenance
 
-Written 2026-07-03. Primary sources: `shard_core/settings.py`, `config.toml`,
-`local_config.toml`, `tests/config.toml`, `.env.template`, `docker-compose.yml`, `justfile`,
-`tests/conftest.py`, `.github/workflows/test.yml`; commits e2c06a7 (gconf → pydantic-settings),
-5de2998 (env delimiter incident), 773f736 (local_config.toml dockerignore). All catalog
-entries, dead-config claims, and both trap reproductions were verified by running the listed
-commands on 2026-07-03.
+Written 2026-07-03; config surface updated 2026-07-15 for issue #128, which removed the three
+dead-config items, fixed the justfile single-underscore recipe, and defaulted the `DISABLE_SSL`
+compose mapping. Primary sources: `shard_core/settings.py`, `config.toml`, `local_config.toml`,
+`tests/config.toml`, `.env.template`, `docker-compose.yml`, `justfile`, `tests/conftest.py`,
+`.github/workflows/test.yml`; commits e2c06a7 (gconf → pydantic-settings), 5de2998 (env
+delimiter incident), 773f736 (local_config.toml dockerignore).
 
 Drift-prone facts — re-verify before relying on them:
 
@@ -288,12 +291,9 @@ Drift-prone facts — re-verify before relying on them:
 | Prod values | `cat config.toml` |
 | Dev / test overlay values | `cat local_config.toml tests/config.toml` |
 | Precedence: init > env > local_config.toml > config.toml | `sed -n '129,152p' shard_core/settings.py` |
-| `CONFIG` env var still dead | `grep -rn "environ" shard_core/ \| grep CONFIG` (expect empty) |
-| `CONFIG` still set in justfile/CI | `grep -n CONFIG justfile .github/workflows/test.yml` |
-| `included_globs` still dead | `grep -rn included_globs shard_core/` (only settings.py) |
-| `[portal_controller]` still dead | `grep -rn "settings().portal_controller" shard_core/ tests/` (expect empty) |
-| justfile controller recipe still single-underscore-broken | `grep -n FREESHARD_FREESHARD_CONTROLLER justfile` (broken if not `__BASE_URL`) |
-| `DISABLE_SSL` compose mapping still unguarded | `grep -n DISABLE_SSL docker-compose.yml` (broken if no `:?` or `:-` ) |
+| `CONFIG` / `included_globs` / `[portal_controller]` all still gone | `grep -rn "CONFIG=\|included_globs\|portal_controller" justfile .github/workflows/test.yml tests/conftest.py config.toml shard_core/settings.py` (expect empty; a hit means dead config came back) |
+| justfile controller recipe still uses the double underscore | `grep -n FREESHARD_FREESHARD_CONTROLLER justfile` (broken if not `__BASE_URL`) |
+| `DISABLE_SSL` compose mapping still defaulted | `grep -n DISABLE_SSL docker-compose.yml` (broken if no `:?` or `:-`) |
 | ACR credentials still committed / still docker-login'd in tests | `sed -n '30,33p' config.toml; sed -n '129,131p' tests/conftest.py` |
 | Feature-flag consumers unchanged | `grep -rn "disable_ssl\|telemetry.enabled\|pruning.enabled" shard_core/` |
 | Peer-to-peer still unflagged | `grep -rn "peer" shard_core/settings.py` (expect empty) |

--- a/.claude/skills/freeshard-diagnostics-and-tooling/SKILL.md
+++ b/.claude/skills/freeshard-diagnostics-and-tooling/SKILL.md
@@ -245,7 +245,6 @@ Drift-prone facts — re-verify before relying:
 | 134 tests collected at e55ce51 (137 on origin/main), collection needs no Docker | `.venv/bin/pytest tests --collect-only -q` |
 | Test compose project `shard-core-test`, host port 5433 | `grep -n "shard-core-test" tests/conftest.py; grep -n 5433 tests/docker-compose.yml` |
 | disk_space_low threshold = free < 1 GiB on user_data, 30 s period | `sed -n '22,30p' shard_core/service/disk.py; grep -n update_disk_space shard_core/app_factory.py` |
-| justfile run-dev-for-freeshard-controller still has the single-underscore inert env var | `grep -n "FREESHARD_FREESHARD_CONTROLLER" justfile` |
 | yappi fixture exists but no test uses it | `git grep -n profile_with_yappi -- tests` |
 | Dev Board = project 3, 25/71 items from this repo, field names | `gh project item-list 3 --owner FreeshardBase --format json --limit 200 --jq '[.items[] \| keys] \| add \| unique'` |
 | `gh issue view --comments` still broken on this org | `gh issue view 24 --repo FreeshardBase/freeshard --comments` (expect projectCards GraphQL error) |

--- a/.claude/skills/freeshard-docs-and-positioning/SKILL.md
+++ b/.claude/skills/freeshard-docs-and-positioning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: freeshard-docs-and-positioning
-description: Maintaining Freeshard's docs of record (agents.md, README.md, docs.freeshard.net) and writing anything user- or public-facing. TRIGGER on editing agents.md or README.md, "update the docs", "is this doc still true", contradictions between a doc and the code (especially the Ed25519-vs-RSA claim), the Portal/Freeshard naming question ("should I rename portal to shard?"), portal_controller.py vs freeshard_controller.py confusion, writing PR descriptions/commit messages/release notes, or any external claim about what Freeshard is or does. SKIP when the task is the mechanics of config options (use freeshard-config-and-flags), cross-repo type-sync (use freeshard-ecosystem-contracts), release *execution* (use freeshard-run-and-operate), or change gating/review policy (use freeshard-change-control).
+description: Maintaining Freeshard's docs of record (agents.md, README.md, docs.freeshard.net) and writing anything user- or public-facing. TRIGGER on editing agents.md or README.md, "update the docs", "is this doc still true", contradictions between a doc and the code, the Portal/Freeshard naming question ("should I rename portal to shard?"), portal_controller.py vs freeshard_controller.py confusion, writing PR descriptions/commit messages/release notes, or any external claim about what Freeshard is or does. SKIP when the task is the mechanics of config options (use freeshard-config-and-flags), cross-repo type-sync (use freeshard-ecosystem-contracts), release *execution* (use freeshard-run-and-operate), or change gating/review policy (use freeshard-change-control).
 ---
 
 # Freeshard docs and positioning
@@ -27,26 +27,22 @@ When documents disagree, trust them in this order — and trust **code over all 
 | Rank | Document | Audience | Authority |
 |---|---|---|---|
 | 1 | The code + `git log` | — | Ground truth. Always wins. |
-| 2 | `agents.md` (repo root, 131 lines) | Agents/engineers working on shard_core | Primary agent-facing reference: stack, architecture, commands, patterns. Mostly accurate; known errors listed below. |
+| 2 | `agents.md` (repo root) | Agents/engineers working on shard_core | Primary agent-facing reference: stack, architecture, commands, patterns. |
 | 3 | This skill library (`.claude/skills/`) | Agents | Curated, date-stamped; defers to code. |
-| 4 | `README.md` (repo root) | Humans: overview, self-hosting, dev setup | Concept sections good; several dead mechanics (below). |
+| 4 | `README.md` (repo root) | Humans: overview, self-hosting, dev setup | Concept sections good; the dead dev-setup mechanics were fixed by issue #128. |
 | 5 | docs.freeshard.net (sibling repo `documentation/`, MkDocs Material, deployed to GitHub Pages via `.github/workflows/ci.yml`) | End users + third-party app developers | User-level truth; not an engineering reference. |
 | 6 | `/home/ubuntu/projects/freeshard/agents.md` (workspace-level, one directory up) | Agents working across repos | Useful repo map + cross-repo command reference. NOT in any git repo — exists only on the dev machine; do not cite it as a versioned source. |
 
-**Standing rule — agents.md must not rot:** when your PR changes anything agents.md describes (tech stack, architecture, key patterns, commands, file-path conventions), updating agents.md in the same PR is part of the change, not optional polish. Stale statements there cause real agent mistakes — the Ed25519 error below is the proof.
+**Standing rule — agents.md must not rot:** when your PR changes anything agents.md describes (tech stack, architecture, key patterns, commands, file-path conventions), updating agents.md in the same PR is part of the change, not optional polish. Stale statements there cause real agent mistakes. The proof: agents.md claimed Ed25519 crypto for years while the code was RSA-4096/PSS, and the claim was believed until issue #128 checked it against `crypto.py`.
 
-## Known-stale docs (as of 2026-07-03)
+## Known-stale docs (as of 2026-07-15)
 
 Fixing a stale doc is **in scope for any PR that touches the described area**. You do not need a separate issue to correct a doc you just proved wrong — but a pure doc-fix PR is also fine and cheap to review.
 
 | # | Location | Stale claim | The truth | Evidence |
 |---|---|---|---|---|
-| 1 | `agents.md:32`, `agents.md:74`, `agents.md:105` | "Ed25519 key generation / signature verification / requests are signed with Ed25519 keys" | Crypto is **RSA-4096 with PSS padding**; HTTP Message Signatures use **RSA_PSS_SHA512**. There is zero Ed25519 anywhere in `shard_core/`. | `shard_core/service/crypto.py:4-58` (`rsa.generate_private_key`, `padding.PSS`), `shard_core/service/signed_call.py:27` (`algorithms.RSA_PSS_SHA512`) |
-| 2 | `README.md:160-161` | Export `CONFIG=config.yml,local_config.yml`; edit `local_config.yml` | Dead mechanism AND dead file format. No code reads `CONFIG` (grep `shard_core/` — only an unrelated enum member matches). Config is pydantic-settings loading `config.toml` + `local_config.toml` from CWD, env prefix `FREESHARD_`, since commit e2c06a7 ("Fix #41: Replace gconf with pydantic-settings"). `agents.md:11` has the correct description. | `shard_core/settings.py:129-152`; https://github.com/FreeshardBase/freeshard/issues/41 |
-| 3 | `justfile` recipes `run-dev` and `run-dev-for-freeshard-controller` | Both export the same dead `CONFIG=config.yml,local_config.yml` | Inert for the same reason as #2. The recipes work anyway (TOML files auto-load from CWD). Related live bug in the second recipe (single-underscore env var, silently ignored) belongs to freeshard-config-and-flags. | `justfile:48,51` |
-| 4 | `README.md:79` | "[API-doc](https://ptl.gitlab.io/portal_core/) of the latest stable release" | Dead link — GitLab Pages from before the Feb 2025 GitHub migration (commit b33eada deleted `.gitlab-ci.yml`). Live API doc is the local `/docs` endpoint (`just run-dev`, then http://localhost:8080/docs). | `README.md:79` |
-| 5 | `documentation/README.md` (sibling repo) | "Documentation for Portal app developers" + GitLab Pages boilerplate, badge to ptl-public.gitlab.io | Legacy scaffold README. The repo's `agents.md` is the current reference: MkDocs Material site at docs.freeshard.net. | `documentation/README.md` vs `documentation/agents.md:1-10` |
-| 6 | `documentation/agents.md:61` | "Built and deployed via GitLab Pages" | Deploys via **GitHub** Pages: `.github/workflows/ci.yml` builds with `mkdocs build --strict` and deploys with `actions/upload-pages-artifact` / `actions/deploy-pages` on main. No `.gitlab-ci.yml` exists in the repo. | `documentation/.github/workflows/ci.yml` |
+| 1 | `documentation/README.md` (sibling repo) | "Documentation for Portal app developers" + GitLab Pages boilerplate, badge to ptl-public.gitlab.io | Legacy scaffold README. The repo's `agents.md` is the current reference: MkDocs Material site at docs.freeshard.net. | `documentation/README.md` vs `documentation/agents.md:1-10` |
+| 2 | `documentation/agents.md:61` | "Built and deployed via GitLab Pages" | Deploys via **GitHub** Pages: `.github/workflows/ci.yml` builds with `mkdocs build --strict` and deploys with `actions/upload-pages-artifact` / `actions/deploy-pages` on main. No `.gitlab-ci.yml` exists in the repo. | `documentation/.github/workflows/ci.yml` |
 
 Before repeating ANY doc claim in new writing, verify it against code first. Re-verification one-liners for this table are in "Provenance and maintenance".
 
@@ -88,7 +84,7 @@ The project was named **Portal** until the Feb 2025 rebrand (rename commit 88e58
 - `portal_controller._call_freeshard_controller` **prepends `api/`**: `url = f"{controller_base_url}/api/{path}"` (`portal_controller.py:16`). Handles profile + backup SAS URLs.
 - `freeshard_controller.call_freeshard_controller` does **not** — callers pass `api/shards/self` themselves (`freeshard_controller.py:15`). Handles the shared secret.
 
-Adding a controller call to the wrong module produces `/api/api/...` or a missing `/api/` prefix. Check which module the neighboring calls live in, and pass the path in that module's convention. (Also: `[portal_controller]` in `config.toml` is dead config — `portal_controller.py` reads `settings().freeshard_controller`; see freeshard-config-and-flags.)
+Adding a controller call to the wrong module produces `/api/api/...` or a missing `/api/` prefix. Check which module the neighboring calls live in, and pass the path in that module's convention. (Note the naming trap that survives: the `portal_controller.py` *module* is live, but it reads `settings().freeshard_controller` — there is no `[portal_controller]` config section, since issue #128 removed the dead one.)
 
 ## External positioning and claims discipline
 
@@ -122,17 +118,13 @@ Rules for anything public-facing (README, docs site, release notes, blog/newslet
 
 ## Provenance and maintenance
 
-Written 2026-07-03 against working tree at commit e55ce51 (branch `fix-profile-billing-fields`; origin/main then at 0a40684) plus sibling checkouts `documentation/` and `app-repository/` under `/home/ubuntu/projects/freeshard/`. Primary sources: repo files cited inline, `git log`/`git tag`, GitHub via `gh` (issues 41, 118; PRs 83, 90, 102, 108).
+Written 2026-07-03; known-stale table updated 2026-07-15 after issue #128 fixed the agents.md Ed25519 claim, the README/justfile CONFIG mechanism, and the README GitLab API-doc link. Originally written against working tree at commit e55ce51 (branch `fix-profile-billing-fields`; origin/main then at 0a40684) plus sibling checkouts `documentation/` and `app-repository/` under `/home/ubuntu/projects/freeshard/`. Primary sources: repo files cited inline, `git log`/`git tag`, GitHub via `gh` (issues 41, 118; PRs 83, 90, 102, 108).
 
 Drift-prone facts — re-verify before relying on them:
 
 | Fact | Re-verify with |
 |---|---|
-| agents.md still claims Ed25519 (stale rows 1) | `grep -n Ed25519 agents.md` — empty means FIXED; delete row 1 |
 | Crypto is RSA-4096/PSS, RSA_PSS_SHA512 | `grep -n "RSA_PSS\|generate_private_key" shard_core/service/signed_call.py shard_core/service/crypto.py` |
-| README still documents dead CONFIG mechanism | `grep -n "CONFIG=config.yml" README.md justfile` |
-| No code reads CONFIG env var | `grep -rn "environ\|getenv" shard_core/ --include="*.py" \| grep -i config` |
-| README dead GitLab API-doc link | `grep -n "ptl.gitlab.io" README.md` |
 | documentation repo README/agents.md staleness | `head -5 ../documentation/README.md; grep -n "GitLab Pages" ../documentation/agents.md` |
 | portal_controller `api/` prefix split | `grep -n "api/" shard_core/service/portal_controller.py shard_core/service/freeshard_controller.py` |
 | Docker network still named `portal` | `grep -n "name: portal" docker-compose.yml` |

--- a/.claude/skills/freeshard-domain-reference/SKILL.md
+++ b/.claude/skills/freeshard-domain-reference/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: freeshard-domain-reference
-description: Theory pack for shard_core's protocols and standards AS APPLIED HERE — HTTP Message Signatures (RSA-PSS, not Ed25519), shard ID / short_id derivation, Traefik forwardAuth + errors middleware + DNS-01 wildcard ACME, terminal JWT pairing, rclone crypt backups, compose-file-per-app orchestration, yoyo + psycopg3 transaction semantics, Pydantic v2 idioms. TRIGGER on "how does peer/signature auth work", "key_id / short_id / shard id", edits to shard_core/service/{crypto,signed_call,peer,pairing,backup,traefik_dynamic_config}.py, data/traefik.yml, migrations/, shard_core/settings.py, app_meta versioning, X-Forwarded-* / X-Ptl-* headers, "forwardAuth protocol mechanics" (for "why is there no auth on this route", use freeshard-architecture-contract), rclone flags, "where do transactions commit". SKIP when you need step-by-step failure triage (use freeshard-debugging-playbook), running/deploying the stack (freeshard-run-and-operate), config-key catalogs (freeshard-config-and-flags), cross-repo type sync (freeshard-ecosystem-contracts), or writing tests (freeshard-testing-and-qa).
+description: Theory pack for shard_core's protocols and standards AS APPLIED HERE — HTTP Message Signatures (RSA-PSS), shard ID / short_id derivation, Traefik forwardAuth + errors middleware + DNS-01 wildcard ACME, terminal JWT pairing, rclone crypt backups, compose-file-per-app orchestration, yoyo + psycopg3 transaction semantics, Pydantic v2 idioms. TRIGGER on "how does peer/signature auth work", "key_id / short_id / shard id", edits to shard_core/service/{crypto,signed_call,peer,pairing,backup,traefik_dynamic_config}.py, data/traefik.yml, migrations/, shard_core/settings.py, app_meta versioning, X-Forwarded-* / X-Ptl-* headers, "forwardAuth protocol mechanics" (for "why is there no auth on this route", use freeshard-architecture-contract), rclone flags, "where do transactions commit". SKIP when you need step-by-step failure triage (use freeshard-debugging-playbook), running/deploying the stack (freeshard-run-and-operate), config-key catalogs (freeshard-config-and-flags), cross-repo type sync (freeshard-ecosystem-contracts), or writing tests (freeshard-testing-and-qa).
 ---
 
 # Freeshard Domain Reference
@@ -37,19 +37,19 @@ The theory a zero-context engineer needs before touching shard_core's crypto, pr
 - Dropping semantically load-bearing headers in a sign-and-forward proxy. shard_core's `/internal/call_backend` proxy once forwarded a body without its `Content-Type`; years later a FastAPI upgrade on the controller (strict content-type parsing) turned every proxied write into a 422 while reads stayed green. When proxying, forward `Content-Type` with the body.
 - Making the key resolver async or lazy — the library calls it synchronously; that's why both sides preload/caches keys.
 
-## 2. RSA-PSS keys and shard IDs (the Ed25519 myth)
+## 2. RSA-PSS keys and shard IDs
 
-**What you must know.** `agents.md` claims Ed25519 crypto. **This is false — do not implement against it.** The code is RSA-4096 end to end. Verify yourself: `grep -ri ed25519 shard_core/` → zero hits.
+**What you must know.** The code is RSA-4096 end to end. Verify yourself: `grep -ri ed25519 shard_core/` → zero hits. `agents.md` claimed Ed25519 until issue #128 corrected it; if you meet that claim in an old branch or a stale summary, the code wins.
 
 **How this repo uses it.**
 - Key generation: `shard_core/service/crypto.py:52-57` — `rsa.generate_private_key(public_exponent=65537, key_size=4096)`.
 - Raw sign/verify (not HTTP): PSS padding, MGF1(SHA-256), SHA-256 digest (`crypto.py:34-46, 79-86`).
-- HTTP message signatures: `algorithms.RSA_PSS_SHA512` (`signed_call.py:27`, `peer.py:103`). Two different digest choices in one codebase — both RSA-PSS, neither Ed25519.
+- HTTP message signatures: `algorithms.RSA_PSS_SHA512` (`signed_call.py:27`, `peer.py:103`). Two different digest choices in one codebase — both RSA-PSS.
 - Shard ID pipeline: public key PEM bytes → SHA-512 → `human_encoding.encode` (`crypto.py:29-32`). The encoding (`shard_core/service/human_encoding.py`) maps 5 bits per character onto a 32-char alphabet `abcdefghjklnpqrstvwxyz0123456789` (line 102 — note: no `i`, `m`, `o`, `u`; chosen to avoid lookalikes). 512 bits / 5 = **103-character ID** (verified by generating a key).
 - `short_id` = first 6 chars of the ID (`shard_core/data_model/identity.py:44-47`); the shard's domain = `id[:dns.prefix_length].lower() + "." + dns.zone` with `prefix_length` defaulting to 6 (`identity.py:58-64`, `shard_core/settings.py:10-12`). So a hosted shard lives at e.g. `c0p3x5.freeshard.cloud`.
 - 6 chars × 5 bits = 30 bits of prefix. That is a deliberate usability/security compromise: the short_id is a routable DNS label and a signature `keyid`, not a security boundary by itself — trust comes from the full-ID/public-key binding (peers verify `peer_identity.id.startswith(peer.id)` on refresh, `peer.py:60-63`, and the `Peer` model validates pubkey-matches-id). Collision handling between hosted shards' short_ids would have to live controller-side — **not verifiable from this repo (unverified as of 2026-07-03)**.
 
-**Classic mistake.** Writing new signing/verification code against Ed25519 because agents.md says so, or "harmonizing" the SHA-256 raw-crypto and SHA-512 HTTP-signature digests. Both changes break every existing identity and peer relationship — key format and ID derivation are wire/storage contracts.
+**Classic mistake.** Writing new signing/verification code against Ed25519 on the strength of a stale doc, or "harmonizing" the SHA-256 raw-crypto and SHA-512 HTTP-signature digests. Both changes break every existing identity and peer relationship — key format and ID derivation are wire/storage contracts.
 
 ## 3. Traefik mechanics (forwardAuth is THE auth layer; repo compose pins v3.6, fleet runs v2.11 — see below)
 
@@ -137,7 +137,7 @@ The theory a zero-context engineer needs before touching shard_core's crypto, pr
 **What you must know.** Three v2 features carry real weight in this repo: layered `BaseSettings` sources, `@computed_field` (which puts derived properties INTO serialized output), and `model_validator(mode="before")` as a data-migration hook that rewrites raw input before validation.
 
 **How this repo uses it.**
-- Settings layering (`shard_core/settings.py:109-152`): `settings_customise_sources` builds one `TomlConfigSettingsSource` **per file** so overlay files override individual fields, not whole nested sections. Precedence: init kwargs > env (`FREESHARD_` prefix, `__` nested delimiter, e.g. `FREESHARD_TRAEFIK__DISABLE_SSL`) > `local_config.toml` (if present) > `config.toml`. Access is via the `settings()` singleton (:155-159). A `CONFIG` env var appears in the justfile/CI but is read by nothing — dead.
+- Settings layering (`shard_core/settings.py:109-152`): `settings_customise_sources` builds one `TomlConfigSettingsSource` **per file** so overlay files override individual fields, not whole nested sections. Precedence: init kwargs > env (`FREESHARD_` prefix, `__` nested delimiter, e.g. `FREESHARD_TRAEFIK__DISABLE_SSL`) > `local_config.toml` (if present) > `config.toml`. Access is via the `settings()` singleton (:155-159).
 - `@computed_field` on `Identity`/`SafeIdentity` (`shard_core/data_model/identity.py:44-64`): `short_id`, `public_key_pem`, `domain` are computed AND serialized — that's why `GET /public/meta/whoareyou` returns them and why compose templates can use `{{ portal.short_id }}`. `domain` reads `settings()` at property-access time, so identity serialization depends on live settings.
 - AppMeta version-migration chain (`shard_core/data_model/app_meta.py:128-140` + `app_meta_migration.py`): `CURRENT_VERSION = "1.2"`. A `model_validator(mode="before")` loops: while `values["v"] != CURRENT_VERSION`, look up `migrations[values["v"]]` (dict keyed by OLD version) and apply. Each migration function must set `values["v"]` to the next version or the loop raises "migration seems to be stuck". This lets years-old app-store zips (`app_meta.json` v1.0) parse today. To bump the format: add `migrate_1_2_to_1_3` to the dict under key `"1.2"`, set `CURRENT_VERSION = "1.3"`.
 - `shard_core/data_model/backend/` is a verbatim copy of controller models (`just get-types`), every file stamped `# DO NOT MODIFY`. `Profile.from_shard` uses `getattr(shard, field, default)` for newer fields (`shard_core/data_model/profile.py:42-46`) so a stale copy degrades gracefully instead of stripping fields — a real shipped failure (fields silently dropped at re-validation; fixed in commits 6d4b101 + e55ce51). Cross-repo procedure: freeshard-ecosystem-contracts.
@@ -183,5 +183,5 @@ Drift-prone facts — re-verify before relying:
 | One yoyo migration; naming `shard-core-NNNN-*` | `git ls-tree origin/main migrations/` |
 | Pool max_size=20, timeout=10 | `grep -n "max_size\|timeout" shard_core/database/connection.py` |
 | AppMeta CURRENT_VERSION "1.2" | `grep -n CURRENT_VERSION shard_core/data_model/app_meta.py` |
-| agents.md still claims Ed25519 (stale-doc warning still needed) | `grep -in ed25519 agents.md` |
+| No Ed25519 claim has crept back into agents.md | `grep -in ed25519 agents.md` (expect empty) |
 | Settings precedence env > local_config.toml > config.toml | read `settings_customise_sources` in shard_core/settings.py |

--- a/.claude/skills/freeshard-ecosystem-contracts/SKILL.md
+++ b/.claude/skills/freeshard-ecosystem-contracts/SKILL.md
@@ -44,7 +44,7 @@ Naming residue: the project was formerly "Portal". `portal_controller.py`, the `
 | C4 | app-repository → shard + web-terminal | Azure blob `https://storageaccountportab0da.blob.core.windows.net/app-store/...` | None (public blob) | `store_metadata.json` + zips; format = AppMeta (section 7) |
 | C5 | controller backend → controller frontend | OpenAPI spec → generated TS client | n/a | Yes — the only generated contract in the system (section 6) |
 
-WARNING (stale doc): `agents.md` in this repo claims Ed25519 crypto. The code is **RSA-4096 with PSS padding**; signatures are `RSA_PSS_SHA512` (`shard_core/service/crypto.py`, `signed_call.py:27`). Never implement against Ed25519.
+The crypto is **RSA-4096 with PSS padding**; signatures are `RSA_PSS_SHA512` (`shard_core/service/crypto.py`, `signed_call.py:27`). agents.md claimed Ed25519 until issue #128 corrected it — never implement against Ed25519.
 
 ### C1 endpoints shard_core actually calls
 
@@ -55,7 +55,6 @@ WARNING (stale doc): `agents.md` in this repo claims Ed25519 crypto. The code is
 | `POST api/telemetry` | `service/telemetry.py:39` | |
 | `POST {settings().management.api_url}/app_usage` | `service/app_usage_reporting.py:54-55` | config.toml:58 default is a **legacy Azure Functions URL** (`ptlfunctionapp.azurewebsites.net/api/management`), not controller.freeshard.net; the fleet v18 compose sets no override env var. The controller has its own `api/app_usage` router. Where production reports actually land is unverified as of 2026-07-03 — check before touching |
 
-Related dead config: `[portal_controller]` in config.toml (settings.py:124) is defined but no code reads `settings().portal_controller` — see freeshard-config-and-flags.
 
 ## 3. The type-sync copy: `just get-types`
 
@@ -231,7 +230,7 @@ Change all six together, and recompute pinned test values from the real function
 - Actually cutting a release, running the stack, first start → **freeshard-run-and-operate**.
 - Recreating the dev environment, worktrees, uv → **freeshard-build-and-env** (it covers running `get-types` as environment setup; this skill covers *when and why*).
 - Debugging a live cross-repo failure (422s on proxied writes, profile not refreshing) → **freeshard-debugging-playbook**; past investigations → **freeshard-failure-archaeology**.
-- Config keys and env overrides (e.g. the dead `[portal_controller]` section) → **freeshard-config-and-flags**.
+- Config keys and env overrides → **freeshard-config-and-flags**.
 - Running the drift-check script and other measurement tools → **freeshard-diagnostics-and-tooling** (script lives there; this skill only points at it).
 
 ## Provenance and maintenance

--- a/.claude/skills/freeshard-run-and-operate/SKILL.md
+++ b/.claude/skills/freeshard-run-and-operate/SKILL.md
@@ -49,9 +49,8 @@ Dev-server limits — know these before "testing" anything:
 
 ### Second instance for controller development
 
-`just run-dev-for-freeshard-controller` (justfile:50-51) starts a second shard_core on port 8081, intended to point at a locally running controller on port 8080. **As of 2026-07-03 the recipe is broken**: it sets `FREESHARD_FREESHARD_CONTROLLER_BASE_URL` (single underscore before `BASE_URL`), which pydantic-settings silently ignores — the instance actually talks to the production controller. The working form is `FREESHARD_FREESHARD_CONTROLLER__BASE_URL`. Details and the verification one-liner: freeshard-config-and-flags.
+`just run-dev-for-freeshard-controller` (justfile:50-51) starts a second shard_core on port 8081, intended to point at a locally running controller on port 8080. It sets `FREESHARD_FREESHARD_CONTROLLER__BASE_URL`. Until issue #128 that var had a single underscore before `BASE_URL`, which pydantic-settings silently ignored — the instance actually talked to the production controller. Details and the verification one-liner: freeshard-config-and-flags.
 
-Also note: the `CONFIG=config.yml,local_config.yml` env var in both run-dev recipes is dead — no code reads it (freeshard-config-and-flags).
 
 ## 3. Full local stack: `docker compose up`
 
@@ -65,7 +64,7 @@ cp .env.template .env
 docker compose up
 ```
 
-.env variables map to `FREESHARD_*` env vars inside the shard_core container (docker-compose.yml:63-67). `FREESHARD_DIR`, `DNS_ZONE`, `EMAIL` are fail-fast (`${VAR:?}`); `DISABLE_SSL` is not — **leaving it out of `.env` makes Settings() crash on an empty-string boolean** (see freeshard-config-and-flags).
+.env variables map to `FREESHARD_*` env vars inside the shard_core container (docker-compose.yml:63-67). `FREESHARD_DIR`, `DNS_ZONE`, `EMAIL` are fail-fast (`${VAR:?}`); `DISABLE_SSL` defaults to `false` when unset (`${DISABLE_SSL:-false}`). Until issue #128 it was unguarded, and leaving it out of `.env` crashed Settings() on an empty-string boolean (see freeshard-config-and-flags).
 
 The stack (docker-compose.yml, all on one docker network named `portal`):
 
@@ -241,6 +240,6 @@ Drift-prone facts — re-verify before relying on them:
 | Backup cron 03:00 + ≤3600s jitter | `grep -A2 'backup.timing' config.toml` |
 | Postgres-not-in-backup still open | `gh issue view 122 --json state` |
 | Semver migration still pending | `gh issue view 118 --json state` |
-| run-dev-for-freeshard-controller env var still broken (single `_`) | `grep FREESHARD_FREESHARD_CONTROLLER justfile` (broken if not `CONTROLLER__BASE_URL`) |
+| run-dev-for-freeshard-controller env var still uses the double `_` | `grep FREESHARD_FREESHARD_CONTROLLER justfile` (broken if not `CONTROLLER__BASE_URL`) |
 | Release tag==version gate exists | `grep -n 'does not match pyproject' .github/workflows/release.yml` |
 | Pairing route + 10-min first-start code | `grep -n 'pairing-code' shard_core/web/protected/terminals.py; grep -n '10 \* 60' shard_core/app_factory.py` |

--- a/.claude/skills/freeshard-testing-and-qa/SKILL.md
+++ b/.claude/skills/freeshard-testing-and-qa/SKILL.md
@@ -142,7 +142,7 @@ There is **no coverage tooling** (no pytest-cov in deps) — "has tests" is judg
 ## CI: what actually runs
 
 - **snapshot.yml** — triggers on push to `**` AND pull_request to `**`. Runs test.yml (two jobs: ruff, and pytest; both on ubuntu-latest / Python 3.13, installing via `uv sync --frozen --extra dev` and running `uv run ruff check .` / `uv run pytest tests` — as of origin/main 0a40684; older branches still carry the previous `pip install ".[dev]"` variant), then builds and pushes `ghcr.io/freeshardbase/freeshard:<branch-slug>`. Because both events fire for a PR branch, **every PR effectively runs the whole suite twice**.
-- The `TEST_ENV` sparse/full input threaded through snapshot.yml → test.yml:42 is **DEAD**: nothing in shard_core or tests reads it (the consuming decorator was removed; last straggler cleaned in 639ba77). Likewise `CONFIG: tests/config.yml` in test.yml:41 is dead — nothing reads `CONFIG` (full evidence: freeshard-config-and-flags). Don't build on either; don't "fix" them in a drive-by either (see freeshard-change-control).
+- The `TEST_ENV` sparse/full input threaded through snapshot.yml → test.yml:42 is **DEAD**: nothing in shard_core or tests reads it (the consuming decorator was removed; last straggler cleaned in 639ba77). A companion dead `CONFIG: tests/config.yml` was removed by issue #128. Don't build on `TEST_ENV`; don't "fix" it in a drive-by either (see freeshard-change-control).
 - **release.yml** — triggers on GitHub release created. Gate: release tag must equal `pyproject.toml` version, else the job fails and tells you to run `just set-version <tag>` first. Then tests, then builds in container `ghcr.io/freeshardbase/cicd-image:1.0.3` and pushes `ghcr.io/freeshardbase/freeshard:<tag>`. Two commented-out jobs (`pages` redoc docs, `json-schema` Azure upload) are dead since the GitLab→GitHub migration (skipped in d309113, Feb 2025). Release procedure itself: freeshard-run-and-operate and freeshard-change-control.
 - Only secret used anywhere: `secrets.GITHUB_TOKEN` (packages:write for ghcr).
 
@@ -182,7 +182,7 @@ Drift-prone facts — re-verify before relying on them:
 | ACR creds committed and used by setup_all | `grep -n -A3 'apps.registries' config.toml; grep -n login_docker_registries tests/conftest.py` |
 | Reloaded-by-fixture module list (websocket, app_installation.worker, telemetry) | `grep -n 'importlib.reload' tests/conftest.py` |
 | Truncate-BEFORE-each-test, `_yoyo*` preserved | `grep -n -B2 -A12 '_truncate_all_tables' tests/conftest.py` |
-| TEST_ENV / CONFIG env vars still dead | `grep -rn 'TEST_ENV\|environ\[.CONFIG' shard_core/ tests/ .github/` |
+| TEST_ENV still dead | `grep -rn 'TEST_ENV' shard_core/ tests/ .github/` |
 | portal_controller / websocket still untested; backup routes still untested | `grep -rln 'portal_controller\|websocket\|protected/backup' tests/ --include='*.py'` |
 | Suite runs twice per PR (push + pull_request triggers) | `head -12 .github/workflows/snapshot.yml` |
 | No skip/xfail markers in suite | `grep -rn 'pytest.mark.skip\|pytest.mark.xfail\|pytest.skip' tests/ --include='*.py'` |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,6 @@ jobs:
           uv sync --frozen --extra dev
       - name: Run Pytest
         env:
-          CONFIG: tests/config.yml
           TEST_ENV: ${{ inputs.full && 'full' || 'sparse' }}
         run: |
           uv run pytest tests

--- a/README.md
+++ b/README.md
@@ -165,8 +165,9 @@ To restore, point a fresh shard's `${FREESHARD_DIR}` at the decrypted backup (so
 
 Make sure to set up your Python environment and install dependencies using the tools of your choice.
 
-Then, export the environment variable `CONFIG=config.yml,local_config.yml` so the `local_config.yml` is loaded in addition to the default `config.yml`.
-You can modify the `local_config.yml` to your needs, e.g. to set different log levels.
+Configuration is loaded from `config.toml`, overlaid per-field by `local_config.toml` if that file exists in the working directory, and overridden by `FREESHARD_*` environment variables (nested options use a double underscore, e.g. `FREESHARD_DNS__ZONE`).
+You can modify `local_config.toml` to your needs, e.g. to set different log levels.
+Both files are read relative to the working directory, so start the server from the repository root.
 
 Run development server with 
 ```shell

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Shard Core provides a REST API separated into four parts which are accessible at
 * `/management` - Management API, can only be called from the management backend and is only relevant for hosted shards
 * `/internal` - Internal API, only accessible from the same machine e.g. by apps or the reverse proxy
 
-[API-doc](https://ptl.gitlab.io/portal_core/) of the latest stable release.
+Each shard serves the API docs for the version it is actually running, at `/redoc` and `/docs`, with the OpenAPI schema at `/openapi.json`.
 
 ### App Management
 

--- a/agents.md
+++ b/agents.md
@@ -31,7 +31,7 @@ shard_core/
     pairing.py          Terminal pairing (JWT creation, code generation)
     backup.py           Azure Blob Storage backup via rclone
     peer.py             Peer shard management
-    crypto.py           Ed25519 key generation, signing, verification
+    crypto.py           RSA-4096 key generation, signing, verification (PSS padding)
     portal_controller.py  API calls to management portal
     freeshard_controller.py  API calls to controller
     telemetry.py        Usage metrics reporting
@@ -75,7 +75,7 @@ Postgres data is not part of the rclone backup set (which only syncs `core/`/`us
 ### Authentication (4 levels)
 - `/public/*` — No auth
 - `/protected/*` — JWT in `authorization` cookie (from terminal pairing)
-- `/internal/*` — Ed25519 signature verification (for app-to-shard and peer-to-shard calls)
+- `/internal/*` — HTTP Message Signature verification, `RSA_PSS_SHA512` (for app-to-shard and peer-to-shard calls)
 - `/management/*` — Management API auth (hosted shards only)
 
 ### Background Tasks
@@ -106,7 +106,7 @@ Blinker-based async signals defined in `util/signals.py`. DB-writing handlers ar
 Long operations use `asyncio.create_task()` with done callbacks. No thread pools.
 
 ### Service-to-Controller Communication
-`freeshard_controller.py` and `portal_controller.py` make HTTP calls to the central platform. Requests are signed with Ed25519 keys via `signed_call.py`.
+`freeshard_controller.py` and `portal_controller.py` make HTTP calls to the central platform. Requests are signed with the shard's RSA key via `signed_call.py`, using HTTP Message Signatures with `RSA_PSS_SHA512`.
 
 ## File Path Conventions
 

--- a/config.toml
+++ b/config.toml
@@ -14,7 +14,6 @@ prefix_length = 6
 
 [services.backup]
 directories = ["core", "user_data"]
-included_globs = ["core/**/*", "user_data/**/*"]
 
 [services.backup.timing]
 base_schedule = "0 3 * * *"
@@ -60,9 +59,6 @@ send_interval_seconds = 300
 
 [management]
 api_url = "https://ptlfunctionapp.azurewebsites.net/api/management"
-
-[portal_controller]
-base_url = "https://portal-aca.purplemoss-96f7db40.westeurope.azurecontainerapps.io"
 
 [freeshard_controller]
 base_url = "https://controller.freeshard.net"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,7 +63,7 @@ services:
     environment:
       - FREESHARD_DNS__ZONE=${DNS_ZONE:?}
       - FREESHARD_TRAEFIK__ACME_EMAIL=${EMAIL:?}
-      - FREESHARD_TRAEFIK__DISABLE_SSL=${DISABLE_SSL}
+      - FREESHARD_TRAEFIK__DISABLE_SSL=${DISABLE_SSL:-false}
       - FREESHARD_PATH_ROOT_HOST=${FREESHARD_DIR:?}
     depends_on:
       postgres:

--- a/justfile
+++ b/justfile
@@ -46,7 +46,7 @@ _set-version-files version:
         f.write(content)
 
 run-dev:
-    PYTHONUNBUFFERED=1 CONFIG=config.yml,local_config.yml ./.venv/bin/fastapi dev --port 8080 shard_core/app.py
+    PYTHONUNBUFFERED=1 ./.venv/bin/fastapi dev --port 8080 shard_core/app.py
 
 run-dev-for-freeshard-controller:
-    PYTHONUNBUFFERED=1 CONFIG=config.yml,local_config.yml UVICORN_PORT=8001 FREESHARD_FREESHARD_CONTROLLER_BASE_URL=http://127.0.0.1:8080 ./.venv/bin/fastapi dev --port 8081 shard_core/app.py
+    PYTHONUNBUFFERED=1 UVICORN_PORT=8001 FREESHARD_FREESHARD_CONTROLLER_BASE_URL=http://127.0.0.1:8080 ./.venv/bin/fastapi dev --port 8081 shard_core/app.py

--- a/justfile
+++ b/justfile
@@ -49,4 +49,4 @@ run-dev:
     PYTHONUNBUFFERED=1 ./.venv/bin/fastapi dev --port 8080 shard_core/app.py
 
 run-dev-for-freeshard-controller:
-    PYTHONUNBUFFERED=1 UVICORN_PORT=8001 FREESHARD_FREESHARD_CONTROLLER_BASE_URL=http://127.0.0.1:8080 ./.venv/bin/fastapi dev --port 8081 shard_core/app.py
+    PYTHONUNBUFFERED=1 UVICORN_PORT=8001 FREESHARD_FREESHARD_CONTROLLER__BASE_URL=http://127.0.0.1:8080 ./.venv/bin/fastapi dev --port 8081 shard_core/app.py

--- a/shard_core/settings.py
+++ b/shard_core/settings.py
@@ -20,7 +20,6 @@ class BackupTimingSettings(BaseModel):
 class BackupSettings(BaseModel):
     directories: list[str]
     timing: BackupTimingSettings
-    included_globs: list[str] = []
 
 
 class ServicesSettings(BaseModel):
@@ -87,10 +86,6 @@ class ManagementSettings(BaseModel):
     api_url: str
 
 
-class PortalControllerSettings(BaseModel):
-    base_url: str
-
-
 class FreeshardControllerSettings(BaseModel):
     base_url: str
 
@@ -127,7 +122,6 @@ class Settings(BaseSettings):
     apps: AppsSettings
     telemetry: TelemetrySettings = TelemetrySettings()
     management: ManagementSettings
-    portal_controller: Optional[PortalControllerSettings] = None
     freeshard_controller: FreeshardControllerSettings
     log: LogSettings = LogSettings()
     terminal: TerminalSettings = TerminalSettings()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,3 @@
-import os
-
-os.environ.setdefault("CONFIG", "tests/config.toml")
-
 import asyncio
 import importlib
 import json


### PR DESCRIPTION
Closes #128.

One mechanical sweep removing dead config and correcting docs that contradict the code. Each item was verified against the code before being touched, and the two runtime bugs were reproduced before and after the fix.

## What changed

**Dead `CONFIG` env var removed** (README, both justfile run-dev recipes, CI `test.yml`, `tests/conftest.py`). Nothing has read it since e2c06a7 swapped gconf for pydantic-settings; the justfile/CI values additionally named `.yml` files that no longer exist. The README now describes the real mechanism (`config.toml` + optional `local_config.toml` overlay + `FREESHARD_*` env, CWD-relative).

**justfile `run-dev-for-freeshard-controller` pointed at production.** `FREESHARD_FREESHARD_CONTROLLER_BASE_URL` is one underscore short of the `__` nested delimiter, so pydantic-settings silently ignored it and the recipe talked to `https://controller.freeshard.net`. Same bug class as the 5de2998 incident. Reproduced both ways:

```
FREESHARD_FREESHARD_CONTROLLER_BASE_URL=...  -> https://controller.freeshard.net   # inert
FREESHARD_FREESHARD_CONTROLLER__BASE_URL=... -> http://127.0.0.1:8080              # lands
```

**`DISABLE_SSL` could crash boot.** It was interpolated bare, so a self-hoster omitting the line from `.env` passed an empty string and `Settings()` raised `bool_parsing` at startup. Now `${DISABLE_SSL:-false}`; `docker compose config` renders `false` when unset and still honours an explicit `true`.

**Two dead config options removed**: `services.backup.included_globs` (never wired into the rclone command) and the `[portal_controller]` section (zero consumers — `portal_controller.py` reads `freeshard_controller.base_url`). Note the naming trap survives deliberately: the `portal_controller.py` *module* is live.

**agents.md said Ed25519**; the code is RSA-4096 with PSS padding (`service/crypto.py`), and both peer auth and controller calls use HTTP Message Signatures with `RSA_PSS_SHA512`. Three claims corrected; zero `Ed25519` left in the repo.

**README's API-doc link.** Worth a note: the issue called it dead, but it still returns HTTP 200 — it serves a Redoc render of a **0.30.6** spec titled "Portal Core" while the repo is at 0.40.0. So the falsehood was "of the latest stable release", not a 404. Replaced with a pointer to `/redoc`, `/docs` and `/openapi.json`, which always match the running version.

**Skill library de-staled** (last commit). Nine `SKILL.md` files documented these as *live* findings; left alone they would now teach the opposite of the truth. Two rows even carried their own retirement condition and had met it (`docs-and-positioning` said "empty means FIXED; delete row 1"; `config-and-flags` recommended exactly the `${DISABLE_SSL:-false}` written here). Durable lessons are kept and reframed as history; the specific "still broken" claims are gone.

## Verification

- `173 passed` (full suite), `just cleanup` clean, `ruff` clean.
- One test is **deselected, not fixed**: `test_app_lifecycle.py::test_app_starts_and_stops` needs to bind host port 80, which this dev VM's own Traefik holds (`Bind for 0.0.0.0:80 failed: port is already allocated`). It fails **identically on unmodified main** — I confirmed that in a clean worktree at the branch point, so it is environmental and not a regression from this PR. CI has port 80 free.

## Deliberately not done (two findings for you, not fixed here)

1. **`uv.lock` is drifted on main**: it pins `shard-core==0.39.5` while `pyproject.toml` says `0.40.0`, so any `uv run` rewrites the lock and dirties the tree. `uv sync --frozen` does *not* fail on it, so CI is unaffected. It predates this branch and looks like a 0.40.0 bump that landed before 2f4e134 taught `set-version` to keep the lock in sync. Left out of this PR as unrelated — worth its own one-line commit.
2. **`.serena/` is untracked and not gitignored.** The serena MCP writes it into the repo, and my first `git add -A` swept it into a commit; I stripped it back out of history. Any bulk-commit recipe will sweep it again. A `.gitignore` line would fix it, but that's your tooling choice, so I've only flagged it.

## Recommended reading order

1. `shard_core/settings.py`, `config.toml` — the dead options
2. `docker-compose.yml`, `justfile`, `.github/workflows/test.yml`, `tests/conftest.py` — the env-var fixes
3. `README.md`, `agents.md` — the doc corrections
4. `.claude/skills/**` — the de-staling sweep (largest diff, lowest risk; read last)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
