### PR TITLE
Say why the registry and db credentials are checked in

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,17 @@ All communication is encrypted and authenticated using the shard IDs as trust an
 The Shard Core can be hosted on any machine that has access to the internet.
 It is recommended to use a machine that is always on, e.g. a virtual private server (VPS).
 
+### Where the apps come from
+
+A self-hosted shard is not self-contained. Both halves of the app catalogue are served by infrastructure Freeshard operates:
+
+- the catalogue metadata and the app packages come from an Azure blob container (`apps.app_store` in `config.toml`), and
+- the container images for the apps that do not use a public upstream image come from our container registry, `portalapps.azurecr.io`.
+
+Shard Core logs in to that registry at startup, using the credentials checked into `config.toml` under `[[apps.registries]]`. **Those credentials are committed on purpose.** The account is a Microsoft Entra service principal, `sp-apps-reader`, whose only role assignment anywhere in our subscription is `Reader`, scoped to that single registry — it can pull images and read registry metadata, and it can do nothing else: no push, no delete, no configuration change, no access to any other resource. It is shared with everyone who runs a shard because every shard needs it to install an app.
+
+If you would rather not depend on our infrastructure, note that this is what you would have to replace.
+
 ### Localhost
 
 In order to test freeshard, you might want to launch it on localhost first.

--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,10 @@
 path_root = "/"
 path_root_host = "/home/shard"
 
+# `password` here is a fixed default, not a secret. Postgres publishes no port to
+# the host; it is reachable only from the `portal` docker network, which every app
+# container on the shard also joins. Changing it per shard would buy nothing as
+# long as that is true, so it is left at the default and stated plainly instead.
 [db]
 host = "postgres"
 port = 5432
@@ -26,6 +30,18 @@ acme_email = "contact@freeshard.net"
 base_url = "https://storageaccountportab0da.blob.core.windows.net"
 container_name = "app-store"
 
+# These credentials are checked in deliberately and are not a leak.
+#
+# `portalapps.azurecr.io` is the container registry the app images are served
+# from, and every shard — including a self-hosted one — logs in to it at startup
+# to pull them. The account is the Microsoft Entra service principal
+# `sp-apps-reader`, whose only role assignment anywhere in the subscription is
+# `Reader`, scoped to this one registry. `Reader` grants `*/read` and no data
+# actions at all: it can pull images and read registry metadata, and it cannot
+# push, delete, change registry configuration, or reach any other Azure resource.
+#
+# So the credential is shared with everyone who runs a shard by design. Do not
+# copy the pattern for anything that can write.
 [[apps.registries]]
 uri = "portalapps.azurecr.io"
 username = "0e4000f7-41b1-45d6-9f2f-7e4a952a19b0"


### PR DESCRIPTION
Documentation only — no behaviour change, no credential change, two files touched.

A reader who finds a plaintext container-registry username and password on `main` of a public repository has to assume the worst. The self-hoster walkthrough did exactly that and reported it as an exposure. This writes the credential's actual scope down where it is found, so the next reader does not have to guess.

## Recommended reading order

1. `config.toml` — the two comments, at `[[apps.registries]]` and `[db]`
2. `README.md` — a new "Where the apps come from" subsection under Hosting

## What was verified, and how

Not asserted from the account name. Checked against Azure:

- The appId in `config.toml` resolves to the Microsoft Entra service principal **`sp-apps-reader`**.
- That principal has **exactly one role assignment in the entire subscription**: `Reader`, scoped to `…/registries/portalapps` — not the resource group, not the subscription.
- `az role definition list --name Reader` gives `actions: ["*/read"]` with an **empty `dataActions`**. No write action of any kind, no delete, no configuration change.
- There are no ACR scope-map tokens on the registry at all (`az acr token list` returns `[]`), which is what ruled out the other candidate shape for a GUID username. Anonymous pull is disabled, so the login is genuinely needed.

So the credential can pull images and read registry metadata, and it can do nothing else. It is shared with everyone who runs a shard by design, because every shard logs in at startup to install an app.

## Why documentation and not rotation

Rotation was the other option and it is not free: `login_docker_registries()` reads this file at every shard boot, so a new credential means a core release to the fleet, and the test suite performs a real `docker login` with the committed values, so `api_client` tests break until they are updated too. Since the scope is pull-only on a single registry, the exposure is the free egress on our Azure bill and the ability to enumerate our app images — both acceptable, neither improved by a rotation that leaves the credential just as public in the next commit.

If that judgement is ever revisited, the check to redo is the role assignment, not the account name.

## Also closes the disclosure half of #195

https://github.com/FreeshardBase/freeshard/issues/195 says self-hosting is not self-contained and that this is never disclosed. The README section states it: both the catalogue metadata and the app images come from infrastructure we operate, and that is what a self-hoster would have to replace.

## One thing the `[db]` comment deliberately does not say

It does not call the fixed `shard_core` password harmless. Postgres publishes no port to the host, but every app container joins the same `portal` network and can reach `postgres:5432` with those credentials. The comment says that plainly rather than reassuring.
