### PR TITLE
Fix peer.py catching httpx exceptions around requests calls (#131)

### DIFF
--- a/shard_core/service/peer.py
+++ b/shard_core/service/peer.py
@@ -54,7 +54,7 @@ async def update_peer_meta(peer: Peer):
 
     try:
         response.raise_for_status()
-    except requests.exceptions.HTTPError as e:
+    except requests.HTTPError as e:
         log.debug(f"Could not update peer meta for {peer.short_id}: {e}")
         async with db_conn() as conn:
             await db_peers.update_by_id(conn, peer.id, {"is_reachable": False})

--- a/shard_core/service/peer.py
+++ b/shard_core/service/peer.py
@@ -35,9 +35,7 @@ async def update_all_peer_pubkeys():
     )
     for peer, result in zip(peers_with_pubkey, results):
         if isinstance(result, Exception):
-            log.warning(
-                f"Failed to update peer meta for {peer.short_id}: {result}"
-            )
+            log.warning(f"Failed to update peer meta for {peer.short_id}: {result}")
 
 
 async def update_peer_meta(peer: Peer):

--- a/shard_core/service/peer.py
+++ b/shard_core/service/peer.py
@@ -29,7 +29,15 @@ async def update_all_peer_pubkeys():
     async with db_conn() as conn:
         all_peers = await db_peers.get_all(conn)
     peers_with_pubkey = [Peer(**p) for p in all_peers if p.get("public_bytes_b64")]
-    await asyncio.gather(*[update_peer_meta(peer) for peer in peers_with_pubkey])
+    results = await asyncio.gather(
+        *[update_peer_meta(peer) for peer in peers_with_pubkey],
+        return_exceptions=True,
+    )
+    for peer, result in zip(peers_with_pubkey, results):
+        if isinstance(result, Exception):
+            log.warning(
+                f"Failed to update peer meta for {peer.short_id}: {result}"
+            )
 
 
 async def update_peer_meta(peer: Peer):

--- a/shard_core/service/peer.py
+++ b/shard_core/service/peer.py
@@ -1,7 +1,6 @@
 import asyncio
 import logging
 
-import httpx
 import requests
 from fastapi.requests import Request
 from http_message_signatures import HTTPSignatureKeyResolver, algorithms
@@ -49,7 +48,7 @@ async def update_peer_meta(peer: Peer):
 
     try:
         response.raise_for_status()
-    except httpx.HTTPStatusError as e:
+    except requests.exceptions.HTTPError as e:
         log.debug(f"Could not update peer meta for {peer.short_id}: {e}")
         async with db_conn() as conn:
             await db_peers.update_by_id(conn, peer.id, {"is_reachable": False})

--- a/tests/test_peer_refresh.py
+++ b/tests/test_peer_refresh.py
@@ -1,0 +1,79 @@
+import responses
+from starlette import status
+
+from shard_core.data_model.identity import Identity, OutputIdentity
+from shard_core.database import peers as db_peers
+from shard_core.database.connection import db_conn
+from shard_core.data_model.peer import Peer
+from shard_core.service.peer import update_all_peer_pubkeys
+
+
+def _whoareyou_url(identity: Identity) -> str:
+    return f"https://{identity.short_id}.freeshard.cloud/core/public/meta/whoareyou"
+
+
+async def _insert_peer(identity: Identity, name: str):
+    async with db_conn() as conn:
+        await db_peers.insert(
+            conn,
+            {
+                "id": identity.id,
+                "name": name,
+                "public_bytes_b64": identity.public_key_pem,
+                "is_reachable": True,
+            },
+        )
+
+
+async def _get_peer(identity: Identity) -> Peer:
+    async with db_conn() as conn:
+        return Peer(**await db_peers.get_by_id_prefix(conn, identity.id))
+
+
+async def test_unreachable_peer_does_not_block_others(db):
+    bad = Identity.create("bad peer")
+    good = Identity.create("good peer")
+    await _insert_peer(bad, name="stale bad")
+    await _insert_peer(good, name="stale good")
+
+    with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
+        rsps.get(_whoareyou_url(bad), status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        rsps.get(
+            _whoareyou_url(good),
+            json=OutputIdentity(**good.model_dump()).model_dump(),
+        )
+
+        await update_all_peer_pubkeys()
+
+    good_peer = await _get_peer(good)
+    assert good_peer.name == "good peer"
+    assert good_peer.is_reachable is True
+
+    bad_peer = await _get_peer(bad)
+    assert bad_peer.is_reachable is False
+
+
+async def test_unexpected_peer_error_does_not_block_others(db):
+    broken = Identity.create("broken peer")
+    good = Identity.create("good peer")
+    await _insert_peer(broken, name="stale broken")
+    await _insert_peer(good, name="stale good")
+
+    with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
+        # broken peer answers with a different identity than its stored id,
+        # which raises inside update_peer_meta and is not caught there
+        rsps.get(
+            _whoareyou_url(broken),
+            json=OutputIdentity(
+                **Identity.create("impostor").model_dump()
+            ).model_dump(),
+        )
+        rsps.get(
+            _whoareyou_url(good),
+            json=OutputIdentity(**good.model_dump()).model_dump(),
+        )
+
+        await update_all_peer_pubkeys()
+
+    good_peer = await _get_peer(good)
+    assert good_peer.name == "good peer"

--- a/tests/test_peer_refresh.py
+++ b/tests/test_peer_refresh.py
@@ -1,3 +1,5 @@
+import logging
+
 import responses
 from starlette import status
 
@@ -12,7 +14,7 @@ def _whoareyou_url(identity: Identity) -> str:
     return f"https://{identity.short_id}.freeshard.cloud/core/public/meta/whoareyou"
 
 
-async def _insert_peer(identity: Identity, name: str):
+async def _insert_peer(identity: Identity, name: str, is_reachable: bool = True):
     async with db_conn() as conn:
         await db_peers.insert(
             conn,
@@ -20,7 +22,7 @@ async def _insert_peer(identity: Identity, name: str):
                 "id": identity.id,
                 "name": name,
                 "public_bytes_b64": identity.public_key_pem,
-                "is_reachable": True,
+                "is_reachable": is_reachable,
             },
         )
 
