### PR TITLE
Publish the AI declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 
 Freeshard is a personal cloud computer that a consumer can rent for a small monthly fee (or selfhost) and which is as simple to use as a smartphone. Its aim is to restore people's sovereignty regarding the data they consume and produce - to give them a home on the internet.
 
+It is built by a small team working with coding agents. [ai-declaration.md](ai-declaration.md) states where AI is used and how far it goes.
+
 <div align="center" style="display: flex; flex-wrap: wrap; gap: 10px;">
     <a href="readme/gallery/pairing.png" target="_blank">
         <img src="readme/gallery/pairing.png" alt="Image 1" style="width: 150px; height: 100px; object-fit: cover;">

--- a/ai-declaration.md
+++ b/ai-declaration.md
@@ -1,0 +1,31 @@
+# AI Declaration — Freeshard
+
+Freeshard is built by two people and a fleet of coding agents. This file states where AI is used and how far it goes, so nobody has to guess from the commit history.
+
+Format follows the disclosure convention used by selfhosted@lemmy.world: each phase is rated Hint / Assisted / Pair / Generated.
+
+| Phase | Level | What that means here |
+|---|---|---|
+| Design | Pair | Architecture and product decisions are made by the two humans, in conversation with agents. Specs are drafted jointly and a human approves the spec before any code is written. |
+| Implementation | Generated | Most code in shard_core and the controller is written by headless agents working from triaged, specced issues — one fresh agent per issue, one pull request per issue. |
+| Testing | Generated | Tests are written by the same agents, including integration tests that run against real containers in CI. |
+| Documentation | Generated | Documentation, changelogs and the repository's own runbook libraries are agent-authored under a rule that every command, path and reference must be verified before it is written, then human-reviewed. |
+| Review | Pair | Every pull request gets an agent self-review and, for larger changes, an adversarial review by a second, independent agent. Nothing merges without a human approving it. That gate has never been automated and will not be. |
+| Deployment | Assisted | Releases and staged fleet rollouts are triggered and watched by a human, using tooling the agents built. |
+
+## What a human always does
+
+- Decides what gets built and in which order.
+- Writes or approves the specification for anything non-trivial.
+- Reviews and approves every pull request before it merges.
+- Runs and watches every release.
+
+## What this is not
+
+- It is not unreviewed generated code shipped to production. Every change passes a human review gate.
+- It is not an autonomous company. The agents have no authority over what gets built, what it costs, or what we promise anyone.
+- It is not a marketing claim. It is a description of a workflow, and it is here because communities we take part in ask for it — and because anyone can check it against our public commit history.
+
+Questions about any of this are welcome: contact@freeshard.net
+
+Last updated: 2026-08-24

--- a/ai-declaration.md
+++ b/ai-declaration.md
@@ -1,12 +1,12 @@
 # AI Declaration — Freeshard
 
-Freeshard is built by two people and a fleet of coding agents. This file states where AI is used and how far it goes, so nobody has to guess from the commit history.
+Freeshard is built by a small team and a fleet of coding agents. This file states where AI is used and how far it goes, so nobody has to guess from the commit history.
 
 Format follows the disclosure convention used by selfhosted@lemmy.world: each phase is rated Hint / Assisted / Pair / Generated.
 
 | Phase | Level | What that means here |
 |---|---|---|
-| Design | Pair | Architecture and product decisions are made by the two humans, in conversation with agents. Specs are drafted jointly and a human approves the spec before any code is written. |
+| Design | Pair | Architecture and product decisions are made by the humans on the team, in conversation with agents. Specs are drafted jointly and a human approves the spec before any code is written. |
 | Implementation | Generated | Most code in shard_core and the controller is written by headless agents working from triaged, specced issues — one fresh agent per issue, one pull request per issue. |
 | Testing | Generated | Tests are written by the same agents, including integration tests that run against real containers in CI. |
 | Documentation | Generated | Documentation, changelogs and the repository's own runbook libraries are agent-authored under a rule that every command, path and reference must be verified before it is written, then human-reviewed. |


### PR DESCRIPTION
Adds `ai-declaration.md` at the repository root. One new file, no other changes.

## What it is

A structured statement of where AI is used in building Freeshard, rating six phases — Design, Implementation, Testing, Documentation, Review, Deployment — each at Hint / Assisted / Pair / Generated.

The format is the disclosure convention of `selfhosted@lemmy.world`, which requires it from any post tagged `[AIP]` ("used AI in development in any capacity") and states that a missing disclosure means the post is removed. But the file is written to stand on its own, because it is also the artefact the press pitch, the LinkedIn thread and the blog point at instead of re-explaining the workflow each time.

Freeshard is an `[AIP]` project under any honest reading — the public commit history says so — so the declaration describes that rather than softening it.

## Provenance

The wording is the draft from the marketing plan's Lemmy playbook, read and agreed by Max on 2026-08-24 and published unchanged apart from filling in the date. The draft carried its own warning, which is worth repeating here: a disclosure that overstates human involvement is worse than none, and one that overstates agent involvement is a claim about a product people pay for.

## The row that is a promise

**Review — Pair.** It says every pull request gets an agent self-review, larger changes get an adversarial review by a second independent agent, and nothing merges without a human approving it — and that this gate has never been automated and will not be. That is a commitment about how the repo is run, not a description of existing tooling, and it is the line to defend if the workflow ever changes.

## Deliberately not in this PR

No link from `README.md`. Root placement already puts the file one click from the repo, and the README edit is a separate judgement about how prominent the disclosure should be. Easy to add if it should be visible from the front page.
