### PR TITLE
Startup reconciliation of stranded app installation states (#124)

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -112,13 +112,19 @@ re-enqueues an uninstall for every row still in `UNINSTALLATION_QUEUED` or
 `UNINSTALLING`. `_uninstall_app` asserts no status and tolerates missing files, so
 resuming it is idempotent — the row is the tombstone. The step only enqueues; the
 worker starts later in the lifespan, and awaiting task completion before then
-deadlocks. Install and reinstall have no equivalent reconciliation yet.
+deadlocks. Install and reinstall are made crash-safe the same way by
+`reconcile_interrupted_installs()`: it re-enqueues the row when its source still
+exists (zip on disk → "install from zip", store/config install → re-download,
+reinstall → re-download), and marks the row `ERROR` when the source is gone
+(a custom upload whose zip is lost). It resets the status to the matching
+`*_QUEUED` value first so the worker's status assertion passes.
 
 Apps in `NOT_ROUTABLE_STATUS` (`app_installation/util.py`) get no Traefik router:
 `INSTALLATION_QUEUED`, `ERROR`, `UNINSTALLATION_QUEUED`, `UNINSTALLING`. Their files
-are either not there yet or already being removed, and `write_traefik_dyn_config`
-runs inside the lifespan — an unfiltered status whose metadata is missing raises
-`MetadataNotFound` and takes down the boot.
+are either not there yet or already being removed. For every other status
+`write_traefik_dyn_config` loads the app's metadata in a `try/except` and skips the
+app with a warning if it is missing — so a half-installed row can no longer raise
+`MetadataNotFound` out of the lifespan and boot-loop core.
 
 ### Async Fire-and-Forget
 Long operations use `asyncio.create_task()` with done callbacks. No thread pools.

--- a/agents.md
+++ b/agents.md
@@ -112,12 +112,17 @@ re-enqueues an uninstall for every row still in `UNINSTALLATION_QUEUED` or
 `UNINSTALLING`. `_uninstall_app` asserts no status and tolerates missing files, so
 resuming it is idempotent — the row is the tombstone. The step only enqueues; the
 worker starts later in the lifespan, and awaiting task completion before then
-deadlocks. Install and reinstall are made crash-safe the same way by
-`reconcile_interrupted_installs()`: it re-enqueues the row when its source still
-exists (zip on disk → "install from zip", store/config install → re-download,
-reinstall → re-download), and marks the row `ERROR` when the source is gone
-(a custom upload whose zip is lost). It resets the status to the matching
-`*_QUEUED` value first so the worker's status assertion passes.
+deadlocks. Install is made crash-safe the same way by
+`reconcile_interrupted_installs()` (run right before `write_traefik_dyn_config` so
+a row it resets to a non-routable status is excluded from the boot's Traefik
+config): it re-enqueues an interrupted install when its source still exists (zip
+on disk → "install from zip", otherwise a store/config/unknown install →
+re-download), resetting the status to `INSTALLATION_QUEUED` first so the worker's
+status assertion passes, and marks the row `ERROR` when the source is gone (a
+custom upload whose zip is lost). Reinstall is settled to `ERROR` rather than
+resumed: `_reinstall_app` deletes the app's files before re-downloading, so
+re-running it unattended could destroy a working install if the store is briefly
+unreachable at boot — the user retries it manually.
 
 Apps in `NOT_ROUTABLE_STATUS` (`app_installation/util.py`) get no Traefik router:
 `INSTALLATION_QUEUED`, `ERROR`, `UNINSTALLATION_QUEUED`, `UNINSTALLING`. Their files

--- a/shard_core/app_factory.py
+++ b/shard_core/app_factory.py
@@ -85,6 +85,7 @@ async def lifespan(_):
     await app_installation.login_docker_registries()
     await migration.migrate()
     await app_installation.reconcile_interrupted_uninstalls()
+    await app_installation.reconcile_interrupted_installs()
     await app_installation.refresh_init_apps()
     await backup.ensure_backup_passphrase()
     try:

--- a/shard_core/app_factory.py
+++ b/shard_core/app_factory.py
@@ -80,12 +80,12 @@ async def lifespan(_):
     await database.init_database()
     await identity.init_default_identity()
 
+    await app_installation.reconcile_interrupted_uninstalls()
+    await app_installation.reconcile_interrupted_installs()
     await write_traefik_dyn_config()
     await render_all_docker_compose_templates()
     await app_installation.login_docker_registries()
     await migration.migrate()
-    await app_installation.reconcile_interrupted_uninstalls()
-    await app_installation.reconcile_interrupted_installs()
     await app_installation.refresh_init_apps()
     await backup.ensure_backup_passphrase()
     try:

--- a/shard_core/service/app_installation/__init__.py
+++ b/shard_core/service/app_installation/__init__.py
@@ -154,6 +154,7 @@ async def _resume_interrupted_install(app: InstalledApp):
     elif app.installation_reason in (
         InstallationReason.STORE,
         InstallationReason.CONFIG,
+        InstallationReason.UNKNOWN,
     ):
         task_type = "install from store"
     else:
@@ -167,6 +168,8 @@ async def _resume_interrupted_install(app: InstalledApp):
         )
         return
 