@@ -34,7 +36,7 @@ async def test_unreachable_peer_does_not_block_others(db):
     bad = Identity.create("bad peer")
     good = Identity.create("good peer")
     await _insert_peer(bad, name="stale bad")
-    await _insert_peer(good, name="stale good")
+    await _insert_peer(good, name="stale good", is_reachable=False)
 
     with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
         rsps.get(_whoareyou_url(bad), status=status.HTTP_500_INTERNAL_SERVER_ERROR)
@@ -45,6 +47,10 @@ async def test_unreachable_peer_does_not_block_others(db):
 
         await update_all_peer_pubkeys()
 
+        # both peers were really contacted (the 500 path was exercised, not a
+        # silent ConnectionError fallback from a mismatched URL)
+        assert len(rsps.calls) == 2
+
     good_peer = await _get_peer(good)
     assert good_peer.name == "good peer"
     assert good_peer.is_reachable is True
@@ -53,11 +59,11 @@ async def test_unreachable_peer_does_not_block_others(db):
     assert bad_peer.is_reachable is False
 
 
-async def test_unexpected_peer_error_does_not_block_others(db):
+async def test_unexpected_peer_error_does_not_block_others(db, memory_logger):
     broken = Identity.create("broken peer")
     good = Identity.create("good peer")
     await _insert_peer(broken, name="stale broken")
-    await _insert_peer(good, name="stale good")
+    await _insert_peer(good, name="stale good", is_reachable=False)
 
     with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
         # broken peer answers with a different identity than its stored id,
@@ -77,3 +83,13 @@ async def test_unexpected_peer_error_does_not_block_others(db):
 
     good_peer = await _get_peer(good)
     assert good_peer.name == "good peer"
+    assert good_peer.is_reachable is True
+
+    # the unexpected error is swallowed by the gather and left the broken peer
+    # untouched, and it was surfaced via a warning
+    broken_peer = await _get_peer(broken)
+    assert broken_peer.name == "stale broken"
+    assert any(
+        r.levelno == logging.WARNING and broken.short_id in r.getMessage()
+        for r in memory_logger.records
+    )


### PR DESCRIPTION
Fixes #131.

## Problem

`shard_core/service/peer.py` `update_peer_meta` calls `requests.get(...)` and then `response.raise_for_status()`, which raises `requests.exceptions.HTTPError` — but the handler caught `httpx.HTTPStatusError`. So any non-2xx peer response escaped the handler, propagated through the `asyncio.gather` in `update_all_peer_pubkeys` (which had no `return_exceptions`), and aborted the whole peer-refresh cycle for that tick (only contained by `PeriodicTask` retrying a minute later).

## Change

- Catch `requests.HTTPError` instead of `httpx.HTTPStatusError`, so a non-2xx peer response marks that peer unreachable (as intended) instead of escaping. Dropped the now-unused `httpx` import.
- Add `return_exceptions=True` to the `gather`, with a per-peer warning log, so any *unexpected* exception from one peer (e.g. a wrong-identity `KeyError`) can no longer abort refreshing the others.
- New `tests/test_peer_refresh.py` with two regression tests over `update_all_peer_pubkeys`.

## Verification

`tests/test_peer_refresh.py` — 2 passed. Full suite: 227 passed; the one unrelated failure (`test_app_lifecycle.py::test_app_starts_and_stops`, a Docker container-status timing test) also fails on a clean `origin/main` on this runner, so it is pre-existing and not caused by this change.

Both new tests were proven to have teeth (each fails when the corresponding half of the fix is reverted):
- revert the exception type → `test_unreachable_peer_does_not_block_others` fails (bad peer no longer marked unreachable),
- remove `return_exceptions=True` → `test_unexpected_peer_error_does_not_block_others` fails (gather re-raises),
- remove the warning log → `test_unexpected_peer_error_does_not_block_others` fails (warning assertion).

## Review panel

Three reviewers ran (adversarial always-on; test-adversary because the diff adds real logic + tests; DevEx because it touches tests). **No blocking findings from any.** Advisories addressed:

- **Decorative `is_reachable is True` assertion** (test-adversary, adversarial, DevEx) — fixed: the good peer is now inserted `is_reachable=False`, so the success path's flip to `True` is actually asserted.
- **Test 1 couldn't distinguish the HTTPError path from a ConnectionError fallback** (test-adversary) — fixed: `assert len(rsps.calls) == 2` pins that both whoareyou requests fired.
- **Test 2 didn't assert isolation to the broken peer, and the new warning log was unasserted** (test-adversary, DevEx) — fixed: assert the broken peer is left untouched and that a warning containing its `short_id` was emitted.
- **Exception-alias style inconsistency** (DevEx) — fixed: use `requests.HTTPError` to read symmetrically with the adjacent `requests.ConnectionError` handler.

Advisories intentionally **not** addressed (out of scope for #131, pre-existing): other `requests` failure modes (`Timeout`, `SSLError`) don't mark a peer unreachable; `_on_peer_write` calls `update_peer_meta` outside the guarded gather. Neither is introduced or worsened by this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
