### PR TITLE
Core compose: map PAUSE_ENABLED env for staged shard_core config overrides

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,7 @@ services:
       - FREESHARD_TRAEFIK__ACME_EMAIL=${EMAIL:?}
       - FREESHARD_TRAEFIK__DISABLE_SSL=${DISABLE_SSL:-false}
       - FREESHARD_PATH_ROOT_HOST=${FREESHARD_DIR:?}
+      - FREESHARD_APPS__LIFECYCLE__PAUSE_ENABLED=${PAUSE_ENABLED:-false}
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
Closes #182.

## What + why

The controller (freeshard-controller#368) rolls out the PAUSED+PAGED tier to a subset of shards by writing a per-shard override into that shard's core `.env` on every converge. For that override to reach `shard_core`, the core-version `docker-compose.yml` must map the consuming env var with a safe default. Today the compose has no such mapping, so there is nothing for the controller override to feed into.

This adds the first consumer mapping to the `shard_core` service:

```yaml
- FREESHARD_APPS__LIFECYCLE__PAUSE_ENABLED=${PAUSE_ENABLED:-false}
```

`FREESHARD_` prefix + `__` delimiter is the existing pydantic-settings convention; the flag (`apps.lifecycle.pause_enabled`) already exists and is env-overridable, so no `shard_core` code change. The `:-false` guard mirrors `DISABLE_SSL` and avoids the empty-string boot-crash trap (an omitted or empty `PAUSE_ENABLED` behaves as the default `false`).

Not added to `.env.template` on purpose: this is controller-injected, not a self-hoster knob. Advertising it as a template var would invite manual edits the controller overwrites each converge.

## Acceptance criteria — verified

Proven directly (settings resolution + `docker compose config` interpolation):

- No `PAUSE_ENABLED` → `Settings().apps.lifecycle.pause_enabled` is `false` (fleet behavior identical); compose renders `"false"`.
- `PAUSE_ENABLED=true` → resolves `true`; compose renders `"true"`.

Falsifiable: a wrong single-underscore name would resolve `false` in both cases (silent-fallback trap); the `true` case resolving `true` proves the override lands.

## Out of scope

Controller-side override storage / injection / apply-config / operator UI — all in freeshard-controller#368.

## Review panel

- **Adversarial reviewer** (always-on): **no blocking findings.** Independently verified the setting exists and is consumed (`app_lifecycle.py:54`), the env-var name shape matches pydantic-settings nesting, env precedence outranks the `config.toml` `pause_enabled = false` baseline, the `:-false` guard avoids the empty-string crash, and the `.env.template` omission is correct. Advisory-only: the `config.toml` baseline is now redundant-but-harmless; no compose→settings test harness exists (matches the untested `DISABLE_SSL` precedent — out of scope).

No specialist reviewers triggered: pure config mapping, no logic path, no secret/token/authz/DB/API/UX surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