+    # the worker asserts INSTALLATION_QUEUED, so a row stranded in INSTALLING must
+    # be reset before it is re-enqueued.
     await util.update_app_status(app.name, Status.INSTALLATION_QUEUED)
     worker.installation_worker.enqueue(
         worker.InstallationTask(app_name=app.name, task_type=task_type)
@@ -175,13 +178,18 @@ async def _resume_interrupted_install(app: InstalledApp):
 
 
 async def _resume_interrupted_reinstall(app: InstalledApp):
-    # a reinstall re-downloads from the store; the worker marks the row ERROR if
-    # the app is no longer there, so re-enqueueing is always safe.
-    await util.update_app_status(app.name, Status.REINSTALLATION_QUEUED)
-    worker.installation_worker.enqueue(
-        worker.InstallationTask(app_name=app.name, task_type="reinstall")
+    # a reinstall removes the app's files before re-downloading, so re-running it
+    # unattended could destroy a working install if the store is momentarily
+    # unreachable at boot. Settle it to ERROR instead — a non-destructive terminal
+    # state the user can retry from once the store is reachable.
+    await util.update_app_status(
+        app.name,
+        Status.ERROR,
+        message="reinstallation interrupted by a restart; retry it manually",
     )
-    log.info(f"resuming interrupted reinstallation of {app.name}")
+    log.warning(
+        f"interrupted reinstallation of {app.name} cannot be safely resumed, marking ERROR"
+    )
 
 
 async def refresh_init_apps():

--- a/shard_core/service/app_installation/__init__.py
+++ b/shard_core/service/app_installation/__init__.py
@@ -127,6 +127,63 @@ async def reconcile_interrupted_uninstalls():
         log.info(f"resuming interrupted uninstallation of {app['name']}")
 
 
+async def reconcile_interrupted_installs():
+    """Resume or fail installs and reinstalls a previous process left in flight.
+
+    Like uninstalls, the task queue lives only in memory: a stop while a row is
+    in an installing status strands it with nothing left to resume it. Re-enqueue
+    the work when its source still exists, otherwise mark the row ERROR so it
+    stops looking half-installed and no longer blocks a fresh install. Enqueue
+    only — the worker starts later in the lifespan.
+    """
+    async with db_conn() as conn:
+        all_apps = await db_installed_apps.get_all(conn)
+
+    for record in all_apps:
+        app = InstalledApp.model_validate(record)
+        if app.status in (Status.INSTALLATION_QUEUED, Status.INSTALLING):
+            await _resume_interrupted_install(app)
+        elif app.status in (Status.REINSTALLATION_QUEUED, Status.REINSTALLING):
+            await _resume_interrupted_reinstall(app)
+
+
+async def _resume_interrupted_install(app: InstalledApp):
+    zip_file = get_installed_apps_path() / app.name / f"{app.name}.zip"
+    if zip_file.exists():
+        task_type = "install from zip"
+    elif app.installation_reason in (
+        InstallationReason.STORE,
+        InstallationReason.CONFIG,
+    ):
+        task_type = "install from store"
+    else:
+        await util.update_app_status(
+            app.name,
+            Status.ERROR,
+            message="installation interrupted by a restart and its source is gone",
+        )
+        log.warning(
+            f"cannot resume interrupted installation of {app.name}, marking ERROR"
+        )
+        return
+
+    await util.update_app_status(app.name, Status.INSTALLATION_QUEUED)
+    worker.installation_worker.enqueue(
+        worker.InstallationTask(app_name=app.name, task_type=task_type)
+    )
+    log.info(f"resuming interrupted installation of {app.name}")
+
+
+async def _resume_interrupted_reinstall(app: InstalledApp):
+    # a reinstall re-downloads from the store; the worker marks the row ERROR if
+    # the app is no longer there, so re-enqueueing is always safe.
+    await util.update_app_status(app.name, Status.REINSTALLATION_QUEUED)
+    worker.installation_worker.enqueue(
+        worker.InstallationTask(app_name=app.name, task_type="reinstall")
+    )
+    log.info(f"resuming interrupted reinstallation of {app.name}")
+
+
 async def refresh_init_apps():
     try:
         await database.get_value(STORE_KEY_INITIAL_APPS_INSTALLED)

--- a/tests/test_app_install_crash_recovery.py
+++ b/tests/test_app_install_crash_recovery.py
@@ -1,4 +1,5 @@
 import importlib
+import shutil
 
 import pytest
 from asgi_lifespan import LifespanManager
@@ -11,7 +12,8 @@ from shard_core.database.connection import db_conn
 from shard_core.service import app_installation, telemetry, websocket
 from shard_core.service.app_installation import worker
 from shard_core.service.app_tools import get_installed_apps_path
-from tests.util import docker_network_portal, retry_async
+from tests.conftest import mock_app_store
+from tests.util import docker_network_portal, mock_app_store_path, retry_async
 
 pytest_plugins = ("pytest_asyncio",)
 pytestmark = pytest.mark.asyncio
@@ -61,9 +63,13 @@ async def test_custom_install_without_zip_is_marked_error(db, mocker, status):
 
 
 @pytest.mark.parametrize("status", [Status.INSTALLATION_QUEUED, Status.INSTALLING])
-async def test_custom_install_with_zip_is_requeued_from_zip(db, mocker, status):
+@pytest.mark.parametrize(
+    "reason", [InstallationReason.CUSTOM, InstallationReason.STORE]
+)
+async def test_install_with_zip_is_requeued_from_zip(db, mocker, status, reason):
+    # a zip on disk takes precedence over installation_reason
     enqueue = mocker.patch.object(worker.installation_worker, "enqueue")
-    await _seed_app(status, InstallationReason.CUSTOM)
+    await _seed_app(status, reason)
     zip_file = _place_zip(APP_NAME)
     try:
         await app_installation.reconcile_interrupted_installs()
@@ -77,7 +83,8 @@ async def test_custom_install_with_zip_is_requeued_from_zip(db, mocker, status):
 
 @pytest.mark.parametrize("status", [Status.INSTALLATION_QUEUED, Status.INSTALLING])
 @pytest.mark.parametrize(
-    "reason", [InstallationReason.STORE, InstallationReason.CONFIG]
+    "reason",
+    [InstallationReason.STORE, InstallationReason.CONFIG, InstallationReason.UNKNOWN],
 )
 async def test_store_install_without_zip_is_requeued_from_store(
     db, mocker, status, reason
@@ -93,15 +100,16 @@ async def test_store_install_without_zip_is_requeued_from_store(
 
 
 @pytest.mark.parametrize("status", [Status.REINSTALLATION_QUEUED, Status.REINSTALLING])
-async def test_interrupted_reinstall_is_requeued(db, mocker, status):
+async def test_interrupted_reinstall_is_marked_error(db, mocker, status):
+    # a reinstall is destructive (rmtree then re-download), so it is settled to
+    # ERROR rather than resumed unattended — see _resume_interrupted_reinstall.
     enqueue = mocker.patch.object(worker.installation_worker, "enqueue")
     await _seed_app(status, InstallationReason.STORE)
 
     await app_installation.reconcile_interrupted_installs()
 
-    assert await _status(APP_NAME) == Status.REINSTALLATION_QUEUED
-    enqueue.assert_called_once()
-    assert enqueue.call_args.args[0].task_type == "reinstall"
+    assert await _status(APP_NAME) == Status.ERROR
+    enqueue.assert_not_called()
 
 
 @pytest.mark.parametrize("status", [Status.STOPPED, Status.RUNNING, Status.ERROR])
@@ -115,33 +123,51 @@ async def test_settled_apps_are_left_untouched(db, mocker, status):
     enqueue.assert_not_called()
 
 
-# --- boot loop protection (full lifespan) ---------------------------------
+# --- full-lifespan reconciliation (worker runs) ---------------------------
 
 
-async def _seed_interrupted_install(status: Status):
-    """Leave behind what a stop mid-install of a custom app leaves: a row in an
-    installing status, no zip and no metadata on disk, nothing in the queue."""
+async def _seed_via_own_connection(status: Status, reason: InstallationReason):
+    """Seed a stranded row before the app's lifespan opens its own pool."""
     await database.init_database()
     try:
-        await _seed_app(status, InstallationReason.CUSTOM)
+        await _seed_app(status, reason)
     finally:
         await database.shutdown_database()
 
 
-@pytest.mark.parametrize("status", [Status.INSTALLATION_QUEUED, Status.INSTALLING])
-async def test_interrupted_install_with_missing_files_boots_and_errors(
-    requests_mock, mocker, status
-):
+def _reload_stateful_modules():
     importlib.reload(websocket)
     importlib.reload(app_installation.worker)
     importlib.reload(telemetry)
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        Status.INSTALLATION_QUEUED,
+        Status.INSTALLING,
+        Status.REINSTALLATION_QUEUED,
+        Status.REINSTALLING,
+    ],
+)
+async def test_unrecoverable_stranded_row_boots_and_settles_to_error(
+    requests_mock, mocker, status
+):
+    """A row with no recoverable source boots the shard and ends in ERROR.
+
+    The store is mocked to serve mock_app, so a row misclassified as a store
+    install would be driven to STOPPED — the ERROR assertion therefore fails if
+    reconcile picks the wrong branch, giving it teeth.
+    """
+    _reload_stateful_modules()
+    mock_app_store(mocker)
 
     async def noop():
         pass
 
     mocker.patch("shard_core.service.app_installation.login_docker_registries", noop)
 
-    await _seed_interrupted_install(status)
+    await _seed_via_own_connection(status, InstallationReason.CUSTOM)
 
     async with docker_network_portal():
         app = app_factory.create_app()
@@ -151,3 +177,32 @@ async def test_interrupted_install_with_missing_files_boots_and_errors(
                 assert await _status(APP_NAME) == Status.ERROR
 
             await retry_async(app_row_is_error, timeout=20, frequency=1)
+
+
+@pytest.mark.parametrize("status", [Status.INSTALLATION_QUEUED, Status.INSTALLING])
+async def test_reconciled_install_completes_on_boot(requests_mock, mocker, status):
+    """A stranded install whose zip is on disk is re-queued by reconcile and the
+    worker drives it to STOPPED — proving reconcile's task_type and status reset
+    line up with the worker's status assertion end to end."""
+    _reload_stateful_modules()
+    mock_app_store(mocker)
+
+    async def noop():
+        pass
+
+    mocker.patch("shard_core.service.app_installation.login_docker_registries", noop)
+
+    await _seed_via_own_connection(status, InstallationReason.CUSTOM)
+    src = mock_app_store_path() / APP_NAME / f"{APP_NAME}.zip"
+    dst = get_installed_apps_path() / APP_NAME / f"{APP_NAME}.zip"
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy(src, dst)
+
+    async with docker_network_portal():
+        app = app_factory.create_app()
+        async with LifespanManager(app, startup_timeout=20, shutdown_timeout=20):
+
+            async def app_is_installed():
+                assert await _status(APP_NAME) == Status.STOPPED
+
+            await retry_async(app_is_installed, timeout=60, frequency=2)

--- a/tests/test_app_install_crash_recovery.py
+++ b/tests/test_app_install_crash_recovery.py
@@ -1,0 +1,153 @@
+import importlib
+
+import pytest
+from asgi_lifespan import LifespanManager
+
+from shard_core import app_factory
+from shard_core.data_model.app_meta import InstallationReason, InstalledApp, Status
+from shard_core.database import database
+from shard_core.database import installed_apps as db_installed_apps
+from shard_core.database.connection import db_conn
+from shard_core.service import app_installation, telemetry, websocket
+from shard_core.service.app_installation import worker
+from shard_core.service.app_tools import get_installed_apps_path
+from tests.util import docker_network_portal, retry_async
+
+pytest_plugins = ("pytest_asyncio",)
+pytestmark = pytest.mark.asyncio
+
+config_override = {"apps": {"initial_apps": []}}
+
+APP_NAME = "mock_app"
+
+
+async def _seed_app(status: Status, reason: InstallationReason):
+    async with db_conn() as conn:
+        await db_installed_apps.insert(
+            conn,
+            InstalledApp(
+                name=APP_NAME,
+                installation_reason=reason,
+                status=status,
+            ).model_dump(),
+        )
+
+
+async def _status(app_name: str) -> str:
+    async with db_conn() as conn:
+        record = await db_installed_apps.get_by_name(conn, app_name)
+    return record["status"]
+
+
+def _place_zip(app_name: str):
+    zip_file = get_installed_apps_path() / app_name / f"{app_name}.zip"
+    zip_file.parent.mkdir(parents=True, exist_ok=True)
+    zip_file.write_bytes(b"not a real zip, only its presence matters here")
+    return zip_file
+
+
+# --- decision matrix (db-tier, worker not started) ------------------------
+
+
+@pytest.mark.parametrize("status", [Status.INSTALLATION_QUEUED, Status.INSTALLING])
+async def test_custom_install_without_zip_is_marked_error(db, mocker, status):
+    enqueue = mocker.patch.object(worker.installation_worker, "enqueue")
+    await _seed_app(status, InstallationReason.CUSTOM)
+
+    await app_installation.reconcile_interrupted_installs()
+
+    assert await _status(APP_NAME) == Status.ERROR
+    enqueue.assert_not_called()
+
+
+@pytest.mark.parametrize("status", [Status.INSTALLATION_QUEUED, Status.INSTALLING])
+async def test_custom_install_with_zip_is_requeued_from_zip(db, mocker, status):
+    enqueue = mocker.patch.object(worker.installation_worker, "enqueue")
+    await _seed_app(status, InstallationReason.CUSTOM)
+    zip_file = _place_zip(APP_NAME)
+    try:
+        await app_installation.reconcile_interrupted_installs()
+    finally:
+        zip_file.unlink(missing_ok=True)
+
+    assert await _status(APP_NAME) == Status.INSTALLATION_QUEUED
+    enqueue.assert_called_once()
+    assert enqueue.call_args.args[0].task_type == "install from zip"
+
+
+@pytest.mark.parametrize("status", [Status.INSTALLATION_QUEUED, Status.INSTALLING])
+@pytest.mark.parametrize(
+    "reason", [InstallationReason.STORE, InstallationReason.CONFIG]
+)
+async def test_store_install_without_zip_is_requeued_from_store(
+    db, mocker, status, reason
+):
+    enqueue = mocker.patch.object(worker.installation_worker, "enqueue")
+    await _seed_app(status, reason)
+
+    await app_installation.reconcile_interrupted_installs()
+
+    assert await _status(APP_NAME) == Status.INSTALLATION_QUEUED
+    enqueue.assert_called_once()
+    assert enqueue.call_args.args[0].task_type == "install from store"
+
+
+@pytest.mark.parametrize("status", [Status.REINSTALLATION_QUEUED, Status.REINSTALLING])
+async def test_interrupted_reinstall_is_requeued(db, mocker, status):
+    enqueue = mocker.patch.object(worker.installation_worker, "enqueue")
+    await _seed_app(status, InstallationReason.STORE)
+
+    await app_installation.reconcile_interrupted_installs()
+
+    assert await _status(APP_NAME) == Status.REINSTALLATION_QUEUED
+    enqueue.assert_called_once()
+    assert enqueue.call_args.args[0].task_type == "reinstall"
+
+
+@pytest.mark.parametrize("status", [Status.STOPPED, Status.RUNNING, Status.ERROR])
+async def test_settled_apps_are_left_untouched(db, mocker, status):
+    enqueue = mocker.patch.object(worker.installation_worker, "enqueue")
+    await _seed_app(status, InstallationReason.STORE)
+
+    await app_installation.reconcile_interrupted_installs()
+
+    assert await _status(APP_NAME) == status
+    enqueue.assert_not_called()
+
+
+# --- boot loop protection (full lifespan) ---------------------------------
+
+
+async def _seed_interrupted_install(status: Status):
+    """Leave behind what a stop mid-install of a custom app leaves: a row in an
+    installing status, no zip and no metadata on disk, nothing in the queue."""
+    await database.init_database()
+    try:
+        await _seed_app(status, InstallationReason.CUSTOM)
+    finally:
+        await database.shutdown_database()
+
+
+@pytest.mark.parametrize("status", [Status.INSTALLATION_QUEUED, Status.INSTALLING])
+async def test_interrupted_install_with_missing_files_boots_and_errors(
+    requests_mock, mocker, status
+):
+    importlib.reload(websocket)
+    importlib.reload(app_installation.worker)
+    importlib.reload(telemetry)
+
+    async def noop():
+        pass
+
+    mocker.patch("shard_core.service.app_installation.login_docker_registries", noop)
+
+    await _seed_interrupted_install(status)
+
+    async with docker_network_portal():
+        app = app_factory.create_app()
+        async with LifespanManager(app, startup_timeout=20, shutdown_timeout=20):
+
+            async def app_row_is_error():
+                assert await _status(APP_NAME) == Status.ERROR
+
+            await retry_async(app_row_is_error, timeout=20, frequency=1)


### PR DESCRIPTION
Closes #124.

## What

Startup reconciliation for app-installation rows stranded by a restart. The install queue is an in-memory `asyncio.Queue`, so a stop between enqueue and completion leaves `installed_apps` rows in an in-flight status forever. The uninstall side already got `reconcile_interrupted_uninstalls()` (#161-era); this adds the install/reinstall side.

New `reconcile_interrupted_installs()`, run in the lifespan **before** `write_traefik_dyn_config` (enqueue-only, so it stays clear of the worker-not-started-yet deadlock window):

- **install with zip on disk** → reset to `INSTALLATION_QUEUED`, re-enqueue `"install from zip"`
- **store/config/unknown install, zip gone** → reset to `INSTALLATION_QUEUED`, re-enqueue `"install from store"` (worker re-downloads; self-heals to `ERROR` if the app is gone)
- **custom install, zip gone** → `ERROR` (source is unrecoverable)
- **reinstall (`REINSTALLATION_QUEUED` / `REINSTALLING`)** → `ERROR`. `_reinstall_app` deletes the app's files *before* re-downloading, so resuming it unattended could destroy a working install if the store is briefly unreachable at boot; the user retries manually.

The boot-loop half of the issue (a stranded `INSTALLING` row with missing metadata raising `MetadataNotFound` out of the lifespan) was already fixed by #158's defensive `try/except` in `write_traefik_dyn_config`; `agents.md` is corrected to match.

## Verify

- `tests/test_app_install_crash_recovery.py` — 23 tests. Db-tier decision matrix (worker not started, `enqueue` mocked) asserts DB status + task type for every stranded status; two full-lifespan tests: one proves an unrecoverable row boots and settles to `ERROR` (store mocked, so a misclassified row would reach `STOPPED` — the `ERROR` assertion has teeth), one drives a zip-on-disk install through reconcile → worker → `STOPPED`.
- Full local suite: the fix's tests pass. Unrelated failures in `test_traefik_dyn_spec` / `test_tours` / `test_app_lifecycle` reproduce identically on the base commit with this branch's changes reverted and are environmental to the test VM (postgres container collision on :5433, image-pull/timing) — main CI is green. CI on this PR is the real gate.

## Recommended reading order

1. `shard_core/app_factory.py` — lifespan wiring/order
2. `shard_core/service/app_installation/__init__.py` — `reconcile_interrupted_installs` + helpers
3. `tests/test_app_install_crash_recovery.py`
4. `agents.md`

## Review panel

Ran: **adversarial** (always), **test adversary** (real logic added), **DevEx/readability** (new methods + tests). Skipped — no trigger: security, DB/migration, API-contract, UX.

**Adversarial — blocking findings:** none. Advisories addressed:
- *Reinstall re-enqueue re-triggers a destructive rmtree-then-download → a transient store outage at boot destroys a working app* → **fixed** (e6a642c): reinstall now settles to `ERROR`, never re-triggers the destructive path.
- *Reconcile runs after `write_traefik_dyn_config`; a half-installed `INSTALLING` row with present metadata gets a stale router (502s that boot)* → **fixed** (e6a642c): reconcile moved before the traefik write, so the not-routable reset takes effect.
- *`UNKNOWN` reason + no zip marked `ERROR` instead of resumed* → **fixed** (e6a642c): `UNKNOWN` resumes from store.
- *Custom install that crashed after extraction but before the `STOPPED` write is marked `ERROR` though effectively installed* → **dismissed**: cannot disambiguate "old intact install" from "partial new extraction" without a completion marker; conservative `ERROR` is safe and the user re-uploads. Narrow window.

**Test adversary — blocking findings:** none (verified the db-tier tests have teeth by neutering reconcile → 10/10 active-status params failed). Advisories addressed:
- *Integration test's "boots" claim was decoration (#158 already prevents the boot break)* → **fixed** (b71824e): renamed to `test_unrecoverable_stranded_row_boots_and_settles_to_error`, claim scoped to the load-bearing `ERROR` transition.
- *`ERROR` could pass for the wrong reason (custom misclassified as store → worker 404 → `ERROR`)* → **fixed** (b71824e): store is now mocked, so a misclassified row reaches `STOPPED` and fails the assertion.
- *No reconcile→worker→`STOPPED` end-to-end test* → **fixed** (b71824e): added `test_reconciled_install_completes_on_boot`.

**DevEx — blocking findings:** none. Advisories: added a one-line comment on the load-bearing status reset (b71824e/e6a642c); the flagged `_place_zip` cross-test cleanup concern was verified moot (`path_root` is a per-test tmp dir).

---
*This PR description was AI-drafted and human-reviewed. If verifying any part needs real digging on your side, say so and we'll do a call instead.*
