### PR TITLE
Verify sensitive requests actually came through Traefik (#125)

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -83,7 +83,7 @@ Postgres data is not part of the rclone backup set (which only syncs `core/`/`us
 
 Because every app container shares the `portal` docker network with shard_core, any
 app could reach `/protected` or `/management` directly and bypass the Traefik
-forwardAuth gate. To close that, both routers additionally require a shared secret
+forwardAuth gate. To raise the bar, both routers additionally require a shared secret
 header (`X-Ptl-Traefik-Secret`) injected by the `verify-traefik` Traefik middleware and
 verified by `service/traefik_secret.py`; a request that did not traverse Traefik lacks
 it and is rejected with 403. The secret is generated once and stored in `kv_store`
@@ -91,6 +91,15 @@ it and is rejected with 403. The secret is generated once and stored in `kv_stor
 deliberately NOT gated: the forwardAuth endpoints are called by Traefik directly (they
 never pass through the middleware chain), and `call_backend`/`call_peer` are called by
 apps directly by design.
+
+This is the short-term half of issue #125 and is intentionally partial. Because
+Postgres (`kv_store`, default creds) and the Traefik dashboard (`api.insecure: true`)
+sit on the same `portal` network, an app that actively targets shard_core can still
+read the secret and forge the header — so the gate stops accidental/naive direct calls
+and any app not specifically hunting the secret, but not a determined one. Closing that
+requires the network-isolation work tracked as the long-term half (isolate Postgres from
+`portal`, disable the unauthenticated Traefik API); until then, do not treat `/protected`
+and `/management` as fully sealed against a hostile app.
 
 ### Background Tasks
 Started at app lifespan startup, stopped at shutdown:

--- a/agents.md
+++ b/agents.md
@@ -81,6 +81,17 @@ Postgres data is not part of the rclone backup set (which only syncs `core/`/`us
 - `/internal/*` — HTTP Message Signature verification, `RSA_PSS_SHA512` (for app-to-shard and peer-to-shard calls)
 - `/management/*` — Management API auth (hosted shards only)
 
+Because every app container shares the `portal` docker network with shard_core, any
+app could reach `/protected` or `/management` directly and bypass the Traefik
+forwardAuth gate. To close that, both routers additionally require a shared secret
+header (`X-Ptl-Traefik-Secret`) injected by the `verify-traefik` Traefik middleware and
+verified by `service/traefik_secret.py`; a request that did not traverse Traefik lacks
+it and is rejected with 403. The secret is generated once and stored in `kv_store`
+(`traefik_secret`), and compiled into the dynamic Traefik config. `/internal` routes are
+deliberately NOT gated: the forwardAuth endpoints are called by Traefik directly (they
+never pass through the middleware chain), and `call_backend`/`call_peer` are called by
+apps directly by design.
+
 ### Background Tasks
 Started at app lifespan startup, stopped at shutdown:
 - `InstallationWorker` — async task queue for app install/uninstall

--- a/shard_core/service/app_installation/util.py
+++ b/shard_core/service/app_installation/util.py
@@ -16,6 +16,7 @@ from shard_core.service.app_installation.exceptions import AppInIllegalStatus
 from shard_core.service.app_tools import get_installed_apps_path, get_app_metadata
 from shard_core.settings import settings
 from shard_core.service.traefik_dynamic_config import AppInfo, compile_config
+from shard_core.service.traefik_secret import ensure_traefik_secret
 from shard_core.util import signals
 
 log = logging.getLogger(__name__)
@@ -131,10 +132,14 @@ async def write_traefik_dyn_config():
     default_identity = Identity(**default_row)
     portal = SafeIdentity.from_identity(default_identity)
 
+    traefik_secret = await ensure_traefik_secret()
+
     traefik_dyn_filename = (
         Path(settings().path_root) / "core" / "traefik_dyn" / "traefik_dyn.yml"
     )
-    await _write_to_yaml(compile_config(app_infos, portal), traefik_dyn_filename)
+    await _write_to_yaml(
+        compile_config(app_infos, portal, traefik_secret), traefik_dyn_filename
+    )
 
 
 async def _write_to_yaml(spec: pydantic.BaseModel, output_path: Path):

--- a/shard_core/service/traefik_dynamic_config.py
+++ b/shard_core/service/traefik_dynamic_config.py
@@ -9,6 +9,7 @@ from shard_core.data_model.app_meta import (
     AppMeta,
 )
 from shard_core.data_model.identity import SafeIdentity
+from shard_core.service.traefik_secret import HEADER_NAME as TRAEFIK_SECRET_HEADER
 from shard_core.settings import settings
 
 
@@ -18,9 +19,11 @@ class AppInfo:
     installed_app: InstalledApp
 
 
-def compile_config(apps: List[AppInfo], portal: SafeIdentity) -> t.Model:
+def compile_config(
+    apps: List[AppInfo], portal: SafeIdentity, traefik_secret: str
+) -> t.Model:
     model = t.Model()
-    _add_http_section(model, portal)
+    _add_http_section(model, portal, traefik_secret)
     _add_tcp_section(model, portal)
     for app_info in apps:
         for ep in app_info.app_meta.entrypoints:
@@ -38,7 +41,7 @@ def compile_config(apps: List[AppInfo], portal: SafeIdentity) -> t.Model:
     return model
 
 
-def _add_http_section(model: t.Model, portal: SafeIdentity):
+def _add_http_section(model: t.Model, portal: SafeIdentity, traefik_secret: str):
     http_entrypoint = "http" if _disable_ssl() else "https"
     _routers = {
         "shard_core_public": t.HttpRouter(
@@ -52,14 +55,14 @@ def _add_http_section(model: t.Model, portal: SafeIdentity):
             rule="PathPrefix(`/core/protected`)",
             entryPoints=[http_entrypoint],
             service="shard_core",
-            middlewares=["strip", "auth-private"],
+            middlewares=["strip", "auth-private", "verify-traefik"],
             tls=make_http_cert_resolver(portal),
         ),
         "shard_core_management": t.HttpRouter(
             rule="PathPrefix(`/core/management`)",
             entryPoints=[http_entrypoint],
             service="shard_core",
-            middlewares=["strip", "auth-management"],
+            middlewares=["strip", "auth-management", "verify-traefik"],
             tls=make_http_cert_resolver(portal),
         ),
         "web-terminal": t.HttpRouter(
@@ -111,6 +114,13 @@ def _add_http_section(model: t.Model, portal: SafeIdentity):
                         "X-Ptl-Client-Id": "",
                         "X-Ptl-Client-Name": "",
                     }
+                )
+            )
+        ),
+        "verify-traefik": t.HttpMiddleware(
+            root=t.HttpMiddlewareItem10(
+                headers=t.HeadersMiddleware(
+                    customRequestHeaders={TRAEFIK_SECRET_HEADER: traefik_secret}
                 )
             )
         ),

--- a/shard_core/service/traefik_secret.py
+++ b/shard_core/service/traefik_secret.py
@@ -1,0 +1,40 @@
+import logging
+import secrets
+
+from fastapi import Header, HTTPException, status
+
+from shard_core.database import database
+
+log = logging.getLogger(__name__)
+
+STORE_KEY_TRAEFIK_SECRET = "traefik_secret"
+HEADER_NAME = "X-Ptl-Traefik-Secret"
+_SECRET_LENGTH = 64
+
+
+async def ensure_traefik_secret() -> str:
+    try:
+        return await database.get_value(STORE_KEY_TRAEFIK_SECRET)
+    except KeyError:
+        secret = secrets.token_urlsafe(_SECRET_LENGTH)
+        await database.set_value(STORE_KEY_TRAEFIK_SECRET, secret)
+        log.info("Generated new Traefik verification secret")
+        return secret
+
+
+async def get_traefik_secret() -> str:
+    return await database.get_value(STORE_KEY_TRAEFIK_SECRET)
+
+
+async def verify_traefik_secret(x_ptl_traefik_secret: str = Header(None)):
+    try:
+        expected = await get_traefik_secret()
+    except KeyError:
+        log.error("Traefik verification secret missing from kv_store")
+        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+    if not x_ptl_traefik_secret or not secrets.compare_digest(
+        x_ptl_traefik_secret, expected
+    ):
+        log.warning("rejected request that did not traverse Traefik")
+        raise HTTPException(status.HTTP_403_FORBIDDEN)

--- a/shard_core/web/management/__init__.py
+++ b/shard_core/web/management/__init__.py
@@ -1,10 +1,13 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
+
+from shard_core.service.traefik_secret import verify_traefik_secret
 
 from . import apps, notify, pairing_code
 
 router = APIRouter(
     prefix="/management",
     tags=["/management"],
+    dependencies=[Depends(verify_traefik_secret)],
 )
 
 router.include_router(apps.router)

--- a/shard_core/web/protected/__init__.py
+++ b/shard_core/web/protected/__init__.py
@@ -1,4 +1,6 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
+
+from shard_core.service.traefik_secret import verify_traefik_secret
 
 from . import (
     apps,
@@ -17,6 +19,7 @@ from . import (
 router = APIRouter(
     prefix="/protected",
     tags=["/protected"],
+    dependencies=[Depends(verify_traefik_secret)],
 )
 
 router.include_router(apps.router)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,7 @@ from shard_core import app_factory
 from shard_core.data_model.identity import OutputIdentity, Identity
 from shard_core.data_model.profile import Profile
 from shard_core.database import database
-from shard_core.service import websocket, app_installation, telemetry
+from shard_core.service import websocket, app_installation, telemetry, traefik_secret
 from shard_core.service.app_tools import get_installed_apps_path
 from shard_core.settings import Settings, set_settings, reset_settings
 from shard_core.web.internal.call_peer import _get_app_for_ip_address
@@ -201,6 +201,9 @@ async def api_client(requests_mock, mocker) -> AsyncGenerator[AsyncClient]:
         ):
             whoareyou = (await client.get("/public/meta/whoareyou")).json()
             client.base_url = f'https://{whoareyou["domain"]}'
+            client.headers[traefik_secret.HEADER_NAME] = (
+                await traefik_secret.ensure_traefik_secret()
+            )
             await wait_until_all_apps_installed(client)
             yield client
 
@@ -229,6 +232,9 @@ async def app_client(mocker) -> AsyncGenerator[AsyncClient]:
         ) as client:
             whoareyou = (await client.get("/public/meta/whoareyou")).json()
             client.base_url = f'https://{whoareyou["domain"]}'
+            client.headers[traefik_secret.HEADER_NAME] = (
+                await traefik_secret.ensure_traefik_secret()
+            )
             yield client
     finally:
         await database.shutdown_database()

--- a/tests/test_traefik_dyn_spec.py
+++ b/tests/test_traefik_dyn_spec.py
@@ -50,6 +50,7 @@ async def test_template_is_written(api_client):
             "auth-public",
             "auth-private",
             "auth-management",
+            "verify-traefik",
         }
         assert "authResponseHeadersRegex" in out_middlewares["auth"]["forwardAuth"]
 

--- a/tests/test_traefik_secret.py
+++ b/tests/test_traefik_secret.py
@@ -4,9 +4,41 @@ import yaml
 from httpx import AsyncClient
 from starlette import status
 
+from shard_core.database import database
 from shard_core.service import traefik_secret
 from shard_core.service.app_installation.util import write_traefik_dyn_config
 from shard_core.settings import settings
+
+
+async def _drive_ws_handshake(app_client: AsyncClient, path: str) -> list[str]:
+    """Open a websocket against the ASGI app behind app_client using the client's
+    current headers, and return the ASGI message types the app sent back."""
+    app = app_client._transport.app
+    sent: list[dict] = []
+    received = {"n": 0}
+
+    async def receive():
+        received["n"] += 1
+        if received["n"] == 1:
+            return {"type": "websocket.connect"}
+        return {"type": "websocket.disconnect", "code": 1000}
+
+    async def send(message):
+        sent.append(message)
+
+    scope = {
+        "type": "websocket",
+        "path": path,
+        "raw_path": path.encode(),
+        "headers": [(k.encode(), v.encode()) for k, v in app_client.headers.items()],
+        "query_string": b"",
+        "scheme": "ws",
+        "subprotocols": [],
+        "client": ("10.0.0.9", 1234),
+        "server": ("shard_core", 80),
+    }
+    await app(scope, receive, send)
+    return [m["type"] for m in sent]
 
 
 def _read_traefik_dyn() -> dict:
@@ -68,6 +100,34 @@ async def test_forward_auth_endpoint_is_not_gated_by_secret(app_client: AsyncCli
     response = await app_client.get("internal/authenticate_terminal")
 
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+async def test_missing_secret_fails_closed_with_500(app_client: AsyncClient):
+    # A shard whose secret somehow never got stored must fail closed, not open.
+    await database.remove_value(traefik_secret.STORE_KEY_TRAEFIK_SECRET)
+
+    response = await app_client.get("protected/terminals")
+
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+
+
+async def test_protected_websocket_rejected_without_secret(app_client: AsyncClient):
+    # The /protected/ws/updates stream must not be openable by an app connecting
+    # directly (bypassing Traefik). Without the secret the handshake is denied, so the
+    # app never sees a websocket.accept.
+    del app_client.headers[traefik_secret.HEADER_NAME]
+
+    sent_types = await _drive_ws_handshake(app_client, "/protected/ws/updates")
+
+    assert "websocket.accept" not in sent_types
+
+
+async def test_protected_websocket_accepts_with_secret(app_client: AsyncClient):
+    # Positive control: with the Traefik-injected secret the same handshake is accepted.
+    # This is what makes the rejection test above meaningful rather than decorative.
+    sent_types = await _drive_ws_handshake(app_client, "/protected/ws/updates")
+
+    assert "websocket.accept" in sent_types
 
 
 async def test_traefik_config_injects_secret_on_sensitive_routers(app_client):

--- a/tests/test_traefik_secret.py
+++ b/tests/test_traefik_secret.py
@@ -1,0 +1,86 @@
+from pathlib import Path
+
+import yaml
+from httpx import AsyncClient
+from starlette import status
+
+from shard_core.service import traefik_secret
+from shard_core.service.app_installation.util import write_traefik_dyn_config
+from shard_core.settings import settings
+
+
+def _read_traefik_dyn() -> dict:
+    with open(
+        Path(settings().path_root) / "core" / "traefik_dyn" / "traefik_dyn.yml", "r"
+    ) as f:
+        return yaml.safe_load(f)
+
+
+async def test_protected_without_secret_is_rejected(app_client: AsyncClient):
+    del app_client.headers[traefik_secret.HEADER_NAME]
+
+    response = await app_client.get("protected/terminals")
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+async def test_protected_with_wrong_secret_is_rejected(app_client: AsyncClient):
+    app_client.headers[traefik_secret.HEADER_NAME] = "not-the-real-secret"
+
+    response = await app_client.get("protected/terminals")
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+async def test_protected_with_secret_is_allowed(app_client: AsyncClient):
+    response = await app_client.get("protected/terminals")
+
+    assert response.status_code == status.HTTP_200_OK
+
+
+async def test_management_without_secret_is_rejected(app_client: AsyncClient):
+    del app_client.headers[traefik_secret.HEADER_NAME]
+
+    response = await app_client.get("management/pairing_code")
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+async def test_management_with_secret_is_allowed(app_client: AsyncClient):
+    response = await app_client.get("management/pairing_code")
+
+    assert response.status_code == status.HTTP_200_OK
+
+
+async def test_public_needs_no_secret(app_client: AsyncClient):
+    del app_client.headers[traefik_secret.HEADER_NAME]
+
+    response = await app_client.get("public/meta/whoareyou")
+
+    assert response.status_code == status.HTTP_200_OK
+
+
+async def test_forward_auth_endpoint_is_not_gated_by_secret(app_client: AsyncClient):
+    # Traefik calls the forwardAuth endpoints directly (no verify-traefik middleware
+    # in the chain), so they must reject on their own auth (401), not the secret gate.
+    del app_client.headers[traefik_secret.HEADER_NAME]
+
+    response = await app_client.get("internal/authenticate_terminal")
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+async def test_traefik_config_injects_secret_on_sensitive_routers(app_client):
+    await write_traefik_dyn_config()
+    stored_secret = await traefik_secret.get_traefik_secret()
+    config = _read_traefik_dyn()
+
+    middleware = config["http"]["middlewares"]["verify-traefik"]
+    assert middleware["headers"]["customRequestHeaders"] == {
+        traefik_secret.HEADER_NAME: stored_secret
+    }
+
+    routers = config["http"]["routers"]
+    assert "verify-traefik" in routers["shard_core_private"]["middlewares"]
+    assert "verify-traefik" in routers["shard_core_management"]["middlewares"]
+    assert "verify-traefik" not in routers["shard_core_public"]["middlewares"]


### PR DESCRIPTION
## What & why

Closes the short-term half of #125.

Auth on a shard is enforced entirely by Traefik forwardAuth + docker network topology; FastAPI routes carry no auth dependency. Every installed app joins the same `portal` docker network as shard_core, which serves plain HTTP with no in-app auth — so any app container can `curl http://shard_core/protected/...` or `/management/...` directly and bypass all auth.

This adds a shared secret that only Traefik injects:

- `service/traefik_secret.py` generates a secret once (stored in `kv_store`, matching the `terminal_jwt_secret` pattern) and exposes a `verify_traefik_secret` FastAPI dependency that constant-time-compares the `X-Ptl-Traefik-Secret` request header.
- The Traefik dynamic config gains a `verify-traefik` middleware (`customRequestHeaders`) that injects the secret, wired onto the `shard_core_private` and `shard_core_management` routers.
- The `/protected` and `/management` routers now depend on `verify_traefik_secret`. A request that did not traverse Traefik lacks the header and is rejected with 403.

`/internal` is deliberately left ungated: its forwardAuth endpoints (`authenticate_terminal`, `authenticate_management`, `auth`) are called by Traefik **directly** (they never pass through the middleware chain, so they never carry the header), and `call_backend`/`call_peer` are called by apps directly by design.

## ⚠️ Scope limitation — please read (needs your call, @max-tet)

The review panel (below) found this mitigation is **intentionally partial** and only raises the bar. Because both Postgres (`kv_store`, default creds) and the Traefik dashboard (`api.insecure: true`) sit on the **same `portal` network** as the apps, an app that *actively targets* shard_core can still read the secret (`psql ... SELECT value FROM kv_store` or `curl http://traefik:8080/api/rawdata`) and forge the header. So this stops accidental/naive cross-app calls and any app not specifically hunting the secret — **but not a determined one**.

Fully sealing it needs the network-isolation work that #125 itself defers to its long-term half: isolate Postgres from `portal` (+ non-default creds) and disable the unauthenticated Traefik API. I kept this PR surgical (no topology changes) and did **not** fold that in, since #125 explicitly scopes it separately and it carries real deployment blast radius. **Decision for you:** merge this as the documented short-term step and track the network-hardening follow-up, or you'd prefer I expand scope here. The `agents.md` note is written to not overstate the protection.

## Acceptance criteria

- ✅ Test that a `/protected/...` request from inside `portal` without the injected secret is rejected (`test_protected_without_secret_is_rejected`).
- ✅ All existing tests pass; app→internal flows unaffected. Local run: **236 passed, 1 failed**. The single failure is `test_app_lifecycle.py::test_app_starts_and_stops`, a pre-existing **environmental** collision — the grind VM's own `clayde-traefik-1` permanently holds host port 80, which the `quick_stop` mock app publishes; the test fails at `docker compose up -d`, a path this change never touches. It is green on CI (port 80 free).

## Review panel

Three adversarial reviewers ran (each given only the diff + issue, instructed to refute):

**Adversarial correctness** — 1 blocking, 1 advisory.
- **BLOCKING: secret leaks via the unauthenticated Traefik dashboard** (`api.insecure: true` on `traefik:8080`, reachable on `portal`) → an app reads `customRequestHeaders` and forges the header. **Resolved:** confirmed real; it is a facet of the co-location limitation now documented in `agents.md` and in the scope section above, and escalated to you rather than silently fixed (dashboard hardening belongs with the deferred network-isolation half). Not fixed in-PR by design.
- Advisory: websocket route `/protected/ws/updates` gated via `HTTPException` (works today, unpinned). **Fixed** in `e60f242` — added a behavioral handshake test (with an accept-with-secret positive control).
- Cleared as non-issues: header duplicate/parse (Traefik overwrites), startup race, `/internal` correctly ungated, controller `/management` calls unaffected, no dead code.

**Security** — 2 blocking, 1 advisory, all the same co-location root cause.
- **BLOCKING: secret readable from Postgres** on `portal` (default creds) via `SELECT value FROM kv_store`. **BLOCKING: secret readable from the Traefik dashboard** (same as above). Advisory: readable from the dyn-config file via a path-traversal volume mount. **Resolved:** these are the co-location limitation — documented honestly and escalated as the network-isolation follow-up; not fixable inside this PR's scope (reviewer agreed: "cannot be fixed inside `traefik_secret.py` … requires network segmentation"). Cleared as sound: `compare_digest` usage, 512-bit entropy, no spoof-through-Traefik, no leak via `authResponseHeadersRegex ^X-Ptl-.*` (that copies *response* headers on the app routers only; `verify-traefik` is a request header on the `shard_core_*` routers), no secret in logs, fail-closed persistence.

**Test adversary** — 0 blocking, 2 advisory. Verified the committed negative/positive tests have real teeth by stripping the dependency and watching them fail.
- Advisory: ws route untested → **fixed** (`e60f242`). Advisory: 500-on-missing-secret branch untested → **fixed** (`e60f242`, `test_missing_secret_fails_closed_with_500`). Confirmed the conftest header injection masks nothing (routes had no gate before).

## Recommended reading order

1. `shard_core/service/traefik_secret.py` — the secret + verify dependency (new)
2. `shard_core/service/traefik_dynamic_config.py` — `verify-traefik` middleware, wired onto the two routers
3. `shard_core/service/app_installation/util.py` — fetch/ensure secret when compiling the config
4. `shard_core/web/protected/__init__.py`, `shard_core/web/management/__init__.py` — the router gate
5. `tests/conftest.py` — fixtures carry the secret header (simulate Traefik traversal)
6. `tests/test_traefik_secret.py`, `tests/test_traefik_dyn_spec.py` — coverage
7. `agents.md` — auth-model note incl. the scope limitation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
