### PR TITLE
Inject shard-specific secrets into app compose templates (#138)

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -71,7 +71,7 @@ async with db_conn() as conn:
     await db_installed_apps.update_status(conn, "myapp", Status.RUNNING)
 ```
 
-Tables: `identities`, `terminals`, `installed_apps`, `peers`, `backups`, `tours`, `app_usage_tracks`, `kv_store`.
+Tables: `identities`, `terminals`, `installed_apps`, `peers`, `backups`, `tours`, `app_usage_tracks`, `kv_store`, `app_secrets`.
 
 Postgres data is not part of the rclone backup set (which only syncs `core/`/`user_data/`). To keep it, `database/db_snapshot.py` dumps all application tables to `core/db_snapshot.json` before each backup, and `init_database()` restores it on a fresh shard (before the default identity is generated, so the restored identity survives). Pre-0.38 backups are restored from TinyDB by `tinydb_migration.py` instead.
 
@@ -134,8 +134,8 @@ snapshot backup. Secrets are kept on uninstall (so a reinstall of the same app r
 them, matching the app's retained `user_data`), never rotated, and never encrypted at
 rest. App-scoping is NOT a boundary against a hostile app author: the compose template is
 rendered with a non-sandboxed jinja environment (as `portal`/`fs` already are), so a
-malicious template can escape and read any app's secrets — tracked separately for a
-`SandboxedEnvironment` fix.
+malicious template can escape and read any app's secrets. Closing that gap would need a
+`SandboxedEnvironment`; it is out of scope here.
 
 ### Async Fire-and-Forget
 Long operations use `asyncio.create_task()` with done callbacks. No thread pools.

--- a/agents.md
+++ b/agents.md
@@ -101,7 +101,7 @@ Blinker-based async signals defined in `util/signals.py`. DB-writing handlers ar
 ### App Installation Flow
 0. Custom-app uploads (`POST /protected/apps`) are validated by `app_installation/app_zip.py` **before** any state is created: the zip is buffered to a temp dir, must carry `app_meta.json` + `docker-compose.yml.template` at its root (a single top-level directory is stripped), and the app name comes from the manifest, not the filename. Invalid uploads get a 400 and leave no row, no dir, no task. Extraction goes through `extract_app_zip`, which refuses members resolving outside the app dir.
 1. Request queued → `InstallationWorker` picks it up
-2. Docker Compose template rendered with Jinja2 (shard domain, data paths, etc.)
+2. Docker Compose template rendered with Jinja2 (shard domain, data paths, per-app secrets, etc.)
 3. Traefik dynamic config generated for the app's subdomain routing
 4. `docker-compose up -d` via subprocess
 5. Status updated in PostgreSQL
@@ -119,6 +119,23 @@ Apps in `NOT_ROUTABLE_STATUS` (`app_installation/util.py`) get no Traefik router
 are either not there yet or already being removed, and `write_traefik_dyn_config`
 runs inside the lifespan — an unfiltered status whose metadata is missing raises
 `MetadataNotFound` and takes down the boot.
+
+### App compose template context
+`render_docker_compose_template` (`app_installation/util.py`) exposes three things to an
+app's `docker-compose.yml.template`: `fs.*` (host data paths), `portal` (the shard
+identity), and `secret('<name>')`. The secret helper returns an app-scoped secret,
+generating one (32 chars, `[A-Za-z0-9]`) on first reference and persisting it in the
+`app_secrets` table (`database/app_secrets.py`); the name is arbitrary and declared
+purely by referencing it. The resolver mints missing secrets synchronously during the
+single jinja pass (jinja is sync, the DB is not) and they are persisted afterwards. A
+secret is stable across
+re-renders, upgrades and restarts (it is reused, never rotated) and rides along in the DB
+snapshot backup. Secrets are kept on uninstall (so a reinstall of the same app reuses
+them, matching the app's retained `user_data`), never rotated, and never encrypted at
+rest. App-scoping is NOT a boundary against a hostile app author: the compose template is
+rendered with a non-sandboxed jinja environment (as `portal`/`fs` already are), so a
+malicious template can escape and read any app's secrets — tracked separately for a
+`SandboxedEnvironment` fix.
 
 ### Async Fire-and-Forget
 Long operations use `asyncio.create_task()` with done callbacks. No thread pools.

--- a/migrations/shard-core-0002-app-secrets.sql
+++ b/migrations/shard-core-0002-app-secrets.sql
@@ -1,0 +1,9 @@
+-- shard-core-0002-app-secrets
+-- depends: shard-core-0001-init
+
+CREATE TABLE IF NOT EXISTS app_secrets (
+    app_name TEXT NOT NULL,
+    name TEXT NOT NULL,
+    value TEXT NOT NULL,
+    PRIMARY KEY (app_name, name)
+);

--- a/shard_core/database/app_secrets.py
+++ b/shard_core/database/app_secrets.py
@@ -1,0 +1,17 @@
+from typing import LiteralString
+
+from psycopg import AsyncConnection
+
+
+async def get_all_for_app(conn: AsyncConnection, app_name: str) -> dict[str, str]:
+    sql: LiteralString = "SELECT name, value FROM app_secrets WHERE app_name = %s"
+    async with conn.cursor() as cur:
+        await cur.execute(sql, (app_name,))
+        return {name: value for name, value in await cur.fetchall()}
+
+
+async def insert(conn: AsyncConnection, app_name: str, name: str, value: str):
+    sql: LiteralString = """INSERT INTO app_secrets (app_name, name, value)
+        VALUES (%(app_name)s, %(name)s, %(value)s)
+        ON CONFLICT (app_name, name) DO NOTHING"""
+    await conn.execute(sql, {"app_name": app_name, "name": name, "value": value})

--- a/shard_core/service/app_installation/app_secrets.py
+++ b/shard_core/service/app_installation/app_secrets.py
@@ -1,4 +1,4 @@
-import secrets as pysecrets  # aliased: this module is itself named secrets
+import secrets
 import string
 
 from shard_core.database import app_secrets as db_app_secrets
@@ -9,7 +9,7 @@ _SECRET_LENGTH = 32
 
 
 def generate_secret() -> str:
-    return "".join(pysecrets.choice(_SECRET_ALPHABET) for _ in range(_SECRET_LENGTH))
+    return "".join(secrets.choice(_SECRET_ALPHABET) for _ in range(_SECRET_LENGTH))
 
 
 class SecretResolver:

--- a/shard_core/service/app_installation/secrets.py
+++ b/shard_core/service/app_installation/secrets.py
@@ -1,0 +1,48 @@
+import secrets as pysecrets  # aliased: this module is itself named secrets
+import string
+
+from shard_core.database import app_secrets as db_app_secrets
+from shard_core.database.connection import db_conn
+
+_SECRET_ALPHABET = string.ascii_letters + string.digits
+_SECRET_LENGTH = 32
+
+
+def generate_secret() -> str:
+    return "".join(pysecrets.choice(_SECRET_ALPHABET) for _ in range(_SECRET_LENGTH))
+
+
+class SecretResolver:
+    """Jinja ``secret('name')`` helper for an app's compose template.
+
+    Returns an app-scoped secret, reusing an existing one or minting a new one
+    (32 chars from ``[A-Za-z0-9]``) on first reference. New secrets are only
+    remembered here; call :func:`persist_new_secrets` after rendering to store
+    them. Resolving synchronously keeps rendering to a single jinja pass even
+    though the DB is async.
+    """
+
+    def __init__(self, existing: dict[str, str]):
+        self._existing = existing
+        self.new: dict[str, str] = {}
+
+    def __call__(self, name: str) -> str:
+        if name in self._existing:
+            return self._existing[name]
+        if name not in self.new:
+            self.new[name] = generate_secret()
+        return self.new[name]
+
+
+async def load_secret_resolver(app_name: str) -> SecretResolver:
+    async with db_conn() as conn:
+        existing = await db_app_secrets.get_all_for_app(conn, app_name)
+    return SecretResolver(existing)
+
+
+async def persist_new_secrets(app_name: str, resolver: SecretResolver):
+    if not resolver.new:
+        return
+    async with db_conn() as conn:
+        for name, value in resolver.new.items():
+            await db_app_secrets.insert(conn, app_name, name, value)

--- a/shard_core/service/app_installation/util.py
+++ b/shard_core/service/app_installation/util.py
@@ -13,7 +13,7 @@ from shard_core.database import identities as db_identities
 from shard_core.data_model.app_meta import Status, InstalledApp
 from shard_core.data_model.identity import Identity, SafeIdentity
 from shard_core.service.app_installation.exceptions import AppInIllegalStatus
-from shard_core.service.app_installation.secrets import (
+from shard_core.service.app_installation.app_secrets import (
     load_secret_resolver,
     persist_new_secrets,
 )

--- a/shard_core/service/app_installation/util.py
+++ b/shard_core/service/app_installation/util.py
@@ -13,6 +13,10 @@ from shard_core.database import identities as db_identities
 from shard_core.data_model.app_meta import Status, InstalledApp
 from shard_core.data_model.identity import Identity, SafeIdentity
 from shard_core.service.app_installation.exceptions import AppInIllegalStatus
+from shard_core.service.app_installation.secrets import (
+    load_secret_resolver,
+    persist_new_secrets,
+)
 from shard_core.service.app_tools import get_installed_apps_path, get_app_metadata
 from shard_core.settings import settings
 from shard_core.service.traefik_dynamic_config import AppInfo, compile_config
@@ -102,12 +106,13 @@ async def render_docker_compose_template(app: InstalledApp):
 
     app_dir = get_installed_apps_path() / app.name
     template = jinja2.Template((app_dir / "docker-compose.yml.template").read_text())
-    (app_dir / "docker-compose.yml").write_text(
-        template.render(
-            fs=fs,
-            portal=portal,
-        )
-    )
+
+    secret_resolver = await load_secret_resolver(app.name)
+    rendered = template.render(fs=fs, portal=portal, secret=secret_resolver)
+    # Persist before writing the file so a persistence failure aborts the render
+    # instead of leaving a compose file with secrets that were never stored.
+    await persist_new_secrets(app.name, secret_resolver)
+    (app_dir / "docker-compose.yml").write_text(rendered)
 
 
 async def write_traefik_dyn_config():

--- a/tests/test_app_secrets.py
+++ b/tests/test_app_secrets.py
@@ -1,3 +1,4 @@
+import shutil
 import string
 
 import pytest
@@ -8,6 +9,7 @@ from shard_core.database import app_secrets as db_app_secrets
 from shard_core.database import installed_apps as db_installed_apps
 from shard_core.database.connection import db_conn
 from shard_core.service import identity
+from shard_core.service.app_installation.app_secrets import generate_secret
 from shard_core.service.app_installation.util import render_docker_compose_template
 from shard_core.service.app_installation.worker import _uninstall_app
 from shard_core.service.app_tools import get_installed_apps_path
@@ -76,6 +78,22 @@ async def test_secret_reused_across_renders():
     assert first == second
 
 
+async def test_secret_reused_after_reinstall():
+    # Intent (issue #138): reinstall reuses the kept secret. A reinstall wipes
+    # the app dir (worker._reinstall_app) but leaves the DB row and app_secrets.
+    app = await _install_app_with_template("reinstall_app", _TEMPLATE)
+    await render_docker_compose_template(app)
+    first = _rendered_env("reinstall_app")["PASSWORD"]
+
+    app_dir = get_installed_apps_path() / "reinstall_app"
+    shutil.rmtree(app_dir)
+    app_dir.mkdir(parents=True)
+    (app_dir / "docker-compose.yml.template").write_text(_TEMPLATE)
+
+    await render_docker_compose_template(app)
+    assert _rendered_env("reinstall_app")["PASSWORD"] == first
+
+
 async def test_distinct_names_get_distinct_secrets():
     template = """
 services:
@@ -93,6 +111,10 @@ services:
 
     assert env["A"] == env["A_AGAIN"]
     assert env["A"] != env["B"]
+
+    async with db_conn() as conn:
+        stored = await db_app_secrets.get_all_for_app(conn, "multi_app")
+    assert stored == {"one": env["A"], "two": env["B"]}
 
 
 async def test_secrets_kept_on_uninstall(mocker):
@@ -184,3 +206,13 @@ async def test_insert_is_idempotent():
         await db_app_secrets.insert(conn, "idem_app", "k", "second")
         stored = await db_app_secrets.get_all_for_app(conn, "idem_app")
     assert stored == {"k": "first"}
+
+
+async def test_generate_secret_length_charset_and_uniqueness():
+    values = [generate_secret() for _ in range(100)]
+    for v in values:
+        assert len(v) == 32
+        assert set(v) <= _SECRET_CHARS
+    # distinct values across 100 draws → the generator is actually random,
+    # not returning a constant.
+    assert len(set(values)) == 100

--- a/tests/test_app_secrets.py
+++ b/tests/test_app_secrets.py
@@ -1,0 +1,186 @@
+import string
+
+import pytest
+import yaml
+
+from shard_core.data_model.app_meta import InstallationReason, InstalledApp, Status
+from shard_core.database import app_secrets as db_app_secrets
+from shard_core.database import installed_apps as db_installed_apps
+from shard_core.database.connection import db_conn
+from shard_core.service import identity
+from shard_core.service.app_installation.util import render_docker_compose_template
+from shard_core.service.app_installation.worker import _uninstall_app
+from shard_core.service.app_tools import get_installed_apps_path
+
+pytestmark = pytest.mark.asyncio
+
+_SECRET_CHARS = set(string.ascii_letters + string.digits)
+
+
+async def _install_app_with_template(app_name: str, template: str) -> InstalledApp:
+    app = InstalledApp(
+        name=app_name,
+        installation_reason=InstallationReason.CUSTOM,
+        status=Status.STOPPED,
+    )
+    async with db_conn() as conn:
+        await db_installed_apps.insert(conn, app.model_dump())
+    app_dir = get_installed_apps_path() / app_name
+    app_dir.mkdir(parents=True, exist_ok=True)
+    (app_dir / "docker-compose.yml.template").write_text(template)
+    return app
+
+
+def _rendered_env(app_name: str) -> dict:
+    rendered = (get_installed_apps_path() / app_name / "docker-compose.yml").read_text()
+    return yaml.safe_load(rendered)["services"]["app"]["environment"]
+
+
+@pytest.fixture(autouse=True)
+async def default_identity(db):
+    await identity.init_default_identity()
+
+
+_TEMPLATE = """
+services:
+    app:
+        image: nginx:alpine
+        environment:
+            PASSWORD: "{{ secret('db_password') }}"
+"""
+
+
+async def test_secret_generated_persisted_and_injected():
+    app = await _install_app_with_template("secret_app", _TEMPLATE)
+
+    await render_docker_compose_template(app)
+
+    injected = _rendered_env("secret_app")["PASSWORD"]
+    assert len(injected) == 32
+    assert set(injected) <= _SECRET_CHARS
+
+    async with db_conn() as conn:
+        stored = await db_app_secrets.get_all_for_app(conn, "secret_app")
+    assert stored == {"db_password": injected}
+
+
+async def test_secret_reused_across_renders():
+    app = await _install_app_with_template("reuse_app", _TEMPLATE)
+
+    await render_docker_compose_template(app)
+    first = _rendered_env("reuse_app")["PASSWORD"]
+
+    await render_docker_compose_template(app)
+    second = _rendered_env("reuse_app")["PASSWORD"]
+
+    assert first == second
+
+
+async def test_distinct_names_get_distinct_secrets():
+    template = """
+services:
+    app:
+        image: nginx:alpine
+        environment:
+            A: "{{ secret('one') }}"
+            B: "{{ secret('two') }}"
+            A_AGAIN: "{{ secret('one') }}"
+"""
+    app = await _install_app_with_template("multi_app", template)
+
+    await render_docker_compose_template(app)
+    env = _rendered_env("multi_app")
+
+    assert env["A"] == env["A_AGAIN"]
+    assert env["A"] != env["B"]
+
+
+async def test_secrets_kept_on_uninstall(mocker):
+    # Intent (issue #138): keep secrets on uninstall so reinstalling the same app
+    # reuses them, matching its retained user_data.
+    mocker.patch(
+        "shard_core.service.app_installation.worker.docker_stop_app",
+        mocker.AsyncMock(),
+    )
+    mocker.patch(
+        "shard_core.service.app_installation.worker.docker_shutdown_app",
+        mocker.AsyncMock(),
+    )
+
+    app = await _install_app_with_template("kept_app", _TEMPLATE)
+    await render_docker_compose_template(app)
+    async with db_conn() as conn:
+        before = await db_app_secrets.get_all_for_app(conn, "kept_app")
+    assert before
+
+    await _uninstall_app("kept_app")
+
+    async with db_conn() as conn:
+        after = await db_app_secrets.get_all_for_app(conn, "kept_app")
+    assert after == before
+
+
+async def test_secrets_are_app_scoped():
+    app_a = await _install_app_with_template("app_a", _TEMPLATE)
+    app_b = await _install_app_with_template("app_b", _TEMPLATE)
+
+    await render_docker_compose_template(app_a)
+    await render_docker_compose_template(app_b)
+
+    secret_a = _rendered_env("app_a")["PASSWORD"]
+    secret_b = _rendered_env("app_b")["PASSWORD"]
+    assert secret_a != secret_b
+
+    async with db_conn() as conn:
+        assert await db_app_secrets.get_all_for_app(conn, "app_a") == {
+            "db_password": secret_a
+        }
+        assert await db_app_secrets.get_all_for_app(conn, "app_b") == {
+            "db_password": secret_b
+        }
+
+
+async def test_no_secrets_persisted_for_secret_free_template():
+    template = """
+services:
+    app:
+        image: nginx:alpine
+        volumes:
+            - "{{ fs.app_data }}:/data"
+"""
+    app = await _install_app_with_template("plain_app", template)
+
+    await render_docker_compose_template(app)
+
+    assert (get_installed_apps_path() / "plain_app" / "docker-compose.yml").exists()
+    async with db_conn() as conn:
+        assert await db_app_secrets.get_all_for_app(conn, "plain_app") == {}
+
+
+async def test_render_aborts_without_writing_file_when_persist_fails(mocker):
+    mocker.patch(
+        "shard_core.service.app_installation.util.persist_new_secrets",
+        mocker.AsyncMock(side_effect=RuntimeError("db down")),
+    )
+    app = await _install_app_with_template("fail_app", _TEMPLATE)
+
+    with pytest.raises(RuntimeError):
+        await render_docker_compose_template(app)
+
+    assert not (get_installed_apps_path() / "fail_app" / "docker-compose.yml").exists()
+
+
+async def test_insert_is_idempotent():
+    async with db_conn() as conn:
+        await db_installed_apps.insert(
+            conn,
+            InstalledApp(
+                name="idem_app",
+                installation_reason=InstallationReason.CUSTOM,
+                status=Status.STOPPED,
+            ).model_dump(),
+        )
+        await db_app_secrets.insert(conn, "idem_app", "k", "first")
+        await db_app_secrets.insert(conn, "idem_app", "k", "second")
+        stored = await db_app_secrets.get_all_for_app(conn, "idem_app")
+    assert stored == {"k": "first"}

--- a/tests/test_db_snapshot.py
+++ b/tests/test_db_snapshot.py
@@ -13,7 +13,7 @@ from tests.conftest import settings_override
 
 _APP_TABLES = (
     "identities, terminals, installed_apps, peers, backups, tours, "
-    "app_usage_tracks, kv_store"
+    "app_usage_tracks, kv_store, app_secrets"
 )
 
 
@@ -42,6 +42,8 @@ async def _seed_shard_state():
             "INSERT INTO backups (directories, start_time, end_time) VALUES (%s, %s, %s)",
             (Jsonb([]), now, now),
         )
+        await conn.execute("""INSERT INTO app_secrets (app_name, name, value)
+               VALUES ('filebrowser', 'db_password', 'super-secret-value')""")
 
 
 @pytest.mark.asyncio
@@ -75,6 +77,13 @@ async def test_snapshot_roundtrip_restores_core_state(db, tmp_path):
                 )
             ).fetchone()
             assert passphrase[0] == "correct horse battery staple"
+
+            secret = await (
+                await conn.execute(
+                    "SELECT value FROM app_secrets WHERE app_name = 'filebrowser'"
+                )
+            ).fetchone()
+            assert secret[0] == "super-secret-value"
 
             # SERIAL sequence advanced past the restored row → new insert must not collide.
             new_id = await (


### PR DESCRIPTION
Closes #138.

## What

Apps can now declare and receive shard-specific secrets in their `docker-compose.yml.template`:

```yaml
services:
  db:
    environment:
      POSTGRES_PASSWORD: "{{ secret('db_password') }}"
```

On render, `secret('<name>')` returns an app-scoped secret — generating one (32 chars, `[A-Za-z0-9]`, via the stdlib `secrets` CSPRNG) on first reference and persisting it in a new `app_secrets` table. Names are arbitrary and declared purely by referencing them. A secret is **stable across re-renders, upgrades, and restarts** (reused, never rotated), **kept on uninstall** (so a reinstall reuses it, matching the app's retained `user_data`), and **not encrypted at rest** — matching the decisions in the issue thread.

Templating syntax decision: the issue floated `{{ secret.my-secret }}`; a Jinja attribute access breaks on hyphens (parses as subtraction), so this uses the callable `{{ secret('name') }}` form — the alternative the issue also blessed ("identifiers cannot be mistaken for fixed keys").

The secret rides into the existing DB-snapshot backup automatically (`db_snapshot.py` discovers all non-yoyo tables), so it survives a restore.

## How it works

`render_docker_compose_template` (`app_installation/util.py`) loads the app's existing secrets, renders with a `SecretResolver` that mints missing secrets synchronously during the single Jinja pass (Jinja is sync, the DB is not), **persists new secrets before writing the compose file** (a persistence failure aborts the render rather than leaving a compose file with secrets that were never stored), then writes the file.

## Recommended reading order

1. `migrations/shard-core-0002-app-secrets.sql` — the `app_secrets` table (composite PK `(app_name, name)`, no FK to `installed_apps` so secrets survive uninstall)
2. `shard_core/database/app_secrets.py` — `get_all_for_app` / idempotent `insert`
3. `shard_core/service/app_installation/app_secrets.py` — `generate_secret`, `SecretResolver`, load/persist
4. `shard_core/service/app_installation/util.py` — wiring into the render path
5. `tests/test_app_secrets.py`, `tests/test_db_snapshot.py` — coverage
6. `agents.md` — documents the template context + honest limitations

## Verification

- `tests/test_app_secrets.py` (10 tests) and `tests/test_db_snapshot.py` (3) green.
- `tests/test_app_installation.py` (12, real Docker) green — confirms the change is safe on the real install path.
- `ruff check` clean; full suite collects (236 tests, no import breakage).

## Review panel

Five reviewers ran (adversarial + test-adversary + DevEx + security + DB/migration), each given only the diff and the issue, instructed to refute. **No blocking findings** from any reviewer. Cheap advisories addressed:

| # | Reviewer | Advisory | Resolution |
|---|----------|----------|------------|
| 1 | DevEx (×2) | Service module `secrets.py` shadowed stdlib `secrets` (forced a `pysecrets` alias) and mismatched the DB module `app_secrets.py` | **Fixed** — renamed to `app_secrets.py`, dropped the alias (commit `5480bed`) |
| 2 | Test adversary | `test_distinct_names` asserted rendered values but never that both secrets minted in one pass were *persisted* (a persist-loop bug storing only the first would slip through) | **Fixed** — added DB assertion (commit `ced8b0d`) |
| 3 | Test adversary | Reinstall-reuse (the headline lifecycle promise) only covered transitively | **Fixed** — added `test_secret_reused_after_reinstall` (commit `ced8b0d`) |
| 4 | Test adversary | `generate_secret()` never unit-tested directly (charset check was probabilistic) | **Fixed** — added length/charset/uniqueness unit test (commit `ced8b0d`) |
| — | Me (self-review) | agents.md claimed a "tracked separately" `SandboxedEnvironment` fix — no such issue is filed | **Fixed** — softened wording, no fabricated reference (commit `277fe75`) |

Advisories deliberately **not** taken, with reasons:

- **Non-sandboxed Jinja lets a malicious app template escape and read any app's secrets** (security + adversarial). This is **pre-existing** — `portal`/`fs` already render through the same non-sandboxed `jinja2.Template`, and custom-app upload is app-reachable per the architecture contract. This diff does **not** widen it: `SecretResolver` is built with only the current app's rows, so `secret('x')` can never name another app's secret without the pre-existing escape. Honestly disclosed in agents.md; a real `SandboxedEnvironment` fix is a separate, broader change.
- **Secrets accumulate for permanently-removed apps** (no purge path) — intended per the issue ("keep on uninstall"), symmetric with retained `user_data`, and rows are tiny.
- **Read-generate-persist is non-atomic** (TOCTOU under concurrent same-app renders) — unreachable today: renders are serialized through the single `InstallationWorker`, and boot re-render runs sequentially before the worker starts.
- **Unbounded secret minting** — dominated by the fact that a hostile template already has RCE; not worth a cap now.
- **Worker end-to-end secret test** — the direct-render tests are a fair proxy and the passing real-Docker `test_app_installation.py` already exercises the render path; skipped as costly for low marginal coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
