### PR TITLE
Verify the owner email before asserting email_verified

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,14 @@ Shard Core logs in to that registry at startup, using the credentials checked in
 
 If you would rather not depend on our infrastructure, note that this is what you would have to replace.
 
+### The owner's email address
+
+The owner's address lives on their user row and is verified by definition: a new address is only a candidate until somebody opens a confirmation link that was delivered to it. On a hosted shard the controller does that delivery, and it is also what mails the owner about disk space, billing and service notices.
+
+A self-hosted shard has no controller and therefore no way to send mail at all, so it cannot run that round trip. Set `oidc.email_verification = false` in `local_config.toml` and the address is taken as given, with no candidate step and no confirmation mail — acceptable because you control the machine. Leave it at its default of `true` and a self-hosted shard can never complete an address change, because the mail it waits for is never sent.
+
+The address is what the built-in OIDC provider emits as the `email` claim, alongside `email_verified`. With no confirmed address it emits neither, and apps you log into through it will create fresh accounts rather than linking to an existing one by address.
+
 ### Localhost
 
 In order to test freeshard, you might want to launch it on localhost first.

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ If you would rather not depend on our infrastructure, note that this is what you
 
 The owner's address lives on their user row and is verified by definition: a new address is only a candidate until somebody opens a confirmation link that was delivered to it. On a hosted shard the controller does that delivery, and it is also what mails the owner about disk space, billing and service notices.
 
-A self-hosted shard has no controller and therefore no way to send mail at all, so it cannot run that round trip. Set `oidc.email_verification = false` in `local_config.toml` and the address is taken as given, with no candidate step and no confirmation mail — acceptable because you control the machine. Leave it at its default of `true` and a self-hosted shard can never complete an address change, because the mail it waits for is never sent.
+A self-hosted shard has no controller and therefore no way to send mail at all, so it cannot run that round trip. Set `oidc.email_verification = false` in `local_config.toml` and the address is taken as given, with no candidate step and no confirmation mail — acceptable because you control the machine. Leave it at its default of `true` and setting an address fails with HTTP 502 — the address is kept as a candidate, but the confirmation mail that would promote it cannot be delivered.
 
 The address is what the built-in OIDC provider emits as the `email` claim, alongside `email_verified`. With no confirmed address it emits neither, and apps you log into through it will create fresh accounts rather than linking to an existing one by address.
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ If you would rather not depend on our infrastructure, note that this is what you
 
 The owner's address lives on their user row and is verified by definition: a new address is only a candidate until somebody opens a confirmation link that was delivered to it. On a hosted shard the controller does that delivery, and it is also what mails the owner about disk space, billing and service notices.
 
-A self-hosted shard has no controller and therefore no way to send mail at all, so it cannot run that round trip. Set `oidc.email_verification = false` in `local_config.toml` and the address is taken as given, with no candidate step and no confirmation mail — acceptable because you control the machine. Leave it at its default of `true` and setting an address fails with HTTP 502 — the address is kept as a candidate, but the confirmation mail that would promote it cannot be delivered.
+A self-hosted shard has no controller and therefore no way to send mail at all, so it cannot run that round trip. Set `email.enabled = false` in `local_config.toml` and the address is taken as given, with no candidate step and no confirmation mail — acceptable because you control the machine. Leave it at its default of `true` and setting an address fails with HTTP 502 — the address is kept as a candidate, but the confirmation mail that would promote it cannot be delivered.
 
 The address is what the built-in OIDC provider emits as the `email` claim, alongside `email_verified`. With no confirmed address it emits neither, and apps you log into through it will create fresh accounts rather than linking to an existing one by address.
 

--- a/agents.md
+++ b/agents.md
@@ -29,6 +29,7 @@ shard_core/
     memory_pressure.py  PSI parsing (/host/pressure/memory), cgroup v2 memory.reclaim page-out
     pause_metrics.py    In-memory pause-tier telemetry accumulators (transitions, latencies, PSI snapshots)
     pairing.py          Terminal pairing (JWT creation, code generation)
+    owner_email.py      Owner address: candidate, confirmation token, promotion
     backup.py           Azure Blob Storage backup via rclone
     peer.py             Peer shard management
     crypto.py           RSA-4096 key generation, signing, verification (PSS padding)
@@ -41,7 +42,9 @@ shard_core/
   database/           → PostgreSQL access layer (per-entity modules, conn-first-arg pattern)
   data_model/         → Pydantic v2 models
     app_meta.py         App metadata, Status enum, VMSize enum
-    identity.py         Shard identity (keys, domain, short_id)
+    identity.py         Shard identity (keys, domain, short_id) — the shard's
+                        public profile, published unauthenticated; holds no address
+    user.py             People on the shard (owner, later members) and their address
     terminal.py         Paired device models
     peer.py             Peer shard models
     backend/            Models copied from freeshard-controller (via `just get-types`)
@@ -71,7 +74,7 @@ async with db_conn() as conn:
     await db_installed_apps.update_status(conn, "myapp", Status.RUNNING)
 ```
 
-Tables: `identities`, `terminals`, `installed_apps`, `peers`, `backups`, `tours`, `app_usage_tracks`, `kv_store`.
+Tables: `identities`, `users`, `terminals`, `installed_apps`, `peers`, `backups`, `tours`, `app_usage_tracks`, `kv_store`, `oidc_clients`, `oidc_codes`, `oidc_tokens`.
 
 Postgres data is not part of the rclone backup set (which only syncs `core/`/`user_data/`). To keep it, `database/db_snapshot.py` dumps all application tables to `core/db_snapshot.json` before each backup, and `init_database()` restores it on a fresh shard (before the default identity is generated, so the restored identity survives). Pre-0.38 backups are restored from TinyDB by `tinydb_migration.py` instead.
 
@@ -89,6 +92,35 @@ Started at app lifespan startup, stopped at shutdown:
 - `CronTask(start_backup, "0 3 * * *")` — daily backup with random delay
 - `CronTask(docker_prune_images, daily)` — image cleanup
 - Various telemetry and peer key refresh tasks
+
+### The Owner's Email Address
+`users.email` is the single home for a person's address and is **verified by
+definition**; `users.pending_email` is an unverified candidate, at most one in
+flight per user. That invariant is the whole reason the OIDC provider may assert
+`email_verified: true` — a relying party consults that claim before linking an
+OIDC identity to an existing local account. With no verified address the provider
+emits no `email` claim and no `email_verified` at all; there is deliberately no
+synthetic fallback.
+
+`service/owner_email.py` owns the transitions. Setting an address writes the
+candidate, mints a single-use token (1h, stored as a SHA-256 digest) and asks the
+controller to deliver it — the controller owns the template and builds the link
+from the shard domain it already knows, so no shard-supplied URL is ever mailed.
+`POST /public/users/confirm-email` is the only unauthenticated surface: the token
+is its sole credential, compared with `secrets.compare_digest`, rate limited, and
+answered with an identical 204 whether or not it matched, so it cannot be used to
+probe for pending addresses. There is no `GET` confirmation route on purpose —
+mail scanners and link prefetchers would burn the single-use token.
+
+On confirmation, in this order: notify the old address, promote the candidate,
+mirror to `shards.owner_email` on the controller, notify the new address. The
+first step must precede the mirror, because the controller's relay only ever
+sends to the address it currently has on file.
+
+`oidc.email_verification` (default `true`) is the explicit self-hosted signal. A
+self-hosted shard has no controller and therefore no mail at all, so it sets the
+address directly. Never infer this from a failed delivery — a controller outage
+would silently downgrade a security control.
 
 ### Signals (Event System)
 Blinker-based async signals defined in `util/signals.py`. DB-writing handlers are async and called via `await signal.send_async()`:

--- a/agents.md
+++ b/agents.md
@@ -99,7 +99,7 @@ Started at app lifespan startup, stopped at shutdown:
 - `service/owner_email.py` owns every transition. Anything that writes `pending_email` must retire the token with it, or the token promotes an address it was never sent to.
 - On confirmation, in this order: notify the old address, promote, mirror to `shards.owner_email`, notify the new one. The first step must precede the mirror — the controller's relay only ever reaches the address it currently has on file.
 - `POST /public/users/confirm-email` is unauthenticated by design and the token is its only credential. There is no `GET`: mail scanners and link prefetchers would burn a single-use token.
-- `oidc.email_verification` (default `true`) is the explicit self-hosted signal — no controller means no mail, so the address is set directly. Never infer it from a failed delivery; a controller outage would silently downgrade a security control.
+- `email.enabled` (default `true`) says whether the shard can send mail at all, and is the explicit self-hosted signal — no controller means no mail, so the address is set directly. Never infer it from a failed delivery; a controller outage would silently downgrade a security control.
 
 ### Signals (Event System)
 Blinker-based async signals defined in `util/signals.py`. DB-writing handlers are async and called via `await signal.send_async()`:

--- a/agents.md
+++ b/agents.md
@@ -94,33 +94,12 @@ Started at app lifespan startup, stopped at shutdown:
 - Various telemetry and peer key refresh tasks
 
 ### The Owner's Email Address
-`users.email` is the single home for a person's address and is **verified by
-definition**; `users.pending_email` is an unverified candidate, at most one in
-flight per user. That invariant is the whole reason the OIDC provider may assert
-`email_verified: true` — a relying party consults that claim before linking an
-OIDC identity to an existing local account. With no verified address the provider
-emits no `email` claim and no `email_verified` at all; there is deliberately no
-synthetic fallback.
+`users.email` is the single home for a person's address and is **verified by definition**; `users.pending_email` is an unverified candidate, at most one in flight per user. That invariant is the only reason the OIDC provider may assert `email_verified: true` — with no verified address it emits neither claim, and there is deliberately no synthetic fallback.
 
-`service/owner_email.py` owns the transitions. Setting an address writes the
-candidate, mints a single-use token (1h, stored as a SHA-256 digest) and asks the
-controller to deliver it — the controller owns the template and builds the link
-from the shard domain it already knows, so no shard-supplied URL is ever mailed.
-`POST /public/users/confirm-email` is the only unauthenticated surface: the token
-is its sole credential, compared with `secrets.compare_digest`, rate limited, and
-answered with an identical 204 whether or not it matched, so it cannot be used to
-probe for pending addresses. There is no `GET` confirmation route on purpose —
-mail scanners and link prefetchers would burn the single-use token.
-
-On confirmation, in this order: notify the old address, promote the candidate,
-mirror to `shards.owner_email` on the controller, notify the new address. The
-first step must precede the mirror, because the controller's relay only ever
-sends to the address it currently has on file.
-
-`oidc.email_verification` (default `true`) is the explicit self-hosted signal. A
-self-hosted shard has no controller and therefore no mail at all, so it sets the
-address directly. Never infer this from a failed delivery — a controller outage
-would silently downgrade a security control.
+- `service/owner_email.py` owns every transition. Anything that writes `pending_email` must retire the token with it, or the token promotes an address it was never sent to.
+- On confirmation, in this order: notify the old address, promote, mirror to `shards.owner_email`, notify the new one. The first step must precede the mirror — the controller's relay only ever reaches the address it currently has on file.
+- `POST /public/users/confirm-email` is unauthenticated by design and the token is its only credential. There is no `GET`: mail scanners and link prefetchers would burn a single-use token.
+- `oidc.email_verification` (default `true`) is the explicit self-hosted signal — no controller means no mail, so the address is set directly. Never infer it from a failed delivery; a controller outage would silently downgrade a security control.
 
 ### Signals (Event System)
 Blinker-based async signals defined in `util/signals.py`. DB-writing handlers are async and called via `await signal.send_async()`:

--- a/config.toml
+++ b/config.toml
@@ -75,6 +75,7 @@ send_interval_seconds = 300
 
 [oidc]
 enabled = false
+email_verification = true
 
 [management]
 api_url = "https://ptlfunctionapp.azurewebsites.net/api/management"

--- a/config.toml
+++ b/config.toml
@@ -75,7 +75,9 @@ send_interval_seconds = 300
 
 [oidc]
 enabled = false
-email_verification = true
+
+[email]
+enabled = true
 
 [management]
 api_url = "https://ptlfunctionapp.azurewebsites.net/api/management"

--- a/migrations/shard-core-0005-owner-email-verification.sql
+++ b/migrations/shard-core-0005-owner-email-verification.sql
@@ -1,0 +1,24 @@
+-- shard-core-0005-owner-email-verification
+-- depends: shard-core-0004-oidc
+
+-- users.email becomes the single home for a person's address, and it is
+-- verified by definition. pending_email holds an unverified candidate, at most
+-- one per user, together with the digest and expiry of its confirmation token.
+ALTER TABLE users ADD COLUMN pending_email TEXT;
+ALTER TABLE users ADD COLUMN email_token_hash TEXT;
+ALTER TABLE users ADD COLUMN email_token_expires TIMESTAMPTZ;
+
+-- identities.email was editable on the Public page and never verified, so it
+-- carries over as a candidate rather than as the owner's verified address.
+UPDATE users
+SET pending_email = (SELECT email FROM identities WHERE is_default = TRUE LIMIT 1)
+WHERE role = 'owner';
+
+-- Every users.email written so far is either the synthetic owner@<domain> or an
+-- unverified copy of identities.email. Neither may be asserted as verified, so
+-- every shard lands with no verified address.
+UPDATE users SET email = NULL;
+
+-- An identity is the shard's public profile, published unauthenticated by
+-- GET /public/meta/whoareyou; a personal address has no business there.
+ALTER TABLE identities DROP COLUMN email;

--- a/migrations/shard-core-0005-owner-email-verification.sql
+++ b/migrations/shard-core-0005-owner-email-verification.sql
@@ -8,16 +8,23 @@ ALTER TABLE users ADD COLUMN pending_email TEXT;
 ALTER TABLE users ADD COLUMN email_token_hash TEXT;
 ALTER TABLE users ADD COLUMN email_token_expires TIMESTAMPTZ;
 
+-- the two token columns are only ever written together
+ALTER TABLE users ADD CONSTRAINT users_email_token_paired
+    CHECK ((email_token_hash IS NULL) = (email_token_expires IS NULL));
+
 -- identities.email was editable on the Public page and never verified, so it
 -- carries over as a candidate rather than as the owner's verified address.
+-- NULLIF because the dropped column defaulted to '' rather than NULL on the
+-- Public page, and an empty candidate is one nobody can ever confirm.
 UPDATE users
-SET pending_email = (SELECT email FROM identities WHERE is_default = TRUE LIMIT 1)
+SET pending_email = NULLIF(
+    (SELECT email FROM identities WHERE is_default = TRUE LIMIT 1), '')
 WHERE role = 'owner';
 
 -- Every users.email written so far is either the synthetic owner@<domain> or an
 -- unverified copy of identities.email. Neither may be asserted as verified, so
 -- every shard lands with no verified address.
-UPDATE users SET email = NULL;
+UPDATE users SET email = NULL WHERE role = 'owner';
 
 -- An identity is the shard's public profile, published unauthenticated by
 -- GET /public/meta/whoareyou; a personal address has no business there.

--- a/shard_core/data_model/identity.py
+++ b/shard_core/data_model/identity.py
@@ -1,7 +1,6 @@
 from typing import Optional
 
-from email_validator import validate_email, EmailNotValidError
-from pydantic import field_validator, BaseModel, computed_field
+from pydantic import BaseModel, computed_field
 
 from shard_core.service import crypto
 from shard_core.settings import settings
@@ -10,7 +9,6 @@ from shard_core.settings import settings
 class Identity(BaseModel):
     id: str
     name: str
-    email: Optional[str] = None
     description: Optional[str] = None
     private_key: str
     is_default: bool = False
@@ -18,26 +16,13 @@ class Identity(BaseModel):
     def __str__(self):
         return f"Identity[{self.short_id}, {self.name}]"
 
-    @field_validator("email")
     @classmethod
-    def validate_email(cls, v):
-        if v:
-            try:
-                validate_email(v)
-            except EmailNotValidError as e:
-                raise ValueError(f"invalid email: {e}") from e
-        return v
-
-    @classmethod
-    def create(
-        cls, name: str, description: str = None, email: str = None
-    ) -> "Identity":
+    def create(cls, name: str, description: str = None) -> "Identity":
         private_key = crypto.PrivateKey()
         return Identity(
             id=private_key.get_public_key().to_hash_id(),
             name=name,
             description=description,
-            email=email,
             private_key=private_key.to_bytes().decode(),
         )
 
@@ -86,7 +71,6 @@ class SafeIdentity(BaseModel):
 class OutputIdentity(BaseModel):
     id: str
     name: str
-    email: Optional[str] = None
     description: Optional[str] = None
     is_default: bool
     public_key_pem: str
@@ -96,15 +80,4 @@ class OutputIdentity(BaseModel):
 class InputIdentity(BaseModel):
     id: Optional[str] = None
     name: Optional[str] = ""
-    email: Optional[str] = ""
     description: Optional[str] = ""
-
-    @field_validator("email")
-    @classmethod
-    def validate_email(cls, v):
-        if v:
-            try:
-                validate_email(v)
-            except EmailNotValidError as e:
-                raise ValueError(f"invalid email: {e}") from e
-        return v

--- a/shard_core/data_model/user.py
+++ b/shard_core/data_model/user.py
@@ -50,7 +50,11 @@ class InputUser(BaseModel):
     def validate_email(cls, v):
         if v:
             try:
-                validate_email(v)
+                # No deliverability check: it is a blocking DNS query on the
+                # event loop, and an MX record says nothing about whether the
+                # person reads that mailbox. The confirmation mail is what
+                # settles that.
+                validate_email(v, check_deliverability=False)
             except EmailNotValidError as e:
                 raise ValueError(f"invalid email: {e}") from e
         return v

--- a/shard_core/data_model/user.py
+++ b/shard_core/data_model/user.py
@@ -2,7 +2,8 @@ from datetime import datetime
 from enum import Enum
 from typing import Optional
 
-from pydantic import BaseModel
+from email_validator import validate_email, EmailNotValidError
+from pydantic import BaseModel, field_validator
 
 
 class Role(str, Enum):
@@ -16,9 +17,40 @@ class User(BaseModel):
     username: str
     display_name: str
     email: Optional[str] = None
+    pending_email: Optional[str] = None
+    email_token_hash: Optional[str] = None
+    email_token_expires: Optional[datetime] = None
     role: Role = Role.MEMBER
     disabled: bool = False
     created: Optional[datetime] = None
 
     def __str__(self):
         return f"User[{self.id}, {self.username}]"
+
+
+class OutputUser(BaseModel):
+    id: int
+    username: str
+    display_name: str
+    email: Optional[str] = None
+    pending_email: Optional[str] = None
+    role: Role
+
+    @classmethod
+    def from_user(cls, user: User) -> "OutputUser":
+        return cls(**user.model_dump())
+
+
+class InputUser(BaseModel):
+    display_name: Optional[str] = None
+    email: Optional[str] = None
+
+    @field_validator("email")
+    @classmethod
+    def validate_email(cls, v):
+        if v:
+            try:
+                validate_email(v)
+            except EmailNotValidError as e:
+                raise ValueError(f"invalid email: {e}") from e
+        return v

--- a/shard_core/data_model/user.py
+++ b/shard_core/data_model/user.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import Optional
 
 from email_validator import validate_email, EmailNotValidError
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, Field, field_validator
 
 
 class Role(str, Enum):
@@ -42,19 +42,27 @@ class OutputUser(BaseModel):
 
 
 class InputUser(BaseModel):
-    display_name: Optional[str] = None
-    email: Optional[str] = None
+    display_name: Optional[str] = Field(default=None, max_length=200)
+    email: Optional[str] = Field(default=None, max_length=254)
 
     @field_validator("email")
     @classmethod
     def validate_email(cls, v):
-        if v:
-            try:
-                # No deliverability check: it is a blocking DNS query on the
-                # event loop, and an MX record says nothing about whether the
-                # person reads that mailbox. The confirmation mail is what
-                # settles that.
-                validate_email(v, check_deliverability=False)
-            except EmailNotValidError as e:
-                raise ValueError(f"invalid email: {e}") from e
-        return v
+        """Reject anything that is not an address; `null` is how you clear one.
+
+        An empty string is a rejection, not a clear — a form that blanks its
+        field must not take the notify-then-clear path by accident.
+        """
+        if v is None:
+            return None
+        try:
+            # No deliverability check: it is a blocking DNS query on the event
+            # loop, and an MX record says nothing about who reads the mailbox.
+            validated = validate_email(
+                v, check_deliverability=False, allow_smtputf8=False
+            )
+        except EmailNotValidError as e:
+            raise ValueError(f"invalid email: {e}") from e
+        # the normalized form is what gets asserted as verified to third
+        # parties, so store that rather than whatever casing was typed
+        return validated.normalized

--- a/shard_core/database/db_snapshot.py
+++ b/shard_core/database/db_snapshot.py
@@ -105,7 +105,30 @@ async def restore_db_snapshot():
                 await _insert_row(conn, table, row, col_types)
             await _reset_sequences(conn, table, list(col_types))
             restored += len(rows)
+        await _demote_unverified_owner_email(conn, snapshot)
     log.info(f"restored {restored} rows from DB snapshot")
+
+
+async def _demote_unverified_owner_email(conn: AsyncConnection, snapshot: dict):
+    """Apply the 0005 migration's rule to a snapshot that predates it.
+
+    Before 0005 the owner's users.email was the synthetic owner@<domain> or an
+    unverified copy of identities.email, and restoring it as-is would hand the
+    OIDC provider an address it would assert as verified. A snapshot from that
+    era is recognisable by its identity rows still carrying an email column.
+    """
+    identities = snapshot.get("identities") or []
+    if not any("email" in row for row in identities):
+        return
+    candidate = next(
+        (row["email"] for row in identities if row.get("is_default") and row["email"]),
+        None,
+    )
+    await conn.execute(
+        "UPDATE users SET email = NULL, pending_email = %s WHERE role = 'owner'",
+        (candidate,),
+    )
+    log.info("restored owner address from a pre-0005 snapshot as unverified")
 
 
 async def _list_data_tables(conn: AsyncConnection) -> list[str]:
@@ -172,7 +195,14 @@ async def _column_types(conn: AsyncConnection, table: str) -> dict[str, str]:
 async def _insert_row(
     conn: AsyncConnection, table: str, row: dict, col_types: dict[str, str]
 ):
-    values = {c: _adapt_value(v, col_types.get(c)) for c, v in row.items()}
+    dropped = [c for c in row if c not in col_types]
+    if dropped:
+        # a snapshot written by an older version carries columns this schema has
+        # since dropped; inserting them would abort the whole restore
+        log.info(f"ignoring columns no longer in {table}: {', '.join(dropped)}")
+    values = {
+        c: _adapt_value(v, col_types[c]) for c, v in row.items() if c in col_types
+    }
     columns = list(values)
     query = sql.SQL(
         "INSERT INTO {table} ({columns}) VALUES ({placeholders}) "

--- a/shard_core/database/db_snapshot.py
+++ b/shard_core/database/db_snapshot.py
@@ -101,6 +101,7 @@ async def restore_db_snapshot():
             if not rows:
                 continue
             col_types = await _column_types(conn, table)
+            _warn_about_dropped_columns(table, rows[0], col_types)
             for row in rows:
                 await _insert_row(conn, table, row, col_types)
             await _reset_sequences(conn, table, list(col_types))
@@ -121,7 +122,11 @@ async def _demote_unverified_owner_email(conn: AsyncConnection, snapshot: dict):
     if not any("email" in row for row in identities):
         return
     candidate = next(
-        (row["email"] for row in identities if row.get("is_default") and row["email"]),
+        (
+            row["email"]
+            for row in identities
+            if row.get("is_default") and row.get("email")
+        ),
         None,
     )
     await conn.execute(
@@ -195,11 +200,6 @@ async def _column_types(conn: AsyncConnection, table: str) -> dict[str, str]:
 async def _insert_row(
     conn: AsyncConnection, table: str, row: dict, col_types: dict[str, str]
 ):
-    dropped = [c for c in row if c not in col_types]
-    if dropped:
-        # a snapshot written by an older version carries columns this schema has
-        # since dropped; inserting them would abort the whole restore
-        log.info(f"ignoring columns no longer in {table}: {', '.join(dropped)}")
     values = {
         c: _adapt_value(v, col_types[c]) for c, v in row.items() if c in col_types
     }
@@ -213,6 +213,15 @@ async def _insert_row(
         placeholders=sql.SQL(", ").join(map(sql.Placeholder, columns)),
     )
     await conn.execute(query, values)
+
+
+def _warn_about_dropped_columns(table: str, row: dict, col_types: dict[str, str]):
+    """A snapshot written by an older version carries columns this schema has
+    since dropped. _insert_row skips them — inserting them would abort the whole
+    restore — but a silent skip on a disaster-recovery path deserves a line."""
+    dropped = [c for c in row if c not in col_types]
+    if dropped:
+        log.warning(f"ignoring columns no longer in {table}: {', '.join(dropped)}")
 
 
 def _adapt_value(value, data_type: str | None):

--- a/shard_core/database/identities.py
+++ b/shard_core/database/identities.py
@@ -3,7 +3,7 @@ from typing import LiteralString
 from psycopg import AsyncConnection
 from psycopg.rows import dict_row
 
-_UPDATABLE_COLUMNS = {"name", "email", "description", "private_key", "is_default"}
+_UPDATABLE_COLUMNS = {"name", "description", "private_key", "is_default"}
 
 
 async def get_all(conn: AsyncConnection) -> list[dict]:
@@ -35,8 +35,8 @@ async def search_by_name(conn: AsyncConnection, name: str) -> list[dict]:
 
 
 async def insert(conn: AsyncConnection, identity: dict) -> dict:
-    sql: LiteralString = """INSERT INTO identities (id, name, email, description, private_key, is_default)
-        VALUES (%(id)s, %(name)s, %(email)s, %(description)s, %(private_key)s, %(is_default)s)
+    sql: LiteralString = """INSERT INTO identities (id, name, description, private_key, is_default)
+        VALUES (%(id)s, %(name)s, %(description)s, %(private_key)s, %(is_default)s)
         RETURNING *"""
     async with conn.cursor(row_factory=dict_row) as cur:
         await cur.execute(sql, identity)

--- a/shard_core/database/tinydb_migration.py
+++ b/shard_core/database/tinydb_migration.py
@@ -29,7 +29,7 @@ log = logging.getLogger(__name__)
 _TINYDATE_PREFIX = "{TinyDate}:"
 
 # Columns that exist in the DB for each table — used to filter out computed fields
-_IDENTITY_COLUMNS = {"id", "name", "email", "description", "private_key", "is_default"}
+_IDENTITY_COLUMNS = {"id", "name", "description", "private_key", "is_default"}
 _INSTALLED_APP_COLUMNS = {"name", "installation_reason", "status", "last_access"}
 _TERMINAL_COLUMNS = {"id", "name", "icon", "last_connection"}
 _PEER_COLUMNS = {"id", "name", "public_bytes_b64", "is_reachable"}
@@ -71,8 +71,8 @@ async def migrate_tinydb_data():
 
     async with db_conn() as conn:
         await _migrate_kv_store(conn, data.get("_default", {}))
-        await _migrate_identities(conn, data.get("identities", {}))
-        owner_id = await _ensure_owner_user(conn)
+        pending_email = await _migrate_identities(conn, data.get("identities", {}))
+        owner_id = await _ensure_owner_user(conn, pending_email)
         await _migrate_installed_apps(conn, data.get("installed_apps", {}))
         await _migrate_terminals(conn, data.get("terminals", {}), owner_id)
         await _migrate_peers(conn, data.get("peers", {}))
@@ -96,16 +96,25 @@ async def _migrate_kv_store(conn: AsyncConnection, records: dict):
     log.info(f"migrated {len(records)} kv_store entries")
 
 
-async def _migrate_identities(conn: AsyncConnection, records: dict):
+async def _migrate_identities(conn: AsyncConnection, records: dict) -> str | None:
+    """Insert the identities and return the default one's TinyDB-era address.
+
+    That address was never verified, so it is handed to the owner user as a
+    candidate rather than written to the identity, which no longer holds one.
+    """
+    default_email = None
     for record in records.values():
+        if record.get("is_default") and record.get("email"):
+            default_email = record["email"]
         filtered = _filter_keys(record, _IDENTITY_COLUMNS)
         await conn.execute(
-            """INSERT INTO identities (id, name, email, description, private_key, is_default)
-               VALUES (%(id)s, %(name)s, %(email)s, %(description)s, %(private_key)s, %(is_default)s)
+            """INSERT INTO identities (id, name, description, private_key, is_default)
+               VALUES (%(id)s, %(name)s, %(description)s, %(private_key)s, %(is_default)s)
                ON CONFLICT (id) DO NOTHING""",
             filtered,
         )
     log.info(f"migrated {len(records)} identities")
+    return default_email
 
 
 async def _migrate_installed_apps(conn: AsyncConnection, records: dict):
@@ -122,17 +131,22 @@ async def _migrate_installed_apps(conn: AsyncConnection, records: dict):
     log.info(f"migrated {len(records)} installed apps")
 
 
-async def _ensure_owner_user(conn: AsyncConnection) -> int | None:
+async def _ensure_owner_user(
+    conn: AsyncConnection, pending_email: str | None
+) -> int | None:
     """Terminals require a user (NOT NULL); create the owner from the just-
     migrated default identity, mirroring the 0002 migration's backfill."""
     cur = await conn.execute("SELECT id FROM users WHERE role = 'owner'")
     row = await cur.fetchone()
     if row:
         return row[0]
-    cur = await conn.execute("""INSERT INTO users (username, display_name, email, role)
-           SELECT 'owner', COALESCE(name, 'Shard Owner'), email, 'owner'
+    cur = await conn.execute(
+        """INSERT INTO users (username, display_name, pending_email, role)
+           SELECT 'owner', COALESCE(name, 'Shard Owner'), %s, 'owner'
            FROM identities WHERE is_default = TRUE
-           RETURNING id""")
+           RETURNING id""",
+        (pending_email,),
+    )
     row = await cur.fetchone()
     return row[0] if row else None
 

--- a/shard_core/database/users.py
+++ b/shard_core/database/users.py
@@ -5,7 +5,16 @@ from psycopg.rows import class_row
 
 from shard_core.data_model.user import User
 
-_UPDATABLE_COLUMNS = {"username", "display_name", "email", "role", "disabled"}
+_UPDATABLE_COLUMNS = {
+    "username",
+    "display_name",
+    "email",
+    "pending_email",
+    "email_token_hash",
+    "email_token_expires",
+    "role",
+    "disabled",
+}
 
 
 async def get_by_id(conn: AsyncConnection, id: int) -> User | None:
@@ -45,6 +54,18 @@ async def update(conn: AsyncConnection, id: int, data: dict) -> User | None:
     async with conn.cursor(row_factory=class_row(User)) as cur:
         await cur.execute(sql, params)
         return await cur.fetchone()
+
+
+async def get_all_with_pending_email_token(conn: AsyncConnection) -> list[User]:
+    """Every user holding a confirmation token, for constant-time token matching.
+
+    Looking the digest up in SQL would be simpler, but the comparison then
+    happens inside the index rather than in secrets.compare_digest.
+    """
+    sql: LiteralString = "SELECT * FROM users WHERE email_token_hash IS NOT NULL"
+    async with conn.cursor(row_factory=class_row(User)) as cur:
+        await cur.execute(sql)
+        return await cur.fetchall()
 
 
 async def count(conn: AsyncConnection) -> int:

--- a/shard_core/database/users.py
+++ b/shard_core/database/users.py
@@ -57,15 +57,46 @@ async def update(conn: AsyncConnection, id: int, data: dict) -> User | None:
 
 
 async def get_all_with_pending_email_token(conn: AsyncConnection) -> list[User]:
-    """Every user holding a confirmation token, for constant-time token matching.
-
-    Looking the digest up in SQL would be simpler, but the comparison then
-    happens inside the index rather than in secrets.compare_digest.
-    """
+    """Every user holding a confirmation token, so the caller can match the
+    digest with secrets.compare_digest rather than inside an index."""
     sql: LiteralString = "SELECT * FROM users WHERE email_token_hash IS NOT NULL"
     async with conn.cursor(row_factory=class_row(User)) as cur:
         await cur.execute(sql)
         return await cur.fetchall()
+
+
+async def claim_email_token(conn: AsyncConnection, id: int, token_hash: str):
+    """Spend the confirmation token, returning the row it was spent on.
+
+    The token is cleared and the candidate read in one statement, so a
+    double-submitted link promotes once: the second call matches nothing.
+    Returns None when the token is gone, expired, or has no candidate left.
+    The returned row still carries the pending_email to promote.
+    """
+    sql: LiteralString = """UPDATE users
+        SET email_token_hash = NULL, email_token_expires = NULL
+        WHERE id = %s
+          AND email_token_hash = %s
+          AND email_token_expires > now()
+          AND pending_email IS NOT NULL
+        RETURNING *"""
+    async with conn.cursor(row_factory=class_row(User)) as cur:
+        await cur.execute(sql, (id, token_hash))
+        return await cur.fetchone()
+
+
+async def promote_pending_email(conn: AsyncConnection, id: int, address: str):
+    """Make *address* the verified address, unless the candidate moved on.
+
+    Guarded on pending_email so a candidate set while this confirmation was in
+    flight survives instead of being cleared by it.
+    """
+    sql: LiteralString = """UPDATE users SET email = %(address)s, pending_email = NULL
+        WHERE id = %(id)s AND pending_email = %(address)s
+        RETURNING *"""
+    async with conn.cursor(row_factory=class_row(User)) as cur:
+        await cur.execute(sql, {"id": id, "address": address})
+        return await cur.fetchone()
 
 
 async def count(conn: AsyncConnection) -> int:

--- a/shard_core/service/freeshard_controller.py
+++ b/shard_core/service/freeshard_controller.py
@@ -1,3 +1,4 @@
+import json
 import logging
 
 from shard_core.data_model.backend.shard_model import ShardDb
@@ -15,6 +16,45 @@ async def call_freeshard_controller(path: str, method: str = "GET", body: bytes 
     url = f"{base_url}/{path}"
     log.debug(f"call to {method} {url}")
     return await signed_request(method, url, data=body)
+
+
+async def relay_email_to_owner(subject: str, body: list[str]):
+    """Ask the controller to mail the shard's owner.
+
+    The recipient is always the address the controller currently has on file;
+    the shard cannot choose it. That is why a notification about an address
+    change has to be sent before the change is mirrored back.
+    """
+    response = await call_freeshard_controller(
+        "api/email_relay",
+        method="POST",
+        body=json.dumps({"subject": subject, "body": body}).encode(),
+    )
+    response.raise_for_status()
+
+
+async def send_verification_email(address: str, token: str):
+    """Ask the controller to mail a confirmation link to an unconfirmed address.
+
+    The controller owns the template and builds the link from the shard domain
+    it already knows, so no shard-supplied URL is ever rendered into an email.
+    """
+    response = await call_freeshard_controller(
+        "api/email_verification",
+        method="POST",
+        body=json.dumps({"address": address, "token": token}).encode(),
+    )
+    response.raise_for_status()
+
+
+async def set_owner_email(address: str | None):
+    """Mirror a confirmed address to shards.owner_email on the controller."""
+    response = await call_freeshard_controller(
+        "api/shards/self/owner-email",
+        method="PUT",
+        body=json.dumps({"address": address}).encode(),
+    )
+    response.raise_for_status()
 
 
 async def refresh_shared_secret():

--- a/shard_core/service/freeshard_controller.py
+++ b/shard_core/service/freeshard_controller.py
@@ -1,4 +1,3 @@
-import json
 import logging
 
 from shard_core.data_model.backend.shard_model import ShardDb
@@ -18,6 +17,19 @@ async def call_freeshard_controller(path: str, method: str = "GET", body: bytes 
     return await signed_request(method, url, data=body)
 
 
+async def post_json(path: str, payload: dict, method: str = "POST"):
+    """Call the controller with a JSON body, declared as JSON.
+
+    requests sends no Content-Type for a raw-bytes body, and the controller only
+    parses those because it has strict_content_type switched off — a temporary
+    concession it intends to withdraw (FreeshardBase/freeshard-controller#272).
+    """
+    base_url = settings().freeshard_controller.base_url
+    url = f"{base_url}/{path}"
+    log.debug(f"call to {method} {url}")
+    return await signed_request(method, url, json=payload)
+
+
 async def relay_email_to_owner(subject: str, body: list[str]):
     """Ask the controller to mail the shard's owner.
 
@@ -25,11 +37,7 @@ async def relay_email_to_owner(subject: str, body: list[str]):
     the shard cannot choose it. That is why a notification about an address
     change has to be sent before the change is mirrored back.
     """
-    response = await call_freeshard_controller(
-        "api/email_relay",
-        method="POST",
-        body=json.dumps({"subject": subject, "body": body}).encode(),
-    )
+    response = await post_json("api/email_relay", {"subject": subject, "body": body})
     response.raise_for_status()
 
 
@@ -39,20 +47,16 @@ async def send_verification_email(address: str, token: str):
     The controller owns the template and builds the link from the shard domain
     it already knows, so no shard-supplied URL is ever rendered into an email.
     """
-    response = await call_freeshard_controller(
-        "api/email_verification",
-        method="POST",
-        body=json.dumps({"address": address, "token": token}).encode(),
+    response = await post_json(
+        "api/email_verification", {"address": address, "token": token}
     )
     response.raise_for_status()
 
 
 async def set_owner_email(address: str | None):
     """Mirror a confirmed address to shards.owner_email on the controller."""
-    response = await call_freeshard_controller(
-        "api/shards/self/owner-email",
-        method="PUT",
-        body=json.dumps({"address": address}).encode(),
+    response = await post_json(
+        "api/shards/self/owner-email", {"address": address}, method="PUT"
     )
     response.raise_for_status()
 

--- a/shard_core/service/identity.py
+++ b/shard_core/service/identity.py
@@ -2,6 +2,7 @@ import logging
 
 from shard_core.database.connection import db_conn
 from shard_core.database import identities as db_identities
+from shard_core.database import users as db_users
 from shard_core.data_model.identity import Identity
 from shard_core.service.portal_controller import refresh_profile
 from shard_core.util.signals import async_on_first_terminal_add, on_identity_update
@@ -64,12 +65,12 @@ async def enrich_identity_from_profile(_):
 
     async with db_conn() as conn:
         default = await db_identities.get_default(conn)
-        if not default:
-            return
-        update_data = {}
-        if profile.owner:
-            update_data["name"] = profile.owner
+        if default and profile.owner:
+            await update_identity(default["id"], {"name": profile.owner})
+
         if profile.owner_email:
-            update_data["email"] = profile.owner_email
-        if update_data:
-            await update_identity(default["id"], update_data)
+            owner = await db_users.get_owner(conn)
+            if owner and owner.email is None:
+                await db_users.update(
+                    conn, owner.id, {"pending_email": profile.owner_email}
+                )

--- a/shard_core/service/identity.py
+++ b/shard_core/service/identity.py
@@ -71,6 +71,15 @@ async def enrich_identity_from_profile(_):
         if profile.owner_email:
             owner = await db_users.get_owner(conn)
             if owner and owner.email is None:
+                # The token is bound to whatever pending_email holds when it is
+                # opened, so replacing the candidate must retire it — this
+                # handler re-fires whenever the last terminal is re-paired.
                 await db_users.update(
-                    conn, owner.id, {"pending_email": profile.owner_email}
+                    conn,
+                    owner.id,
+                    {
+                        "pending_email": profile.owner_email,
+                        "email_token_hash": None,
+                        "email_token_expires": None,
+                    },
                 )

--- a/shard_core/service/oidc_provider.py
+++ b/shard_core/service/oidc_provider.py
@@ -391,6 +391,10 @@ class ShardOpenIDCode(OpenIDCode):
             info["name"] = user.display_name
             info["preferred_username"] = user.username
         if "email" in scope and user.email:
+            # users.email only ever holds a confirmed address (service.owner_email),
+            # which is what lets a relying party trust email_verified enough to
+            # link this identity to an existing local account. An owner who has
+            # confirmed nothing gets no email claim at all.
             info["email"] = user.email
             info["email_verified"] = True
         return info

--- a/shard_core/service/oidc_provider.py
+++ b/shard_core/service/oidc_provider.py
@@ -391,10 +391,8 @@ class ShardOpenIDCode(OpenIDCode):
             info["name"] = user.display_name
             info["preferred_username"] = user.username
         if "email" in scope and user.email:
-            # users.email only ever holds a confirmed address (service.owner_email),
-            # which is what lets a relying party trust email_verified enough to
-            # link this identity to an existing local account. An owner who has
-            # confirmed nothing gets no email claim at all.
+            # users.email only ever holds a confirmed address — see
+            # service.owner_email, which is what makes this claim true
             info["email"] = user.email
             info["email_verified"] = True
         return info

--- a/shard_core/service/owner_email.py
+++ b/shard_core/service/owner_email.py
@@ -22,6 +22,7 @@ from shard_core.database import users as db_users
 from shard_core.database.connection import db_conn
 from shard_core.service import freeshard_controller
 from shard_core.settings import settings
+from shard_core.util.misc import SlidingWindow
 
 log = logging.getLogger(__name__)
 
@@ -29,6 +30,12 @@ log = logging.getLogger(__name__)
 # is the exposure. An hour covers mail delivery and a distracted owner; resend
 # is one click.
 TOKEN_LIFETIME = timedelta(hours=1)
+
+# Every confirmation mail costs the controller a real send, so the budget sits
+# here rather than on either route — otherwise alternating between setting an
+# address and resending doubles it. Only a send that is actually attempted is
+# charged, so a shard that cannot send mail at all is not rationed.
+_send_limit = SlidingWindow(limit=5, window=3600)
 
 _CLEARED_PENDING = {
     "pending_email": None,
@@ -42,6 +49,14 @@ class NoPendingEmail(Exception):
 
 
 class DeliveryFailed(Exception):
+    pass
+
+
+class SendRateLimited(Exception):
+    pass
+
+
+class VerificationDisabled(Exception):
     pass
 
 
@@ -66,6 +81,7 @@ async def set_email(user: User, address: str) -> User:
         log.info(f"set the address of {updated} without verification")
         return updated
 
+    _require_send_budget()
     token = secrets.token_urlsafe(32)
     async with db_conn() as conn:
         updated = await db_users.update(
@@ -87,8 +103,11 @@ async def resend_verification(user: User) -> None:
     The previous token is replaced rather than re-sent: it is stored as a digest
     and cannot be recovered.
     """
+    if not settings().oidc.email_verification:
+        raise VerificationDisabled
     if user.pending_email is None:
         raise NoPendingEmail
+    _require_send_budget()
     token = secrets.token_urlsafe(32)
     async with db_conn() as conn:
         await db_users.update(
@@ -113,7 +132,15 @@ async def clear_email(user: User) -> User:
     No address is a valid state — it is where every shard lands after the 0005
     migration — but a hijacked session must not be able to remove the owner's
     contact channel without the real owner hearing about it.
+
+    Clearing what is already empty is not that, and must stay a no-op: after the
+    0005 migration every shard has no address while the controller still holds
+    the signup one, and mirroring a null there is what stops disk, billing and
+    wind-down mail from ever reaching the owner again.
     """
+    if user.email is None and user.pending_email is None:
+        return user
+
     if settings().oidc.email_verification:
         await _notify(
             "The contact address for your Freeshard is being removed",
@@ -136,27 +163,33 @@ async def clear_email(user: User) -> User:
 async def confirm_email(token: str) -> bool:
     """Promote the candidate belonging to *token*, if the token is still valid.
 
+    The token is spent before anything else happens, so the notification and the
+    controller calls in the middle cannot be replayed by a second click. The
+    old address is told before the switch is mirrored, because the controller's
+    relay only ever reaches the address it currently has on file.
+
     Returns whether anything was promoted. Callers must not pass that on to an
-    unauthenticated client: the answer says whether an address is pending.
+    unauthenticated client: the answer says whether an address was pending.
     """
-    user = await _user_for_token(token)
-    if user is None:
+    claimed = await _claim_token(token)
+    if claimed is None:
         return False
 
+    address = claimed.pending_email
     await _notify(
         "The contact address for your Freeshard is changing",
         [
             f"The contact address for your Freeshard was just changed to "
-            f"{user.pending_email}. This is the last message going to this address.",
+            f"{address}. This is the last message going to this address.",
             "If this was not you, open your terminal and set the address back.",
         ],
     )
 
-    address = user.pending_email
     async with db_conn() as conn:
-        updated = await db_users.update(
-            conn, user.id, {"email": address, **_CLEARED_PENDING}
-        )
+        updated = await db_users.promote_pending_email(conn, claimed.id, address)
+    if updated is None:
+        log.info(f"candidate of user {claimed.id} moved on before its link was opened")
+        return False
     log.info(f"confirmed the address of {updated}")
 
     if await _mirror_to_controller(address):
@@ -170,21 +203,34 @@ async def confirm_email(token: str) -> bool:
     return True
 
 
-async def _user_for_token(token: str) -> User | None:
+async def _claim_token(token: str) -> User | None:
+    """Find the user whose token this is and spend it, in that order.
+
+    The digest is matched in Python with a constant-time comparison rather than
+    looked up in SQL, so the match itself is not a timing oracle; the spending
+    is then a single conditional UPDATE, which is what makes it single-use.
+    """
     digest = hash_token(token)
-    now = datetime.now(timezone.utc)
     async with db_conn() as conn:
         candidates = await db_users.get_all_with_pending_email_token(conn)
-    for user in candidates:
-        if not secrets.compare_digest(user.email_token_hash, digest):
-            continue
-        if user.email_token_expires is None or user.email_token_expires < now:
-            log.info(f"rejected an expired confirmation token for {user}")
-            return None
-        if user.pending_email is None:
-            return None
-        return user
+        for user in candidates:
+            if not secrets.compare_digest(user.email_token_hash, digest):
+                continue
+            claimed = await db_users.claim_email_token(conn, user.id, digest)
+            if claimed is None:
+                log.info(f"rejected a spent or expired confirmation token for {user}")
+            return claimed
     return None
+
+
+def _require_send_budget():
+    """Charge the mail budget before anything is written.
+
+    Charging after the write would let a refused request replace the token of a
+    candidate whose link is already in the owner's inbox.
+    """
+    if not _send_limit.try_acquire():
+        raise SendRateLimited
 
 
 async def _deliver_verification(address: str, token: str):

--- a/shard_core/service/owner_email.py
+++ b/shard_core/service/owner_email.py
@@ -9,7 +9,7 @@ candidate is in flight per user; a superseded one is simply replaced.
 The shard mints and checks the confirmation token itself. The controller is only
 asked to deliver mail — it never learns what the token unlocks. A self-hosted
 shard has no controller and therefore no mail at all, which is why
-`oidc.email_verification = false` sets the address directly instead.
+`email.enabled = false` sets the address directly instead.
 """
 
 import hashlib
@@ -72,7 +72,7 @@ async def set_email(user: User, address: str) -> User:
     Without verification there is no way to send the link, so the address is
     taken as-is.
     """
-    if not settings().oidc.email_verification:
+    if not settings().email.enabled:
         async with db_conn() as conn:
             updated = await db_users.update(
                 conn, user.id, {"email": address, **_CLEARED_PENDING}
@@ -103,7 +103,7 @@ async def resend_verification(user: User) -> None:
     The previous token is replaced rather than re-sent: it is stored as a digest
     and cannot be recovered.
     """
-    if not settings().oidc.email_verification:
+    if not settings().email.enabled:
         raise VerificationDisabled
     if user.pending_email is None:
         raise NoPendingEmail
@@ -141,7 +141,7 @@ async def clear_email(user: User) -> User:
     if user.email is None and user.pending_email is None:
         return user
 
-    if settings().oidc.email_verification:
+    if settings().email.enabled:
         await _notify(
             "The contact address for your Freeshard is being removed",
             [

--- a/shard_core/service/owner_email.py
+++ b/shard_core/service/owner_email.py
@@ -1,0 +1,213 @@
+"""The owner's email address: setting it, confirming it, clearing it.
+
+The invariant this module exists to keep is what makes the OIDC `email_verified`
+claim mean something: **users.email is always verified, users.pending_email is
+an unverified candidate**. A new address goes to pending_email and only moves to
+email once the owner has opened a link that was delivered to it. At most one
+candidate is in flight per user; a superseded one is simply replaced.
+
+The shard mints and checks the confirmation token itself. The controller is only
+asked to deliver mail — it never learns what the token unlocks. A self-hosted
+shard has no controller and therefore no mail at all, which is why
+`oidc.email_verification = false` sets the address directly instead.
+"""
+
+import hashlib
+import logging
+import secrets
+from datetime import datetime, timedelta, timezone
+
+from shard_core.data_model.user import User
+from shard_core.database import users as db_users
+from shard_core.database.connection import db_conn
+from shard_core.service import freeshard_controller
+from shard_core.settings import settings
+
+log = logging.getLogger(__name__)
+
+# The token alone completes the change, so it is the credential and its lifetime
+# is the exposure. An hour covers mail delivery and a distracted owner; resend
+# is one click.
+TOKEN_LIFETIME = timedelta(hours=1)
+
+_CLEARED_PENDING = {
+    "pending_email": None,
+    "email_token_hash": None,
+    "email_token_expires": None,
+}
+
+
+class NoPendingEmail(Exception):
+    pass
+
+
+class DeliveryFailed(Exception):
+    pass
+
+
+def hash_token(token: str) -> str:
+    return hashlib.sha256(token.encode()).hexdigest()
+
+
+async def set_email(user: User, address: str) -> User:
+    """Take an address as the owner's new one.
+
+    With verification enabled the address becomes the candidate and a link is
+    sent to it; the current address is untouched until that link is opened.
+    Without verification there is no way to send the link, so the address is
+    taken as-is.
+    """
+    if not settings().oidc.email_verification:
+        async with db_conn() as conn:
+            updated = await db_users.update(
+                conn, user.id, {"email": address, **_CLEARED_PENDING}
+            )
+        await _mirror_to_controller(address)
+        log.info(f"set the address of {updated} without verification")
+        return updated
+
+    token = secrets.token_urlsafe(32)
+    async with db_conn() as conn:
+        updated = await db_users.update(
+            conn,
+            user.id,
+            {
+                "pending_email": address,
+                "email_token_hash": hash_token(token),
+                "email_token_expires": datetime.now(timezone.utc) + TOKEN_LIFETIME,
+            },
+        )
+    await _deliver_verification(address, token)
+    return updated
+
+
+async def resend_verification(user: User) -> None:
+    """Send a fresh link for the candidate already on file.
+
+    The previous token is replaced rather than re-sent: it is stored as a digest
+    and cannot be recovered.
+    """
+    if user.pending_email is None:
+        raise NoPendingEmail
+    token = secrets.token_urlsafe(32)
+    async with db_conn() as conn:
+        await db_users.update(
+            conn,
+            user.id,
+            {
+                "email_token_hash": hash_token(token),
+                "email_token_expires": datetime.now(timezone.utc) + TOKEN_LIFETIME,
+            },
+        )
+    await _deliver_verification(user.pending_email, token)
+
+
+async def discard_pending(user: User) -> User:
+    async with db_conn() as conn:
+        return await db_users.update(conn, user.id, dict(_CLEARED_PENDING))
+
+
+async def clear_email(user: User) -> User:
+    """Drop the address entirely, telling the old one first.
+
+    No address is a valid state — it is where every shard lands after the 0005
+    migration — but a hijacked session must not be able to remove the owner's
+    contact channel without the real owner hearing about it.
+    """
+    if settings().oidc.email_verification:
+        await _notify(
+            "The contact address for your Freeshard is being removed",
+            [
+                "The contact address for your Freeshard was just removed, so we can "
+                "no longer reach you about your shard — storage warnings, billing "
+                "notices and service messages included.",
+                "If this was not you, open your terminal and set an address again.",
+            ],
+        )
+    async with db_conn() as conn:
+        updated = await db_users.update(
+            conn, user.id, {"email": None, **_CLEARED_PENDING}
+        )
+    await _mirror_to_controller(None)
+    log.info(f"cleared the address of {updated}")
+    return updated
+
+
+async def confirm_email(token: str) -> bool:
+    """Promote the candidate belonging to *token*, if the token is still valid.
+
+    Returns whether anything was promoted. Callers must not pass that on to an
+    unauthenticated client: the answer says whether an address is pending.
+    """
+    user = await _user_for_token(token)
+    if user is None:
+        return False
+
+    await _notify(
+        "The contact address for your Freeshard is changing",
+        [
+            f"The contact address for your Freeshard was just changed to "
+            f"{user.pending_email}. This is the last message going to this address.",
+            "If this was not you, open your terminal and set the address back.",
+        ],
+    )
+
+    address = user.pending_email
+    async with db_conn() as conn:
+        updated = await db_users.update(
+            conn, user.id, {"email": address, **_CLEARED_PENDING}
+        )
+    log.info(f"confirmed the address of {updated}")
+
+    if await _mirror_to_controller(address):
+        await _notify(
+            "Your Freeshard contact address is confirmed",
+            [
+                "This address is now the contact address for your Freeshard.",
+                "Messages about your shard arrive here from now on.",
+            ],
+        )
+    return True
+
+
+async def _user_for_token(token: str) -> User | None:
+    digest = hash_token(token)
+    now = datetime.now(timezone.utc)
+    async with db_conn() as conn:
+        candidates = await db_users.get_all_with_pending_email_token(conn)
+    for user in candidates:
+        if not secrets.compare_digest(user.email_token_hash, digest):
+            continue
+        if user.email_token_expires is None or user.email_token_expires < now:
+            log.info(f"rejected an expired confirmation token for {user}")
+            return None
+        if user.pending_email is None:
+            return None
+        return user
+    return None
+
+
+async def _deliver_verification(address: str, token: str):
+    try:
+        await freeshard_controller.send_verification_email(address, token)
+    except Exception as e:
+        log.error(f"could not send a verification email: {e}")
+        raise DeliveryFailed from e
+
+
+async def _mirror_to_controller(address: str | None) -> bool:
+    """Best effort: the shard owns the address, the controller only mirrors it."""
+    try:
+        await freeshard_controller.set_owner_email(address)
+    except Exception as e:
+        log.error(f"could not mirror the owner address to the controller: {e}")
+        return False
+    return True
+
+
+async def _notify(subject: str, body: list[str]):
+    """Best effort: a failed courtesy message must not block the change."""
+    try:
+        await freeshard_controller.relay_email_to_owner(subject, body)
+    except Exception as e:
+        log.error(f"could not notify the owner about an address change: {e}")

--- a/shard_core/service/user.py
+++ b/shard_core/service/user.py
@@ -14,8 +14,8 @@ async def ensure_owner_user() -> User:
 
     The owner user is created by the 0002 migration on shards that already
     have an identity; on fresh shards it is created here, right after the
-    default identity. Also backfills the email for migration-created owners —
-    OIDC clients need an email-shaped identifier to auto-provision accounts.
+    default identity. A fresh owner has no address: users.email is verified by
+    definition, and nothing has been verified yet.
     Idempotent — called on every startup, before any pairing can happen.
     """
     async with db_conn() as conn:
@@ -28,15 +28,9 @@ async def ensure_owner_user() -> User:
                 {
                     "username": "owner",
                     "display_name": identity.name,
-                    "email": identity.email or f"owner@{identity.domain}",
+                    "email": None,
                     "role": Role.OWNER.value,
                 },
             )
             log.info(f"created owner user {owner.id}")
-        elif owner.email is None:
-            identity_row = await db_identities.get_default(conn)
-            identity = Identity(**identity_row)
-            owner = await db_users.update(
-                conn, owner.id, {"email": f"owner@{identity.domain}"}
-            )
     return owner

--- a/shard_core/settings.py
+++ b/shard_core/settings.py
@@ -84,6 +84,10 @@ class TelemetrySettings(BaseModel):
 
 class OidcSettings(BaseModel):
     enabled: bool = False  # rollout kill-switch for the embedded OIDC provider
+    # A self-hosted shard has no controller and therefore no way to send mail at
+    # all, so it sets an address without confirming it. Never inferred from a
+    # failed delivery — a controller outage would silently downgrade this.
+    email_verification: bool = True
 
 
 class ManagementSettings(BaseModel):

--- a/shard_core/settings.py
+++ b/shard_core/settings.py
@@ -84,10 +84,14 @@ class TelemetrySettings(BaseModel):
 
 class OidcSettings(BaseModel):
     enabled: bool = False  # rollout kill-switch for the embedded OIDC provider
-    # A self-hosted shard has no controller and therefore no way to send mail at
-    # all, so it sets an address without confirming it. Never inferred from a
+
+
+class EmailSettings(BaseModel):
+    # Whether this shard can send mail at all. A self-hosted shard has no
+    # controller and therefore no way to, so an address is set without being
+    # confirmed and no change notification goes out. Never inferred from a
     # failed delivery — a controller outage would silently downgrade this.
-    email_verification: bool = True
+    enabled: bool = True
 
 
 class ManagementSettings(BaseModel):
@@ -130,6 +134,7 @@ class Settings(BaseSettings):
     apps: AppsSettings
     telemetry: TelemetrySettings = TelemetrySettings()
     oidc: OidcSettings = OidcSettings()
+    email: EmailSettings = EmailSettings()
     management: ManagementSettings
     freeshard_controller: FreeshardControllerSettings
     log: LogSettings = LogSettings()

--- a/shard_core/util/misc.py
+++ b/shard_core/util/misc.py
@@ -50,15 +50,19 @@ class SlidingWindow:
         self._window = window
         self._attempts: deque[float] = deque()
 
-    def is_exceeded(self) -> bool:
-        """Record an attempt and report whether it busts the limit."""
+    def try_acquire(self) -> bool:
+        """Take a slot if one is free, reporting whether it was granted.
+
+        Named for the fact that it records: a predicate name invites calling it
+        twice to branch, which silently spends two slots.
+        """
         now = time.monotonic()
         while self._attempts and self._attempts[0] < now - self._window:
             self._attempts.popleft()
         if len(self._attempts) >= self._limit:
-            return True
+            return False
         self._attempts.append(now)
-        return False
+        return True
 
     def reset(self):
         self._attempts.clear()

--- a/shard_core/util/misc.py
+++ b/shard_core/util/misc.py
@@ -1,5 +1,6 @@
 import inspect
 import time
+from collections import deque
 
 
 def throttle(min_duration: float):
@@ -34,6 +35,33 @@ def throttle(min_duration: float):
         return wrapper_throttle
 
     return decorator_throttle
+
+
+class SlidingWindow:
+    """Counts attempts in a moving time window, to cap a request rate.
+
+    In-process and shared by every caller of the endpoint it guards. A shard has
+    one owner, so splitting the budget per client would only offer an attacker a
+    fresh budget per source address.
+    """
+
+    def __init__(self, limit: int, window: float):
+        self._limit = limit
+        self._window = window
+        self._attempts: deque[float] = deque()
+
+    def is_exceeded(self) -> bool:
+        """Record an attempt and report whether it busts the limit."""
+        now = time.monotonic()
+        while self._attempts and self._attempts[0] < now - self._window:
+            self._attempts.popleft()
+        if len(self._attempts) >= self._limit:
+            return True
+        self._attempts.append(now)
+        return False
+
+    def reset(self):
+        self._attempts.clear()
 
 
 def format_error(e: Exception):

--- a/shard_core/web/protected/__init__.py
+++ b/shard_core/web/protected/__init__.py
@@ -11,6 +11,7 @@ from . import (
     management,
     settings,
     stats,
+    users,
     ws,
 )
 
@@ -29,4 +30,5 @@ router.include_router(help.router)
 router.include_router(management.router)
 router.include_router(settings.router)
 router.include_router(stats.router)
+router.include_router(users.router)
 router.include_router(ws.router)

--- a/shard_core/web/protected/settings.py
+++ b/shard_core/web/protected/settings.py
@@ -1,14 +1,46 @@
 import logging
 
 from fastapi import APIRouter, status
+from pydantic import BaseModel
 
 from shard_core.service.app_tools import docker_prune_images
+from shard_core.settings import settings
 
 log = logging.getLogger(__name__)
 
 router = APIRouter(
     prefix="/settings",
 )
+
+
+class OutputSettings(BaseModel):
+    """The subset of shard configuration a client is allowed to see.
+
+    An explicit allowlist, deliberately not a projection of Settings. That
+    object carries the database password, the controller base URL and the
+    management API URL; a model_dump() with an exclude list would fail open,
+    publishing any field added elsewhere in the config. Naming the fields here
+    fails closed instead.
+    """
+
+    email_enabled: bool
+
+
+@router.get("", response_model=OutputSettings)
+async def get_settings():
+    """What a client needs to know about how this shard is configured.
+
+    Read-only on purpose. User-writable state lives behind
+    /protected/preferences; keeping the two apart means neither payload mixes
+    writable and read-only fields, so a client cannot round-trip a GET into a
+    PUT and silently drop half of it.
+    """
+    return OutputSettings(
+        # whether this shard can send mail at all: it decides both whether an
+        # address must be confirmed and whether change notifications go out,
+        # and a client may legitimately want to say either
+        email_enabled=settings().email.enabled,
+    )
 
 
 @router.post("/prune-images", status_code=status.HTTP_200_OK)

--- a/shard_core/web/protected/users.py
+++ b/shard_core/web/protected/users.py
@@ -3,20 +3,27 @@ import logging
 from fastapi import APIRouter, Cookie, HTTPException, status
 from fastapi.responses import Response
 
-from shard_core.data_model.user import InputUser, OutputUser, User
+from shard_core.data_model.user import InputUser, OutputUser, Role, User
 from shard_core.database import users as db_users
 from shard_core.database.connection import db_conn
 from shard_core.service import owner_email, pairing
-from shard_core.util.misc import SlidingWindow
 
 log = logging.getLogger(__name__)
 
-# Every confirmation mail costs the controller a real send, and both routes that
-# trigger one share the budget — otherwise alternating between them doubles it.
-_email_send_limit = SlidingWindow(limit=5, window=3600)
-
 router = APIRouter(
     prefix="/users",
+)
+
+# Everything the address routes touch is owner-global: the controller relay
+# mails the shard's registered owner and the mirror rewrites shards.owner_email.
+# Every terminal binds to the owner today, so this only fires once members exist
+# — which is exactly when a member editing their own address must stop
+# redirecting the owner's billing mail.
+_OWNER_ONLY = "Only the shard owner's address can be set from here."
+_SEND_LIMITED = "Too many confirmation emails requested. Try again later."
+_DELIVERY_FAILED = (
+    "The address was saved but the confirmation email could not be sent. "
+    "Send it again in a moment."
 )
 
 
@@ -35,11 +42,21 @@ async def _session_user(authorization: str | None) -> User:
         raise HTTPException(status.HTTP_401_UNAUTHORIZED)
     async with db_conn() as conn:
         user = await db_users.get_by_id(conn, terminal.user_id)
-    if user is None or user.disabled:
+    if user is None:
         raise HTTPException(status.HTTP_401_UNAUTHORIZED)
+    if user.disabled:
+        # authenticated, but not allowed — re-authenticating would not help
+        raise HTTPException(status.HTTP_403_FORBIDDEN)
     return user
 
 
+def _owner_or_403(user: User):
+    if user.role is not Role.OWNER:
+        raise HTTPException(status.HTTP_403_FORBIDDEN, detail=_OWNER_ONLY)
+
+
+# NOTE: /me is a literal path. Any future /{id} route must be declared after it,
+# or it swallows /me.
 @router.get("/me", response_model=OutputUser)
 async def get_me(authorization: str = Cookie(None)):
     return OutputUser.from_user(await _session_user(authorization))
@@ -48,32 +65,37 @@ async def get_me(authorization: str = Cookie(None)):
 @router.patch("/me", response_model=OutputUser)
 async def patch_me(update: InputUser, authorization: str = Cookie(None)):
     user = await _session_user(authorization)
+    # an omitted field is untouched, an explicit null clears it — which the
+    # Optional annotation alone cannot tell apart
     fields = update.model_dump(exclude_unset=True)
 
-    if update.display_name is not None:
+    if "display_name" in fields:
+        if update.display_name is None:
+            raise HTTPException(
+                status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="display_name cannot be null.",
+            )
         async with db_conn() as conn:
             user = await db_users.update(
                 conn, user.id, {"display_name": update.display_name}
             )
 
-    # an omitted email is untouched, an explicit null clears it — which
-    # model_dump alone cannot tell apart
     if "email" in fields:
-        if update.email is None:
-            user = await owner_email.clear_email(user)
-        else:
-            if _email_send_limit.is_exceeded():
-                raise HTTPException(status.HTTP_429_TOO_MANY_REQUESTS)
-            try:
-                user = await owner_email.set_email(user, update.email)
-            except owner_email.DeliveryFailed:
-                raise HTTPException(
-                    status.HTTP_502_BAD_GATEWAY,
-                    detail="The address was saved but the confirmation email could "
-                    "not be sent. Try sending it again in a moment.",
-                )
+        _owner_or_403(user)
+        user = await _apply_email(user, update.email)
 
     return OutputUser.from_user(user)
+
+
+async def _apply_email(user: User, address: str | None) -> User:
+    if address is None:
+        return await owner_email.clear_email(user)
+    try:
+        return await owner_email.set_email(user, address)
+    except owner_email.SendRateLimited:
+        raise HTTPException(status.HTTP_429_TOO_MANY_REQUESTS, detail=_SEND_LIMITED)
+    except owner_email.DeliveryFailed:
+        raise HTTPException(status.HTTP_502_BAD_GATEWAY, detail=_DELIVERY_FAILED)
 
 
 @router.post(
@@ -83,14 +105,20 @@ async def patch_me(update: InputUser, authorization: str = Cookie(None)):
 )
 async def resend_confirmation(authorization: str = Cookie(None)):
     user = await _session_user(authorization)
-    if _email_send_limit.is_exceeded():
-        raise HTTPException(status.HTTP_429_TOO_MANY_REQUESTS)
+    _owner_or_403(user)
     try:
         await owner_email.resend_verification(user)
     except owner_email.NoPendingEmail:
         raise HTTPException(
-            status.HTTP_404_NOT_FOUND, detail="No address is waiting for confirmation."
+            status.HTTP_409_CONFLICT, detail="No address is waiting for confirmation."
         )
+    except owner_email.VerificationDisabled:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            detail="This shard does not send confirmation email.",
+        )
+    except owner_email.SendRateLimited:
+        raise HTTPException(status.HTTP_429_TOO_MANY_REQUESTS, detail=_SEND_LIMITED)
     except owner_email.DeliveryFailed:
         raise HTTPException(
             status.HTTP_502_BAD_GATEWAY,
@@ -105,4 +133,5 @@ async def resend_confirmation(authorization: str = Cookie(None)):
 )
 async def delete_pending_email(authorization: str = Cookie(None)):
     user = await _session_user(authorization)
+    _owner_or_403(user)
     await owner_email.discard_pending(user)

--- a/shard_core/web/protected/users.py
+++ b/shard_core/web/protected/users.py
@@ -11,8 +11,9 @@ from shard_core.util.misc import SlidingWindow
 
 log = logging.getLogger(__name__)
 
-# Verification mail is rare and every send costs the controller a real email.
-_resend_limit = SlidingWindow(limit=5, window=3600)
+# Every confirmation mail costs the controller a real send, and both routes that
+# trigger one share the budget — otherwise alternating between them doubles it.
+_email_send_limit = SlidingWindow(limit=5, window=3600)
 
 router = APIRouter(
     prefix="/users",
@@ -61,6 +62,8 @@ async def patch_me(update: InputUser, authorization: str = Cookie(None)):
         if update.email is None:
             user = await owner_email.clear_email(user)
         else:
+            if _email_send_limit.is_exceeded():
+                raise HTTPException(status.HTTP_429_TOO_MANY_REQUESTS)
             try:
                 user = await owner_email.set_email(user, update.email)
             except owner_email.DeliveryFailed:
@@ -80,7 +83,7 @@ async def patch_me(update: InputUser, authorization: str = Cookie(None)):
 )
 async def resend_confirmation(authorization: str = Cookie(None)):
     user = await _session_user(authorization)
-    if _resend_limit.is_exceeded():
+    if _email_send_limit.is_exceeded():
         raise HTTPException(status.HTTP_429_TOO_MANY_REQUESTS)
     try:
         await owner_email.resend_verification(user)

--- a/shard_core/web/protected/users.py
+++ b/shard_core/web/protected/users.py
@@ -1,0 +1,105 @@
+import logging
+
+from fastapi import APIRouter, Cookie, HTTPException, status
+from fastapi.responses import Response
+
+from shard_core.data_model.user import InputUser, OutputUser, User
+from shard_core.database import users as db_users
+from shard_core.database.connection import db_conn
+from shard_core.service import owner_email, pairing
+from shard_core.util.misc import SlidingWindow
+
+log = logging.getLogger(__name__)
+
+# Verification mail is rare and every send costs the controller a real email.
+_resend_limit = SlidingWindow(limit=5, window=3600)
+
+router = APIRouter(
+    prefix="/users",
+)
+
+
+async def _session_user(authorization: str | None) -> User:
+    """The user behind the terminal session this request carries.
+
+    Traefik has already established that the cookie is valid before the request
+    reaches /protected; reading it again here is what resolves *which* user is
+    asking, which is the part forwardAuth cannot answer.
+    """
+    if not authorization:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED)
+    try:
+        terminal = await pairing.verify_terminal_jwt(authorization)
+    except pairing.InvalidJwt:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED)
+    async with db_conn() as conn:
+        user = await db_users.get_by_id(conn, terminal.user_id)
+    if user is None or user.disabled:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED)
+    return user
+
+
+@router.get("/me", response_model=OutputUser)
+async def get_me(authorization: str = Cookie(None)):
+    return OutputUser.from_user(await _session_user(authorization))
+
+
+@router.patch("/me", response_model=OutputUser)
+async def patch_me(update: InputUser, authorization: str = Cookie(None)):
+    user = await _session_user(authorization)
+    fields = update.model_dump(exclude_unset=True)
+
+    if update.display_name is not None:
+        async with db_conn() as conn:
+            user = await db_users.update(
+                conn, user.id, {"display_name": update.display_name}
+            )
+
+    # an omitted email is untouched, an explicit null clears it — which
+    # model_dump alone cannot tell apart
+    if "email" in fields:
+        if update.email is None:
+            user = await owner_email.clear_email(user)
+        else:
+            try:
+                user = await owner_email.set_email(user, update.email)
+            except owner_email.DeliveryFailed:
+                raise HTTPException(
+                    status.HTTP_502_BAD_GATEWAY,
+                    detail="The address was saved but the confirmation email could "
+                    "not be sent. Try sending it again in a moment.",
+                )
+
+    return OutputUser.from_user(user)
+
+
+@router.post(
+    "/me/email/resend",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+)
+async def resend_confirmation(authorization: str = Cookie(None)):
+    user = await _session_user(authorization)
+    if _resend_limit.is_exceeded():
+        raise HTTPException(status.HTTP_429_TOO_MANY_REQUESTS)
+    try:
+        await owner_email.resend_verification(user)
+    except owner_email.NoPendingEmail:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND, detail="No address is waiting for confirmation."
+        )
+    except owner_email.DeliveryFailed:
+        raise HTTPException(
+            status.HTTP_502_BAD_GATEWAY,
+            detail="The confirmation email could not be sent.",
+        )
+
+
+@router.delete(
+    "/me/email/pending",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+)
+async def delete_pending_email(authorization: str = Cookie(None)):
+    user = await _session_user(authorization)
+    await owner_email.discard_pending(user)

--- a/shard_core/web/public/__init__.py
+++ b/shard_core/web/public/__init__.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from . import health, meta, oidc, pair
+from . import health, meta, oidc, pair, users
 
 router = APIRouter(
     prefix="/public",
@@ -11,3 +11,4 @@ router.include_router(health.router)
 router.include_router(meta.router)
 router.include_router(oidc.router)
 router.include_router(pair.router)
+router.include_router(users.router)

--- a/shard_core/web/public/oidc.py
+++ b/shard_core/web/public/oidc.py
@@ -12,8 +12,6 @@ time) and the signing key lives in the database.
 
 import asyncio
 import logging
-import time
-from collections import deque
 from urllib.parse import quote
 
 from authlib.oauth2.rfc6749 import AuthorizationServer, OAuth2Request
@@ -36,6 +34,7 @@ from shard_core.service.oidc_provider import (
     userinfo_for_access_token,
 )
 from shard_core.settings import settings
+from shard_core.util.misc import SlidingWindow
 
 log = logging.getLogger(__name__)
 
@@ -152,7 +151,7 @@ async def _get_server(request: Request) -> StarletteAuthorizationServer:
                 issuer = f"{app.state.oidc_public_base}/public/oidc"
                 jwk = await ensure_jwk()
                 configure(issuer, jwk, asyncio.get_running_loop())
-                _token_request_times.clear()
+                _token_limit.reset()
                 app.state.oidc_server = build_authorization_server(
                     StarletteAuthorizationServer
                 )
@@ -181,18 +180,7 @@ async def _session_user(authorization: str | None) -> ShardUser | None:
 
 # --- token endpoint rate limit ------------------------------------------------------
 
-_token_request_times: deque = deque()
-_RATE_WINDOW = 60
-
-
-def _rate_limited() -> bool:
-    now = time.monotonic()
-    while _token_request_times and _token_request_times[0] < now - _RATE_WINDOW:
-        _token_request_times.popleft()
-    if len(_token_request_times) >= TOKEN_RATE_LIMIT:
-        return True
-    _token_request_times.append(now)
-    return False
+_token_limit = SlidingWindow(limit=TOKEN_RATE_LIMIT, window=60)
 
 
 # --- endpoints -------------------------------------------------------------------
@@ -225,7 +213,7 @@ async def authorize(request: Request, authorization: str = Cookie(None)):
 @router.post("/token")
 async def token(request: Request):
     server = await _get_server(request)
-    if _rate_limited():
+    if not _token_limit.try_acquire():
         return JSONResponse({"error": "slow_down"}, status_code=429)
     oreq = await _build_oauth2_request(request)
     return await asyncio.to_thread(server.create_token_response, oreq)

--- a/shard_core/web/public/users.py
+++ b/shard_core/web/public/users.py
@@ -2,17 +2,18 @@ import logging
 
 from fastapi import APIRouter, HTTPException, status
 from fastapi.responses import Response
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from shard_core.service import owner_email
 from shard_core.util.misc import SlidingWindow
 
 log = logging.getLogger(__name__)
 
-# The token is opaque to everyone but the shard that minted it; anything far off
-# its length is not a guess worth spending a rate-limit slot on.
-_MAX_TOKEN_LENGTH = 512
-_confirm_limit = SlidingWindow(limit=10, window=60)
+# Charged only when a token does not match, so a flood of guesses can never lock
+# the owner out of the one route that produces a verified address. Against a
+# 256-bit token the limit buys little anyway; it is here to keep the log and the
+# database from being pumped for free.
+_miss_limit = SlidingWindow(limit=20, window=60)
 
 router = APIRouter(
     prefix="/users",
@@ -20,7 +21,7 @@ router = APIRouter(
 
 
 class ConfirmEmailInput(BaseModel):
-    token: str
+    token: str = Field(min_length=1, max_length=512)
 
 
 @router.post(
@@ -32,19 +33,22 @@ async def confirm_email(body: ConfirmEmailInput):
     """Promote the address the token belongs to.
 
     The only unauthenticated surface of the address flow, and the token is its
-    only credential: compared in constant time against a stored digest, usable
-    once, valid for an hour, and rate limited.
+    only credential: matched in constant time against a stored digest, spent in
+    a single conditional UPDATE, and valid for an hour.
 
-    A well-formed request always answers 204, whether or not the token matched.
-    Anything else would let a caller probe for pending addresses.
+    A request carrying a plausible token always answers 204, whether or not it
+    matched — anything else would let a caller probe for pending addresses. The
+    429 a flood eventually earns is not such a probe: a guess misses whether or
+    not an address is pending.
 
     There is deliberately no GET: mail scanners and link prefetchers follow
     links, and a GET that mutates would burn the single-use token before the
     owner ever clicked. The mail points at the terminal UI
     (https://<shard-domain>/?confirm_email=<token>), which posts here.
     """
-    if not body.token or len(body.token) > _MAX_TOKEN_LENGTH:
-        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="Malformed token.")
-    if _confirm_limit.is_exceeded():
+    if await owner_email.confirm_email(body.token):
+        log.info("confirmed a pending email address")
+        return
+    log.info("rejected an email confirmation token")
+    if not _miss_limit.try_acquire():
         raise HTTPException(status.HTTP_429_TOO_MANY_REQUESTS)
-    await owner_email.confirm_email(body.token)

--- a/shard_core/web/public/users.py
+++ b/shard_core/web/public/users.py
@@ -1,0 +1,50 @@
+import logging
+
+from fastapi import APIRouter, HTTPException, status
+from fastapi.responses import Response
+from pydantic import BaseModel
+
+from shard_core.service import owner_email
+from shard_core.util.misc import SlidingWindow
+
+log = logging.getLogger(__name__)
+
+# The token is opaque to everyone but the shard that minted it; anything far off
+# its length is not a guess worth spending a rate-limit slot on.
+_MAX_TOKEN_LENGTH = 512
+_confirm_limit = SlidingWindow(limit=10, window=60)
+
+router = APIRouter(
+    prefix="/users",
+)
+
+
+class ConfirmEmailInput(BaseModel):
+    token: str
+
+
+@router.post(
+    "/confirm-email",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+)
+async def confirm_email(body: ConfirmEmailInput):
+    """Promote the address the token belongs to.
+
+    The only unauthenticated surface of the address flow, and the token is its
+    only credential: compared in constant time against a stored digest, usable
+    once, valid for an hour, and rate limited.
+
+    A well-formed request always answers 204, whether or not the token matched.
+    Anything else would let a caller probe for pending addresses.
+
+    There is deliberately no GET: mail scanners and link prefetchers follow
+    links, and a GET that mutates would burn the single-use token before the
+    owner ever clicked. The mail points at the terminal UI
+    (https://<shard-domain>/?confirm_email=<token>), which posts here.
+    """
+    if not body.token or len(body.token) > _MAX_TOKEN_LENGTH:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="Malformed token.")
+    if _confirm_limit.is_exceeded():
+        raise HTTPException(status.HTTP_429_TOO_MANY_REQUESTS)
+    await owner_email.confirm_email(body.token)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -320,6 +320,9 @@ def requests_mock_context(
                 body=_shard_self_response_body(shard or mock_shard, subscription),
             )
             rsps.post(f"{controller_base_url}/api/feedback")
+            rsps.post(f"{controller_base_url}/api/email_relay", status=201)
+            rsps.post(f"{controller_base_url}/api/email_verification", status=201)
+            rsps.put(f"{controller_base_url}/api/shards/self/owner-email", status=204)
             rsps.get(f"{controller_base_url}/api/foo")
             rsps.add_passthru("")
             yield rsps

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,6 +85,18 @@ def settings_override(override: dict):
         set_settings(old)
 
 
+@pytest.fixture(autouse=True)
+def reset_rate_limits():
+    """The rate limiters are module-level, so they leak between tests otherwise
+    — and a 429 in an unrelated test points at entirely the wrong code."""
+    from shard_core.service.owner_email import _send_limit
+    from shard_core.web.public.oidc import _token_limit
+    from shard_core.web.public.users import _miss_limit
+
+    for limiter in (_send_limit, _token_limit, _miss_limit):
+        limiter.reset()
+
+
 @pytest.fixture(scope="session")
 def docker_compose_file():
     return str(Path(__file__).parent / "docker-compose.yml")

--- a/tests/test_db_snapshot.py
+++ b/tests/test_db_snapshot.py
@@ -70,6 +70,13 @@ async def test_snapshot_roundtrip_restores_core_state(db, tmp_path):
             ).fetchone()
             assert identity == ("shard-id-abc", "PRIVATE-KEY-PEM", True)
 
+            owner = await (
+                await conn.execute("SELECT email, pending_email FROM users")
+            ).fetchone()
+            # a confirmed address must survive a restore untouched; only a
+            # pre-0005 snapshot gets demoted to a candidate
+            assert owner == ("owner@shard.test", None)
+
             terminal = await (await conn.execute("SELECT id FROM terminals")).fetchone()
             assert terminal == ("term-1",)
 

--- a/tests/test_db_snapshot.py
+++ b/tests/test_db_snapshot.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime, timezone
 
 import pytest
@@ -116,6 +117,55 @@ async def test_restore_skipped_when_db_already_populated(db, tmp_path):
                 ).fetchall()
             ]
         assert ids == ["other-id"]
+
+
+@pytest.mark.asyncio
+async def test_restore_of_a_pre_0005_snapshot(db, tmp_path):
+    """A snapshot written before identities.email was dropped must still
+    restore, and the address it carries must come back unverified — it was
+    either the synthetic owner@<domain> or an unconfirmed copy."""
+    with settings_override({"path_root": str(tmp_path)}):
+        _snapshot_path().parent.mkdir(parents=True, exist_ok=True)
+        _snapshot_path().write_text(
+            json.dumps(
+                {
+                    "identities": [
+                        {
+                            "id": "shard-id-abc",
+                            "name": "default",
+                            "email": "old@shard.test",
+                            "description": None,
+                            "private_key": "PRIVATE-KEY-PEM",
+                            "is_default": True,
+                        }
+                    ],
+                    "users": [
+                        {
+                            "id": 1,
+                            "username": "owner",
+                            "display_name": "Shard Owner",
+                            "email": "owner@shard-id.freeshard.cloud",
+                            "role": "owner",
+                            "password_hash": None,
+                            "disabled": False,
+                            "created": "2026-01-01T00:00:00+00:00",
+                        }
+                    ],
+                }
+            )
+        )
+
+        await restore_db_snapshot()
+
+        async with db_conn() as conn:
+            identity = await (
+                await conn.execute("SELECT id, private_key FROM identities")
+            ).fetchone()
+            assert identity == ("shard-id-abc", "PRIVATE-KEY-PEM")
+            owner = await (
+                await conn.execute("SELECT email, pending_email FROM users")
+            ).fetchone()
+        assert owner == (None, "old@shard.test")
 
 
 @pytest.mark.asyncio

--- a/tests/test_identities.py
+++ b/tests/test_identities.py
@@ -1,11 +1,9 @@
-from starlette import status
-
 from shard_core.data_model.identity import OutputIdentity
 from httpx import AsyncClient
 
 
 async def test_add_and_get(app_client: AsyncClient):
-    second_identity = {"name": "second id", "email": "hello@freeshard.net"}
+    second_identity = {"name": "second id", "description": "a public profile"}
     response_post = await app_client.put("protected/identities", json=second_identity)
     assert response_post.status_code == 201
     response = await app_client.get("protected/identities")
@@ -14,7 +12,7 @@ async def test_add_and_get(app_client: AsyncClient):
     assert len(result) == 2
     result_i = OutputIdentity(**(result[1]))
     assert result_i.name == second_identity["name"]
-    assert result_i.email == second_identity["email"]
+    assert result_i.description == second_identity["description"]
 
 
 async def test_get_default(app_client: AsyncClient):
@@ -47,14 +45,14 @@ async def test_update(app_client: AsyncClient):
         "protected/identities",
         json={
             "id": default_identity["id"],
-            "email": "hello@freeshard.net",
+            "description": "an updated description",
         },
     )
     assert response.status_code == 201
 
     response = await app_client.get("protected/identities")
     assert len(response.json()) == 1
-    assert response.json()[0]["email"] == "hello@freeshard.net"
+    assert response.json()[0]["description"] == "an updated description"
     assert response.json()[0]["name"] == "Shard Owner"
 
 
@@ -63,7 +61,7 @@ async def test_make_default(app_client: AsyncClient):
     response.raise_for_status()
     first_identity = response.json()
 
-    second_identity = {"name": "second id", "email": "hello@freeshard.net"}
+    second_identity = {"name": "second id"}
     response = await app_client.put("protected/identities", json=second_identity)
     response.raise_for_status()
     second_identity = response.json()
@@ -81,19 +79,19 @@ async def test_make_default(app_client: AsyncClient):
     assert response.json()["id"] == second_identity["id"]
 
 
-async def test_invalid_email(app_client: AsyncClient):
+async def test_identities_carry_no_address(app_client: AsyncClient):
+    """An identity is the shard's public profile, published unauthenticated by
+    /public/meta/whoareyou — a personal address has no business there."""
     response = await app_client.get("protected/identities/default")
     response.raise_for_status()
     default_identity = response.json()
+    assert "email" not in default_identity
 
     response = await app_client.put(
         "protected/identities",
-        json={
-            "id": default_identity["id"],
-            "email": "i am invalid",
-        },
+        json={"id": default_identity["id"], "email": "hello@freeshard.net"},
     )
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.status_code == 201
 
-    response = await app_client.get("protected/identities/default")
-    assert response.json()["email"] is None
+    response = await app_client.get("public/meta/whoareyou")
+    assert "email" not in response.json()

--- a/tests/test_migration/test_migration.py
+++ b/tests/test_migration/test_migration.py
@@ -6,6 +6,7 @@ import pytest
 
 from shard_core.database.connection import db_conn
 from shard_core.database import (
+    users as db_users,
     installed_apps as db_installed_apps,
     identities as db_identities,
     terminals as db_terminals,
@@ -49,6 +50,12 @@ async def test_tinydb_migration(place_tinydb_file, db):
         for record in kv_records.values():
             value = await db_kv_store.get_value(conn, record["key"])
             assert value is not None
+
+        # the owner: a TinyDB-era address was never verified either, so it
+        # arrives as a candidate rather than as the owner's address
+        owner = await db_users.get_owner(conn)
+        assert owner.email is None
+        assert owner.pending_email == "max@vtettenborn.net"
 
         # identities
         identity_records = expected.get("identities", {})

--- a/tests/test_migration_0005.py
+++ b/tests/test_migration_0005.py
@@ -1,0 +1,143 @@
+"""Migration 0005 against data, which the ordinary suite never gives it.
+
+yoyo runs every migration once per test container, against an empty database —
+so 0005's DDL is smoke-tested and its three data statements always sweep zero
+rows. This applies them to a scratch database seeded with the shapes real shards
+are actually in.
+"""
+
+import psycopg
+import pytest
+from yoyo import get_backend, read_migrations
+
+MIGRATIONS_PATH = "migrations"
+BEFORE = "shard-core-0004-oidc"
+UNDER_TEST = "shard-core-0005-owner-email-verification"
+
+
+def _dsn(db: dict, dbname: str) -> str:
+    return (
+        f"host={db['host']} port={db['port']} dbname={dbname} "
+        f"user={db['user']} password={db['password']}"
+    )
+
+
+@pytest.fixture
+def scratch_db(postgres_db):
+    """A database of its own, so migrations can be replayed from scratch."""
+    name = "shard_core_migration_0005"
+    # FORCE because yoyo keeps its connection open past apply_migrations
+    drop = f"DROP DATABASE IF EXISTS {name} WITH (FORCE)"
+    with psycopg.connect(
+        _dsn(postgres_db, postgres_db["dbname"]), autocommit=True
+    ) as c:
+        c.execute(drop)
+        c.execute(f"CREATE DATABASE {name}")
+    try:
+        yield {**postgres_db, "dbname": name}
+    finally:
+        with psycopg.connect(
+            _dsn(postgres_db, postgres_db["dbname"]), autocommit=True
+        ) as c:
+            c.execute(drop)
+
+
+def _backend(db: dict):
+    return get_backend(
+        f"postgresql+psycopg://{db['user']}:{db['password']}@{db['host']}:{db['port']}/{db['dbname']}"
+    )
+
+
+def _migrate(db: dict, up_to: str):
+    backend = _backend(db)
+    all_migrations = read_migrations(MIGRATIONS_PATH)
+    selected = [m for m in all_migrations]
+    keep = []
+    for migration in selected:
+        keep.append(migration)
+        if migration.id == up_to:
+            break
+    with backend.lock():
+        backend.apply_migrations(
+            backend.to_apply(all_migrations.filter(lambda m: m in keep))
+        )
+
+
+def _seed_pre_0005(db: dict, identity_email, users_email):
+    with psycopg.connect(_dsn(db, db["dbname"]), autocommit=True) as conn:
+        conn.execute(
+            """INSERT INTO identities (id, name, email, private_key, is_default)
+               VALUES ('shard-id-abc', 'Shard Owner', %s, 'PEM', TRUE)""",
+            (identity_email,),
+        )
+        conn.execute(
+            """INSERT INTO users (username, display_name, email, role)
+               VALUES ('owner', 'Shard Owner', %s, 'owner')""",
+            (users_email,),
+        )
+
+
+def _owner(db: dict):
+    with psycopg.connect(_dsn(db, db["dbname"])) as conn:
+        return conn.execute(
+            "SELECT email, pending_email FROM users WHERE role = 'owner'"
+        ).fetchone()
+
+
+def _identity_columns(db: dict):
+    with psycopg.connect(_dsn(db, db["dbname"])) as conn:
+        rows = conn.execute(
+            """SELECT column_name FROM information_schema.columns
+               WHERE table_schema = 'public' AND table_name = 'identities'"""
+        ).fetchall()
+    return {r[0] for r in rows}
+
+
+def test_an_edited_address_survives_as_a_candidate(scratch_db):
+    """The address the owner typed on the Public page was never verified, so it
+    must arrive as something to confirm, not as the OIDC email claim."""
+    _migrate(scratch_db, BEFORE)
+    _seed_pre_0005(
+        scratch_db,
+        identity_email="max@freeshard.net",
+        users_email="owner@shard-id.freeshard.cloud",
+    )
+
+    _migrate(scratch_db, UNDER_TEST)
+
+    assert _owner(scratch_db) == (None, "max@freeshard.net")
+    assert "email" not in _identity_columns(scratch_db)
+
+
+def test_the_synthetic_address_is_discarded(scratch_db):
+    _migrate(scratch_db, BEFORE)
+    _seed_pre_0005(
+        scratch_db,
+        identity_email=None,
+        users_email="owner@shard-id.freeshard.cloud",
+    )
+
+    _migrate(scratch_db, UNDER_TEST)
+
+    assert _owner(scratch_db) == (None, None)
+
+
+def test_an_empty_identity_address_does_not_become_a_candidate(scratch_db):
+    """InputIdentity.email defaulted to "", so a Public page saved with a blank
+    field stored an empty string — a candidate nobody could ever confirm."""
+    _migrate(scratch_db, BEFORE)
+    _seed_pre_0005(scratch_db, identity_email="", users_email=None)
+
+    _migrate(scratch_db, UNDER_TEST)
+
+    assert _owner(scratch_db) == (None, None)
+
+
+def test_a_shard_with_no_users_row_migrates_cleanly(scratch_db):
+    """A fresh shard runs the migrations before ensure_owner_user."""
+    _migrate(scratch_db, BEFORE)
+
+    _migrate(scratch_db, UNDER_TEST)
+
+    assert _owner(scratch_db) is None
+    assert "email" not in _identity_columns(scratch_db)

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -138,6 +138,13 @@ async def get_owner():
         return await db_users.get_owner(conn)
 
 
+async def confirm_owner_address(address: str = "owner@example.org"):
+    """Give the owner a verified address, the state that earns an email claim."""
+    async with db_conn() as conn:
+        owner = await db_users.get_owner(conn)
+        return await db_users.update(conn, owner.id, {"email": address})
+
+
 # --- discovery + jwks ---------------------------------------------------------
 
 
@@ -267,10 +274,10 @@ async def test_client_secret_post_accepted(app_client: AsyncClient):
 
 async def test_userinfo(app_client: AsyncClient):
     await pair_new_terminal(app_client)
+    owner = await confirm_owner_address()
     oidc_client = await make_client()
     tok, _ = await run_code_flow(app_client, oidc_client)
 
-    owner = await get_owner()
     r = await app_client.get(
         USERINFO, headers={"Authorization": f"Bearer {tok['access_token']}"}
     )
@@ -278,6 +285,7 @@ async def test_userinfo(app_client: AsyncClient):
     info = r.json()
     assert info["sub"] == str(owner.id)
     assert info["email"] == owner.email
+    assert info["email_verified"] is True
     assert info["preferred_username"] == owner.username
 
     r = await app_client.get(
@@ -288,6 +296,43 @@ async def test_userinfo(app_client: AsyncClient):
 
     r = await app_client.get(USERINFO)
     assert r.status_code == 401
+
+
+async def test_no_email_claim_without_a_confirmed_address(app_client: AsyncClient):
+    """email_verified is what a relying party consults before linking an OIDC
+    identity to an existing local account, so an unconfirmed owner gets neither
+    the claim nor the address it would qualify."""
+    await pair_new_terminal(app_client)
+    assert (await get_owner()).email is None
+    keyset = await jwks_keyset(app_client)
+    oidc_client = await make_client()
+    tok, _ = await run_code_flow(app_client, oidc_client)
+
+    claims = joserfc_jwt.decode(tok["id_token"], keyset).claims
+    assert "email" not in claims
+    assert "email_verified" not in claims
+
+    r = await app_client.get(
+        USERINFO, headers={"Authorization": f"Bearer {tok['access_token']}"}
+    )
+    assert r.status_code == 200
+    assert "email" not in r.json()
+    assert "email_verified" not in r.json()
+
+
+async def test_a_pending_address_is_not_claimed(app_client: AsyncClient):
+    """A candidate is exactly the thing nobody has proved they can read."""
+    await pair_new_terminal(app_client)
+    async with db_conn() as conn:
+        owner = await db_users.get_owner(conn)
+        await db_users.update(conn, owner.id, {"pending_email": "nobody@example.org"})
+    oidc_client = await make_client()
+    tok, _ = await run_code_flow(app_client, oidc_client)
+
+    r = await app_client.get(
+        USERINFO, headers={"Authorization": f"Bearer {tok['access_token']}"}
+    )
+    assert "email" not in r.json()
 
 
 # --- refresh rotation --------------------------------------------------------------

--- a/tests/test_owner_email.py
+++ b/tests/test_owner_email.py
@@ -547,7 +547,7 @@ async def test_without_verification_the_address_is_set_directly(
 ):
     await pair_new_terminal(app_client)
 
-    with settings_override({"oidc": {"email_verification": False}}):
+    with settings_override({"email": {"enabled": False}}):
         body = await set_address(app_client)
 
     assert body["email"] == NEW_ADDRESS
@@ -582,7 +582,7 @@ async def test_without_verification_resending_is_refused(
 ):
     await pair_new_terminal(app_client)
 
-    with settings_override({"oidc": {"email_verification": False}}):
+    with settings_override({"email": {"enabled": False}}):
         response = await app_client.post(RESEND)
 
     assert response.status_code == 409
@@ -593,7 +593,7 @@ async def test_without_verification_the_send_budget_is_not_spent(
     requests_mock, app_client: AsyncClient
 ):
     """A shard that cannot send mail at all has nothing to ration."""
-    with settings_override({"oidc": {"email_verification": False}}):
+    with settings_override({"email": {"enabled": False}}):
         await pair_new_terminal(app_client)
         for i in range(8):
             assert (await set_address(app_client, f"a{i}@example.org"))[
@@ -606,7 +606,7 @@ async def test_without_verification_clearing_sends_no_notification(
 ):
     await pair_new_terminal(app_client)
 
-    with settings_override({"oidc": {"email_verification": False}}):
+    with settings_override({"email": {"enabled": False}}):
         await set_address(app_client)
         response = await app_client.patch(ME, json={"email": None})
 

--- a/tests/test_owner_email.py
+++ b/tests/test_owner_email.py
@@ -10,15 +10,12 @@ import json
 from datetime import datetime, timedelta, timezone
 from urllib.parse import urlparse
 
-import pytest
 import responses
 from httpx import AsyncClient
 
 from shard_core.database import users as db_users
 from shard_core.database.connection import db_conn
 from shard_core.settings import settings
-from shard_core.web.protected.users import _email_send_limit
-from shard_core.web.public.users import _confirm_limit
 from tests.conftest import settings_override
 from tests.util import pair_new_terminal
 
@@ -34,13 +31,6 @@ MIRROR_PATH = "/api/shards/self/owner-email"
 NEW_ADDRESS = "owner@example.org"
 # what the mocked controller reports as the shard's owner (tests.conftest.mock_shard)
 PROFILE_ADDRESS = "testowner@foobar.com"
-
-
-@pytest.fixture(autouse=True)
-def reset_rate_limits():
-    """The limiters are module-level, so they otherwise leak across tests."""
-    _confirm_limit.reset()
-    _email_send_limit.reset()
 
 
 def controller_url(path: str) -> str:
@@ -183,6 +173,31 @@ async def test_an_invalid_address_is_rejected(requests_mock, app_client: AsyncCl
     assert calls_to(requests_mock, VERIFY_PATH) == []
 
 
+async def test_an_empty_address_is_rejected_rather_than_treated_as_a_clear(
+    requests_mock, app_client: AsyncClient
+):
+    """A form that blanks its field sends "", not null. Routing that to the
+    clear path would wipe the controller's copy — the only way we reach a paying
+    customer — on what the user meant as a correction."""
+    await pair_new_terminal(app_client)
+
+    response = await app_client.patch(ME, json={"email": ""})
+
+    assert response.status_code == 422
+    assert calls_to(requests_mock, RELAY_PATH) == []
+    assert calls_to(requests_mock, MIRROR_PATH) == []
+
+
+async def test_the_address_is_stored_normalized(requests_mock, app_client: AsyncClient):
+    """It is asserted as verified to third parties, so the domain casing must
+    not be whatever the owner happened to type."""
+    await pair_new_terminal(app_client)
+
+    body = await set_address(app_client, "Owner@EXAMPLE.ORG")
+
+    assert body["pending_email"] == "Owner@example.org"
+
+
 async def test_omitting_the_address_leaves_it_untouched(
     requests_mock, app_client: AsyncClient
 ):
@@ -212,6 +227,30 @@ async def test_a_failed_delivery_reports_an_error_and_keeps_the_candidate(
     owner = await get_owner()
     assert owner.pending_email == NEW_ADDRESS
     assert owner.email is None
+
+
+async def test_a_member_cannot_touch_the_owners_address(
+    requests_mock, app_client: AsyncClient
+):
+    """The relay mails the shard's owner and the mirror rewrites the owner's
+    address on the controller, whoever asked."""
+    await pair_new_terminal(app_client)
+    async with db_conn() as conn:
+        await db_users.update(conn, (await get_owner()).id, {"role": "member"})
+
+    assert (await app_client.patch(ME, json={"email": NEW_ADDRESS})).status_code == 403
+    assert (await app_client.post(RESEND)).status_code == 403
+    assert (await app_client.delete(PENDING)).status_code == 403
+    # a member may still rename themselves
+    assert (await app_client.patch(ME, json={"display_name": "M"})).status_code == 200
+
+
+async def test_a_disabled_user_is_forbidden(requests_mock, app_client: AsyncClient):
+    await pair_new_terminal(app_client)
+    async with db_conn() as conn:
+        await db_users.update(conn, (await get_owner()).id, {"disabled": True})
+
+    assert (await app_client.get(ME)).status_code == 403
 
 
 # --- confirming ------------------------------------------------------------------
@@ -271,6 +310,48 @@ async def test_confirming_survives_a_controller_that_cannot_send_mail(
     assert (await get_owner()).email == NEW_ADDRESS
 
 
+async def test_confirming_survives_a_controller_that_cannot_mirror(
+    requests_mock, app_client: AsyncClient
+):
+    """The shard owns the address; a failed mirror must not undo a confirmation
+    the owner already completed — but it must suppress the success mail, which
+    the relay would otherwise send to the address we just abandoned."""
+    await pair_new_terminal(app_client)
+    await set_address(app_client)
+    token = sent_token(requests_mock)
+    requests_mock.replace(
+        responses.PUT, controller_url(MIRROR_PATH), status=500, body="nope"
+    )
+
+    response = await app_client.post(CONFIRM, json={"token": token})
+
+    assert response.status_code == 204
+    assert (await get_owner()).email == NEW_ADDRESS
+    assert len(calls_to(requests_mock, RELAY_PATH)) == 1
+
+
+async def test_a_candidate_set_while_a_link_was_in_flight_survives(
+    requests_mock, app_client: AsyncClient
+):
+    """The confirmation promotes the address its own link was sent to, or
+    nothing — it must never clear a candidate it knows nothing about."""
+    await pair_new_terminal(app_client)
+    await set_address(app_client, "first@example.org")
+    stale_token = sent_token(requests_mock)
+    await set_address(app_client, "second@example.org")
+    fresh_token = sent_token(requests_mock)
+
+    assert (
+        await app_client.post(CONFIRM, json={"token": stale_token})
+    ).status_code == 204
+
+    owner = await get_owner()
+    assert owner.email is None
+    assert owner.pending_email == "second@example.org"
+    await app_client.post(CONFIRM, json={"token": fresh_token})
+    assert (await get_owner()).email == "second@example.org"
+
+
 async def test_an_unknown_token_changes_nothing_and_says_nothing(
     requests_mock, app_client: AsyncClient
 ):
@@ -322,19 +403,36 @@ async def test_a_token_works_only_once(requests_mock, app_client: AsyncClient):
 
 
 async def test_a_malformed_token_is_refused(requests_mock, app_client: AsyncClient):
-    assert (await app_client.post(CONFIRM, json={"token": ""})).status_code == 400
+    assert (await app_client.post(CONFIRM, json={"token": ""})).status_code == 422
     assert (
         await app_client.post(CONFIRM, json={"token": "x" * 513})
-    ).status_code == 400
+    ).status_code == 422
     assert (await app_client.post(CONFIRM, json={})).status_code == 422
 
 
-async def test_confirming_is_rate_limited(requests_mock, app_client: AsyncClient):
-    for _ in range(10):
-        r = await app_client.post(CONFIRM, json={"token": "guess"})
-        assert r.status_code == 204
+async def test_there_is_no_get_confirmation_route(app_client: AsyncClient):
+    """A GET would be consumed by mail scanners and link prefetchers, burning
+    the single-use token before the owner ever clicked."""
+    assert (await app_client.get(f"{CONFIRM}?token=whatever")).status_code == 405
 
+
+async def test_a_flood_of_guesses_cannot_lock_the_owner_out(
+    requests_mock, app_client: AsyncClient
+):
+    """Only misses are charged. A global limiter that counted hits too would let
+    any anonymous caller keep the owner off the one route that verifies an
+    address, until the token expired."""
+    await pair_new_terminal(app_client)
+    await set_address(app_client)
+    token = sent_token(requests_mock)
+    for _ in range(20):
+        assert (
+            await app_client.post(CONFIRM, json={"token": "guess"})
+        ).status_code == 204
     assert (await app_client.post(CONFIRM, json={"token": "guess"})).status_code == 429
+
+    assert (await app_client.post(CONFIRM, json={"token": token})).status_code == 204
+    assert (await get_owner()).email == NEW_ADDRESS
 
 
 # --- resending and discarding ----------------------------------------------------
@@ -365,7 +463,7 @@ async def test_resending_without_a_candidate_is_refused(
 
     response = await app_client.post(RESEND)
 
-    assert response.status_code == 404
+    assert response.status_code == 409
     assert calls_to(requests_mock, VERIFY_PATH) == []
 
 
@@ -381,6 +479,21 @@ async def test_sending_confirmation_mail_is_rate_limited(
 
     assert (await app_client.post(RESEND)).status_code == 429
     assert (await app_client.patch(ME, json={"email": NEW_ADDRESS})).status_code == 429
+
+
+async def test_resending_mints_the_first_token_for_a_seeded_candidate(
+    requests_mock, app_client: AsyncClient
+):
+    """Where every existing shard starts: the 0005 migration and first pairing
+    both leave a candidate with no token, and resend is the only way forward."""
+    await pair_new_terminal(app_client)
+    owner = await get_owner()
+    assert (owner.pending_email, owner.email_token_hash) == (PROFILE_ADDRESS, None)
+
+    assert (await app_client.post(RESEND)).status_code == 204
+
+    await app_client.post(CONFIRM, json={"token": sent_token(requests_mock)})
+    assert (await get_owner()).email == PROFILE_ADDRESS
 
 
 async def test_discarding_the_candidate_drops_its_token(
@@ -446,6 +559,46 @@ async def test_without_verification_the_address_is_set_directly(
     assert json.loads(calls_to(requests_mock, MIRROR_PATH)[0].request.body) == {
         "address": NEW_ADDRESS
     }
+
+
+async def test_clearing_an_address_that_is_already_empty_does_nothing(
+    requests_mock, app_client: AsyncClient
+):
+    """Where every shard sits right after the 0005 migration, while the
+    controller still holds the signup address. Mirroring a null there is what
+    silently stops disk, billing and wind-down mail to a paying customer."""
+    await pair_new_terminal(app_client)
+    await app_client.delete(PENDING)
+
+    response = await app_client.patch(ME, json={"email": None})
+
+    assert response.status_code == 200
+    assert calls_to(requests_mock, RELAY_PATH) == []
+    assert calls_to(requests_mock, MIRROR_PATH) == []
+
+
+async def test_without_verification_resending_is_refused(
+    requests_mock, app_client: AsyncClient
+):
+    await pair_new_terminal(app_client)
+
+    with settings_override({"oidc": {"email_verification": False}}):
+        response = await app_client.post(RESEND)
+
+    assert response.status_code == 409
+    assert calls_to(requests_mock, VERIFY_PATH) == []
+
+
+async def test_without_verification_the_send_budget_is_not_spent(
+    requests_mock, app_client: AsyncClient
+):
+    """A shard that cannot send mail at all has nothing to ration."""
+    with settings_override({"oidc": {"email_verification": False}}):
+        await pair_new_terminal(app_client)
+        for i in range(8):
+            assert (await set_address(app_client, f"a{i}@example.org"))[
+                "email"
+            ] == f"a{i}@example.org"
 
 
 async def test_without_verification_clearing_sends_no_notification(

--- a/tests/test_owner_email.py
+++ b/tests/test_owner_email.py
@@ -1,0 +1,462 @@
+"""The owner's email address: candidate, confirmation, and what it costs.
+
+The invariant under test throughout is that users.email only ever holds an
+address somebody proved they can read — that is what the OIDC email_verified
+claim rests on (see tests/test_oidc.py for the claim itself).
+"""
+
+import hashlib
+import json
+from datetime import datetime, timedelta, timezone
+from urllib.parse import urlparse
+
+import pytest
+import responses
+from httpx import AsyncClient
+
+from shard_core.database import users as db_users
+from shard_core.database.connection import db_conn
+from shard_core.settings import settings
+from shard_core.web.protected.users import _email_send_limit
+from shard_core.web.public.users import _confirm_limit
+from tests.conftest import settings_override
+from tests.util import pair_new_terminal
+
+ME = "protected/users/me"
+RESEND = "protected/users/me/email/resend"
+PENDING = "protected/users/me/email/pending"
+CONFIRM = "public/users/confirm-email"
+
+RELAY_PATH = "/api/email_relay"
+VERIFY_PATH = "/api/email_verification"
+MIRROR_PATH = "/api/shards/self/owner-email"
+
+NEW_ADDRESS = "owner@example.org"
+# what the mocked controller reports as the shard's owner (tests.conftest.mock_shard)
+PROFILE_ADDRESS = "testowner@foobar.com"
+
+
+@pytest.fixture(autouse=True)
+def reset_rate_limits():
+    """The limiters are module-level, so they otherwise leak across tests."""
+    _confirm_limit.reset()
+    _email_send_limit.reset()
+
+
+def controller_url(path: str) -> str:
+    return f"{settings().freeshard_controller.base_url}{path}"
+
+
+def calls_to(requests_mock, path: str) -> list:
+    return [c for c in requests_mock.calls if urlparse(c.request.url).path == path]
+
+
+def call_order(requests_mock, *paths: str) -> list[str]:
+    seen = [urlparse(c.request.url).path for c in requests_mock.calls]
+    return [p for p in seen if p in paths]
+
+
+async def get_owner():
+    async with db_conn() as conn:
+        return await db_users.get_owner(conn)
+
+
+async def set_address(client: AsyncClient, address=NEW_ADDRESS):
+    response = await client.patch(ME, json={"email": address})
+    assert response.status_code == 200, response.text
+    return response.json()
+
+
+def sent_token(requests_mock) -> str:
+    calls = calls_to(requests_mock, VERIFY_PATH)
+    assert calls, "no verification email was requested"
+    return json.loads(calls[-1].request.body)["token"]
+
+
+# --- reading the user ------------------------------------------------------------
+
+
+async def test_me_returns_the_owner(requests_mock, app_client: AsyncClient):
+    await pair_new_terminal(app_client)
+
+    response = await app_client.get(ME)
+
+    assert response.status_code == 200
+    body = response.json()
+    owner = await get_owner()
+    assert body["id"] == owner.id
+    assert body["username"] == "owner"
+    assert body["role"] == "owner"
+    # a fresh shard has confirmed nothing, so there is no verified address
+    assert body["email"] is None
+
+
+async def test_me_without_a_session_is_rejected(app_client: AsyncClient):
+    assert (await app_client.get(ME)).status_code == 401
+    assert (await app_client.patch(ME, json={})).status_code == 401
+    assert (await app_client.post(RESEND)).status_code == 401
+    assert (await app_client.delete(PENDING)).status_code == 401
+
+
+async def test_me_hides_the_confirmation_token(requests_mock, app_client: AsyncClient):
+    await pair_new_terminal(app_client)
+    await set_address(app_client)
+
+    body = (await app_client.get(ME)).json()
+
+    assert (await get_owner()).email_token_hash is not None
+    assert "email_token_hash" not in body
+    assert "email_token_expires" not in body
+
+
+async def test_pairing_seeds_the_controller_address_as_a_candidate(
+    requests_mock, app_client: AsyncClient
+):
+    """The controller's signup address was never verified either."""
+    await pair_new_terminal(app_client)
+
+    owner = await get_owner()
+    assert owner.email is None
+    assert owner.pending_email == PROFILE_ADDRESS
+
+
+# --- setting an address ----------------------------------------------------------
+
+
+async def test_setting_an_address_writes_a_candidate_and_sends_a_link(
+    requests_mock, app_client: AsyncClient
+):
+    await pair_new_terminal(app_client)
+
+    body = await set_address(app_client)
+
+    assert body["email"] is None, "the address must not count as verified yet"
+    assert body["pending_email"] == NEW_ADDRESS
+    owner = await get_owner()
+    assert owner.email is None
+    assert owner.pending_email == NEW_ADDRESS
+
+    requested = json.loads(calls_to(requests_mock, VERIFY_PATH)[0].request.body)
+    assert requested["address"] == NEW_ADDRESS
+    assert requested["token"]
+
+
+async def test_the_token_is_stored_only_as_a_digest(
+    requests_mock, app_client: AsyncClient
+):
+    await pair_new_terminal(app_client)
+    await set_address(app_client)
+    token = sent_token(requests_mock)
+
+    owner = await get_owner()
+
+    assert owner.email_token_hash == hashlib.sha256(token.encode()).hexdigest()
+    async with db_conn() as conn:
+        cur = await conn.execute(
+            "SELECT count(*) FROM users WHERE email_token_hash = %s", (token,)
+        )
+        assert (await cur.fetchone())[0] == 0
+
+
+async def test_setting_a_second_address_replaces_the_first_candidate(
+    requests_mock, app_client: AsyncClient
+):
+    await pair_new_terminal(app_client)
+    await set_address(app_client, "first@example.org")
+    first_token = sent_token(requests_mock)
+
+    await set_address(app_client, "second@example.org")
+
+    owner = await get_owner()
+    assert owner.pending_email == "second@example.org"
+    r = await app_client.post(CONFIRM, json={"token": first_token})
+    assert r.status_code == 204
+    assert (await get_owner()).email is None, "the superseded token still worked"
+
+
+async def test_an_invalid_address_is_rejected(requests_mock, app_client: AsyncClient):
+    await pair_new_terminal(app_client)
+
+    response = await app_client.patch(ME, json={"email": "i am invalid"})
+
+    assert response.status_code == 422
+    assert calls_to(requests_mock, VERIFY_PATH) == []
+
+
+async def test_omitting_the_address_leaves_it_untouched(
+    requests_mock, app_client: AsyncClient
+):
+    await pair_new_terminal(app_client)
+    await set_address(app_client)
+
+    response = await app_client.patch(ME, json={"display_name": "Renamed"})
+
+    assert response.status_code == 200
+    assert response.json()["display_name"] == "Renamed"
+    assert response.json()["pending_email"] == NEW_ADDRESS
+    assert len(calls_to(requests_mock, VERIFY_PATH)) == 1
+
+
+async def test_a_failed_delivery_reports_an_error_and_keeps_the_candidate(
+    requests_mock, app_client: AsyncClient
+):
+    """Resend is the recovery, so the candidate has to survive the failure."""
+    await pair_new_terminal(app_client)
+    requests_mock.replace(
+        responses.POST, controller_url(VERIFY_PATH), status=500, body="nope"
+    )
+
+    response = await app_client.patch(ME, json={"email": NEW_ADDRESS})
+
+    assert response.status_code == 502
+    owner = await get_owner()
+    assert owner.pending_email == NEW_ADDRESS
+    assert owner.email is None
+
+
+# --- confirming ------------------------------------------------------------------
+
+
+async def test_confirming_promotes_the_candidate(
+    requests_mock, app_client: AsyncClient
+):
+    await pair_new_terminal(app_client)
+    await set_address(app_client)
+    token = sent_token(requests_mock)
+
+    response = await app_client.post(CONFIRM, json={"token": token})
+
+    assert response.status_code == 204
+    owner = await get_owner()
+    assert owner.email == NEW_ADDRESS
+    assert owner.pending_email is None
+    assert owner.email_token_hash is None
+    assert owner.email_token_expires is None
+
+
+async def test_the_old_address_is_told_before_the_switch_is_mirrored(
+    requests_mock, app_client: AsyncClient
+):
+    """The relay only ever reaches the address the controller currently holds,
+    so a notification after the mirror would go to the new address."""
+    await pair_new_terminal(app_client)
+    await set_address(app_client)
+    token = sent_token(requests_mock)
+
+    await app_client.post(CONFIRM, json={"token": token})
+
+    assert call_order(requests_mock, RELAY_PATH, MIRROR_PATH) == [
+        RELAY_PATH,
+        MIRROR_PATH,
+        RELAY_PATH,
+    ]
+    assert json.loads(calls_to(requests_mock, MIRROR_PATH)[0].request.body) == {
+        "address": NEW_ADDRESS
+    }
+
+
+async def test_confirming_survives_a_controller_that_cannot_send_mail(
+    requests_mock, app_client: AsyncClient
+):
+    await pair_new_terminal(app_client)
+    await set_address(app_client)
+    token = sent_token(requests_mock)
+    requests_mock.replace(
+        responses.POST, controller_url(RELAY_PATH), status=422, body="no owner_email"
+    )
+
+    response = await app_client.post(CONFIRM, json={"token": token})
+
+    assert response.status_code == 204
+    assert (await get_owner()).email == NEW_ADDRESS
+
+
+async def test_an_unknown_token_changes_nothing_and_says_nothing(
+    requests_mock, app_client: AsyncClient
+):
+    await pair_new_terminal(app_client)
+    await set_address(app_client)
+
+    response = await app_client.post(CONFIRM, json={"token": "not-the-token"})
+
+    assert response.status_code == 204, "a miss must look exactly like a hit"
+    owner = await get_owner()
+    assert owner.email is None
+    assert owner.pending_email == NEW_ADDRESS
+
+
+async def test_an_expired_token_does_not_promote(
+    requests_mock, app_client: AsyncClient
+):
+    await pair_new_terminal(app_client)
+    await set_address(app_client)
+    token = sent_token(requests_mock)
+    owner = await get_owner()
+    async with db_conn() as conn:
+        await db_users.update(
+            conn,
+            owner.id,
+            {"email_token_expires": datetime.now(timezone.utc) - timedelta(minutes=1)},
+        )
+
+    response = await app_client.post(CONFIRM, json={"token": token})
+
+    assert response.status_code == 204
+    assert (await get_owner()).email is None
+
+
+async def test_a_token_works_only_once(requests_mock, app_client: AsyncClient):
+    await pair_new_terminal(app_client)
+    await set_address(app_client)
+    token = sent_token(requests_mock)
+    await app_client.post(CONFIRM, json={"token": token})
+    async with db_conn() as conn:
+        await db_users.update(
+            conn, (await get_owner()).id, {"pending_email": "attacker@example.org"}
+        )
+
+    response = await app_client.post(CONFIRM, json={"token": token})
+
+    assert response.status_code == 204
+    assert (await get_owner()).email == NEW_ADDRESS
+
+
+async def test_a_malformed_token_is_refused(requests_mock, app_client: AsyncClient):
+    assert (await app_client.post(CONFIRM, json={"token": ""})).status_code == 400
+    assert (
+        await app_client.post(CONFIRM, json={"token": "x" * 513})
+    ).status_code == 400
+    assert (await app_client.post(CONFIRM, json={})).status_code == 422
+
+
+async def test_confirming_is_rate_limited(requests_mock, app_client: AsyncClient):
+    for _ in range(10):
+        r = await app_client.post(CONFIRM, json={"token": "guess"})
+        assert r.status_code == 204
+
+    assert (await app_client.post(CONFIRM, json={"token": "guess"})).status_code == 429
+
+
+# --- resending and discarding ----------------------------------------------------
+
+
+async def test_resending_replaces_the_token(requests_mock, app_client: AsyncClient):
+    await pair_new_terminal(app_client)
+    await set_address(app_client)
+    first_token = sent_token(requests_mock)
+
+    response = await app_client.post(RESEND)
+
+    assert response.status_code == 204
+    second_token = sent_token(requests_mock)
+    assert second_token != first_token
+    r = await app_client.post(CONFIRM, json={"token": first_token})
+    assert r.status_code == 204
+    assert (await get_owner()).email is None, "the replaced token still worked"
+    await app_client.post(CONFIRM, json={"token": second_token})
+    assert (await get_owner()).email == NEW_ADDRESS
+
+
+async def test_resending_without_a_candidate_is_refused(
+    requests_mock, app_client: AsyncClient
+):
+    await pair_new_terminal(app_client)
+    await app_client.delete(PENDING)
+
+    response = await app_client.post(RESEND)
+
+    assert response.status_code == 404
+    assert calls_to(requests_mock, VERIFY_PATH) == []
+
+
+async def test_sending_confirmation_mail_is_rate_limited(
+    requests_mock, app_client: AsyncClient
+):
+    """Setting an address and resending share one budget, so alternating
+    between the two routes cannot double the mail a shard can send."""
+    await pair_new_terminal(app_client)
+    await set_address(app_client)
+    for _ in range(4):
+        assert (await app_client.post(RESEND)).status_code == 204
+
+    assert (await app_client.post(RESEND)).status_code == 429
+    assert (await app_client.patch(ME, json={"email": NEW_ADDRESS})).status_code == 429
+
+
+async def test_discarding_the_candidate_drops_its_token(
+    requests_mock, app_client: AsyncClient
+):
+    await pair_new_terminal(app_client)
+    await set_address(app_client)
+    token = sent_token(requests_mock)
+
+    response = await app_client.delete(PENDING)
+
+    assert response.status_code == 204
+    owner = await get_owner()
+    assert owner.pending_email is None
+    assert owner.email_token_hash is None
+    await app_client.post(CONFIRM, json={"token": token})
+    assert (await get_owner()).email is None
+
+
+# --- clearing --------------------------------------------------------------------
+
+
+async def test_clearing_tells_the_old_address_first(
+    requests_mock, app_client: AsyncClient
+):
+    await pair_new_terminal(app_client)
+    await set_address(app_client)
+    await app_client.post(CONFIRM, json={"token": sent_token(requests_mock)})
+
+    response = await app_client.patch(ME, json={"email": None})
+
+    assert response.status_code == 200
+    assert response.json()["email"] is None
+    owner = await get_owner()
+    assert owner.email is None
+    assert owner.pending_email is None
+    assert call_order(requests_mock, RELAY_PATH, MIRROR_PATH)[-2:] == [
+        RELAY_PATH,
+        MIRROR_PATH,
+    ]
+    assert json.loads(calls_to(requests_mock, MIRROR_PATH)[-1].request.body) == {
+        "address": None
+    }
+
+
+# --- self-hosted, where no mail can be sent --------------------------------------
+
+
+async def test_without_verification_the_address_is_set_directly(
+    requests_mock, app_client: AsyncClient
+):
+    await pair_new_terminal(app_client)
+
+    with settings_override({"oidc": {"email_verification": False}}):
+        body = await set_address(app_client)
+
+    assert body["email"] == NEW_ADDRESS
+    assert body["pending_email"] is None
+    owner = await get_owner()
+    assert owner.email == NEW_ADDRESS
+    assert owner.email_token_hash is None
+    assert calls_to(requests_mock, VERIFY_PATH) == []
+    assert json.loads(calls_to(requests_mock, MIRROR_PATH)[0].request.body) == {
+        "address": NEW_ADDRESS
+    }
+
+
+async def test_without_verification_clearing_sends_no_notification(
+    requests_mock, app_client: AsyncClient
+):
+    await pair_new_terminal(app_client)
+
+    with settings_override({"oidc": {"email_verification": False}}):
+        await set_address(app_client)
+        response = await app_client.patch(ME, json={"email": None})
+
+    assert response.status_code == 200
+    assert (await get_owner()).email is None
+    assert calls_to(requests_mock, RELAY_PATH) == []

--- a/tests/test_settings_endpoint.py
+++ b/tests/test_settings_endpoint.py
@@ -1,0 +1,32 @@
+import pytest
+from httpx import AsyncClient
+
+from tests.conftest import settings_override
+
+pytest_plugins = ("pytest_asyncio",)
+pytestmark = pytest.mark.asyncio
+
+
+async def test_reports_that_the_shard_can_send_mail(api_client: AsyncClient):
+    response = await api_client.get("protected/settings")
+    assert response.status_code == 200
+    assert response.json()["email_enabled"] is True
+
+
+async def test_reports_when_it_cannot(api_client: AsyncClient):
+    with settings_override({"email": {"enabled": False}}):
+        response = await api_client.get("protected/settings")
+    assert response.status_code == 200
+    assert response.json()["email_enabled"] is False
+
+
+async def test_publishes_nothing_beyond_the_allowlist(api_client: AsyncClient):
+    """The point of the endpoint is what it does *not* say.
+
+    Settings holds the database password, the controller base URL and the
+    management API URL. Asserting the exact key set means a field added
+    elsewhere in the config cannot start being published here unnoticed —
+    whoever adds one has to come here and say so.
+    """
+    body = (await api_client.get("protected/settings")).json()
+    assert set(body) == {"email_enabled"}

--- a/tests/test_terminals.py
+++ b/tests/test_terminals.py
@@ -78,7 +78,13 @@ async def test_pairing_happy(requests_mock, app_client: AsyncClient):
     response = await app_client.get("protected/identities/default")
     assert response.status_code == status.HTTP_200_OK
     assert response.json()["name"] == "test owner"
-    assert response.json()["email"] == "testowner@foobar.com"
+
+    response = await app_client.get("protected/users/me")
+    assert response.status_code == status.HTTP_200_OK
+    # the controller's signup address was never verified, so it arrives as a
+    # candidate rather than as the owner's address
+    assert response.json()["email"] is None
+    assert response.json()["pending_email"] == "testowner@foobar.com"
 
 
 async def test_pairing_two(app_client: AsyncClient):
@@ -195,7 +201,9 @@ async def test_pairing_with_profile_missing_owner(
         response = await app_client.get("protected/identities/default")
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["name"] == "Shard Owner"
-        assert response.json()["email"] == "testowner@foobar.com"
+
+        response = await app_client.get("protected/users/me")
+        assert response.json()["pending_email"] == "testowner@foobar.com"
 
 
 async def test_pairing_with_profile_missing_email(
@@ -211,7 +219,10 @@ async def test_pairing_with_profile_missing_email(
         response = await app_client.get("protected/identities/default")
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["name"] == "test owner"
+
+        response = await app_client.get("protected/users/me")
         assert response.json()["email"] is None
+        assert response.json()["pending_email"] is None
 
 
 async def test_last_connection(api_client: AsyncClient):

--- a/tests/test_throttle.py
+++ b/tests/test_throttle.py
@@ -1,6 +1,6 @@
 import time
 
-from shard_core.util.misc import throttle
+from shard_core.util.misc import SlidingWindow, throttle
 
 
 def test_throttle_once():
@@ -39,3 +39,32 @@ def test_throttle_is_per_argument():
     assert call_me("a") == "called"
     assert call_me("a") is None
     assert call_me("b") == "called"
+
+
+def test_sliding_window_grants_up_to_the_limit():
+    window = SlidingWindow(limit=2, window=60)
+
+    assert window.try_acquire() is True
+    assert window.try_acquire() is True
+    assert window.try_acquire() is False
+
+
+def test_sliding_window_refills_as_the_window_moves():
+    """Without the eviction, the limit is a permanent lockout rather than a
+    rate — the owner would get five address changes per process, ever."""
+    window = SlidingWindow(limit=1, window=0.1)
+    assert window.try_acquire() is True
+    assert window.try_acquire() is False
+
+    time.sleep(0.15)
+
+    assert window.try_acquire() is True
+
+
+def test_sliding_window_reset_returns_the_whole_budget():
+    window = SlidingWindow(limit=1, window=60)
+    window.try_acquire()
+
+    window.reset()
+
+    assert window.try_acquire() is True

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -41,6 +41,10 @@ async def test_ensure_owner_user_is_idempotent(db):
     assert first.id == second.id
     async with db_conn() as conn:
         assert await db_users.count(conn) == 1
+    # the second call is the one every restart makes, and the one the deleted
+    # synthetic-address backfill used to run on
+    assert second.email is None
+    assert second.pending_email is None
 
 
 async def test_ensure_owner_user_leaves_an_existing_owner_alone(db):

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -2,7 +2,6 @@ from httpx import AsyncClient
 
 from shard_core.data_model.user import Role, User
 from shard_core.database.connection import db_conn
-from shard_core.database import identities as db_identities
 from shard_core.database import terminals as db_terminals
 from shard_core.database import users as db_users
 from shard_core.service import identity, user
@@ -19,20 +18,18 @@ async def test_ensure_owner_user_creates_owner_from_default_identity(db):
     assert owner.role == Role.OWNER
     assert owner.username == "owner"
     assert owner.display_name == default_identity.name
-    assert owner.email == f"owner@{default_identity.domain}"
     assert owner.disabled is False
 
 
-async def test_ensure_owner_user_keeps_identity_email(db):
-    default_identity = await identity.init_default_identity()
-    async with db_conn() as conn:
-        await db_identities.update(
-            conn, default_identity.id, {"email": "max@freeshard.net"}
-        )
+async def test_ensure_owner_user_leaves_the_address_empty(db):
+    """users.email is verified by definition and a fresh shard has verified
+    nothing, so there is no address to invent."""
+    await identity.init_default_identity()
 
     owner = await user.ensure_owner_user()
 
-    assert owner.email == "max@freeshard.net"
+    assert owner.email is None
+    assert owner.pending_email is None
 
 
 async def test_ensure_owner_user_is_idempotent(db):
@@ -46,9 +43,7 @@ async def test_ensure_owner_user_is_idempotent(db):
         assert await db_users.count(conn) == 1
 
 
-async def test_ensure_owner_user_backfills_missing_email(db):
-    """Migration-created owners (existing shards) start without a synthesized
-    email; ensure_owner_user fills it on the next startup."""
+async def test_ensure_owner_user_leaves_an_existing_owner_alone(db):
     default_identity = await identity.init_default_identity()
     async with db_conn() as conn:
         await db_users.insert(
@@ -56,14 +51,14 @@ async def test_ensure_owner_user_backfills_missing_email(db):
             {
                 "username": "owner",
                 "display_name": default_identity.name,
-                "email": None,
+                "email": "confirmed@freeshard.net",
                 "role": Role.OWNER.value,
             },
-        )  # simulates the 0002 SQL backfill (no synthesized email)
+        )
 
     owner = await user.ensure_owner_user()
 
-    assert owner.email == f"owner@{default_identity.domain}"
+    assert owner.email == "confirmed@freeshard.net"
 
 
 async def test_pairing_binds_terminal_to_owner(app_client: AsyncClient):


### PR DESCRIPTION
Closes #220. Closes #223.

Makes the OIDC `email_verified` claim mean something. Today the provider asserts it unconditionally beside a synthetic `owner@<shard-domain>` that is not a mailbox and is not the address the owner sees in the UI.

**The invariant:** `users.email` is verified by definition; `users.pending_email` is an unverified candidate, at most one in flight per user. A candidate is only promoted when somebody opens a one-hour, single-use link delivered to it. With no verified address the provider emits no `email` claim and no `email_verified` at all — there is no synthetic fallback any more.

`identities.email` is dropped entirely. An identity is the shard's public profile, published unauthenticated by `GET /public/meta/whoareyou`; a personal address has no business being forcibly published there.

## Two changes on top of #220

**The mail switch moved out of `oidc` to its own section** (`5101509`). It gates two things — whether an address is confirmed before use, and whether the change notifications go out — and neither is an OIDC property; a shard with `oidc.enabled = false` was still consulting a setting under `oidc` to decide whether it may mail anyone. It is also the first outbound-mail capability the shard has had at all: nothing in `shard_core` called the relay before this branch. So `oidc.email_verification` becomes `email.enabled` / `FREESHARD_EMAIL__ENABLED`. Deliberately not named after the deployment (`selfhosted` or similar) — that is a proxy for the real condition and lies in both directions.

**`GET /protected/settings`** (`b8b6ae1`, closes #223). A client had no way to ask how the shard is configured, so the settings UI would have had to offer a resend control and learn from the error that verification is off. Read-only, and separate from `/protected/preferences` (#168) on purpose: that one is the user's and writable, this one is the operator's and is not, so neither payload mixes writable and read-only fields.

The response model is an **explicit allowlist**, not a projection of `Settings` — that object holds the database password, the controller base URL and the management API URL, so an exclude-list would fail open and publish any field added later elsewhere in the config. The test asserts the *exact* key set rather than the presence of one key, so adding a field is a deliberate act with a failing test in front of it. Verified by leaking the controller URL on purpose and watching that test fail.

Exposed as `email_enabled`, mirroring the setting, rather than narrowing it to `email_verification`: the flag says whether the shard can send mail at all, and a client may legitimately want to report either consequence.

## Recommended reading order

1. `migrations/shard-core-0005-owner-email-verification.sql` — the three new columns, the data movement, the drop
2. `shard_core/settings.py`, `config.toml` — `email.enabled`
3. `shard_core/data_model/user.py`, `shard_core/data_model/identity.py` — the models
4. `shard_core/database/users.py` — `claim_email_token` and `promote_pending_email` are where single-use lives
5. `shard_core/database/identities.py`, `tinydb_migration.py`, `db_snapshot.py` — the paths that carried the dropped column
6. `shard_core/service/owner_email.py` — every transition
7. `shard_core/service/freeshard_controller.py`, `shard_core/service/identity.py`, `shard_core/service/user.py`
8. `shard_core/web/protected/users.py`, `shard_core/web/public/users.py` — the HTTP surface
9. `shard_core/util/misc.py`, `shard_core/web/public/oidc.py` — `SlidingWindow`, and the OIDC token limiter folded onto it
10. `shard_core/web/protected/settings.py` — the capability endpoint and its allowlist
11. tests

## Migration

Every shard lands with **no verified address**. `identities.email` moves to the owner's `pending_email` (it was never verified); `users.email` is discarded (synthetic or an unverified copy). Shards therefore show a prompt in the UI rather than a claim. Nothing breaks meanwhile — the provider is off by default and rolled out per shard.

The drop is not reversible: there is no down-migration mechanism in this repo, so running a pre-0005 image against a 0005 database breaks identity creation (`db_identities.insert` still names the column). Addresses on **non-default** identities are lost — only the default one is carried over. Flagging both rather than working around them; say the word if you want expand/contract instead (stop reading the column now, drop it in 0006 one release later).

## Cross-repo

- **Depends on FreeshardBase/freeshard-controller#434.** `POST /api/email_verification` and `PUT /api/shards/self/owner-email` do not exist yet. Until they do, `PATCH /protected/users/me` with an address returns 502 (the candidate is kept, resend is the retry). **This must not be released ahead of the controller.**
- **`OutputIdentity` / `InputIdentity` lose `email`**, so `GET /public/meta/whoareyou` and `GET/PUT /protected/identities*` change shape. Today's web-terminal (`Public.vue` binds an Email field; `Welcome.vue` renders `mailto:{{ identity.email }}`) will silently drop the value and render an empty `mailto:`. Safe order: web-terminal removes those two first (backward-compatible with today's shard_core), then this, then FreeshardBase/web-terminal#44's `/users/me` UI.

## Review panel

Six reviewers: adversarial, test adversary, security, DB/migration, API contract, DevEx. Blocking findings and how each was resolved:

| Finding | Resolution |
|---|---|
| `email: ""` took the notify-then-clear path instead of being rejected — the single most likely input from a blanked form | **Fixed** (75bad37). `InputUser.validate_email` rejects it with 422; `null` remains the only clear. |
| Clearing an already-empty address still mailed the owner and nulled `shards.owner_email` — the state every shard is in after the migration | **Fixed** (75bad37). No-op when both are already empty. |
| `enrich_identity_from_profile` replaced the candidate while leaving its token live, so a token mailed to A could promote B. Re-fires whenever the last terminal is re-paired | **Fixed** (75bad37). The token is retired with the candidate. |
| Token consumed across two transactions with a controller round-trip between — a double-clicked link promoted twice, and a confirmation in flight destroyed a candidate set meanwhile | **Fixed** (75bad37). `claim_email_token` spends it in one conditional UPDATE; the promote is guarded on the candidate it claimed. Constant-time digest matching kept. |
| The confirm rate limit charged hits too, so any anonymous caller could keep the owner off the only route that verifies an address — and the plausible operator response is to switch verification off | **Fixed** (75bad37). Only misses are charged, limit raised to 20/min. |
| No `Content-Type` on the new controller calls | **Fixed** (75bad37). The controller parses them today only via `strict_content_type=False`, which it marks TEMPORARY pending exactly this (FreeshardBase/freeshard-controller#272). |
| Migration 0005's data statements never ran against data — yoyo applies them once, to an empty database | **Fixed** (75bad37). `tests/test_migration_0005.py` replays 0001–0004 into a scratch database, seeds the real shapes, applies 0005. Both mutations of that SQL (dropping the `email = NULL` statement, dropping the `NULLIF`) were confirmed to fail the tests. |
| `ensure_owner_user`'s deleted synthetic backfill lived on the `elif` path no test reached; the snapshot round-trip never read `users` back; the TinyDB path never asserted the owner | **Fixed** (75bad37). Assertions added to all three. |
| `SlidingWindow`'s eviction was untested — deleting it turns the limit into a permanent per-process lockout and every test still passed | **Fixed** (75bad37). Unit tests in `test_throttle.py`. |
| `oidc.email_verification` is in the wrong settings section and named for one of the three things it does | **Dismissed.** #220 specifies this name and location verbatim. Worth renaming, but that is your call, not a silent deviation. |
| CSRF: `POST /me/email/resend` takes no body, so a cross-site form POST from any `*.freeshard.cloud` page (an installed app) can rotate the owner's pending token and burn the mail budget | **Dismissed with a follow-up.** The property is repo-wide — the terminal cookie is `SameSite=Lax` on a shared registrable domain and no mutating `/protected` route has a CSRF defence. Bounded harm here (token rotation, not takeover). Wants its own issue covering all of them; happy to open it. |
| Session hijack chain: clear the address, then set and confirm the attacker's own — the clear disarms the notification that would warn the owner | **Dismissed.** #220 designs clearing exactly this way, with one warning mail. Requiring re-authentication is a design change for you to take. |

Advisories fixed along the way: address normalization before storage (`Owner@EXAMPLE.ORG` → `Owner@example.org`, SMTPUTF8 off — it is asserted as verified to third parties); owner-scope guard on the address routes, so a phase-4 member cannot redirect the owner's billing mail; `403` rather than `401` for a disabled user; `409` rather than `404` for resend with no candidate; `max_length` on both input fields; explicit `display_name: null` rejected rather than silently ignored; a `CHECK` constraint pairing the token columns; snapshot restore warns once per table instead of once per row and no longer `KeyError`s on a mixed-version file; `SlidingWindow.is_exceeded` renamed `try_acquire` because it records; the OIDC token endpoint's inline copy of the same limiter folded onto the shared class.

## Noticed, not touched

`service/telemetry.py:101` posts JSON with no `Content-Type` the same way the new calls did. It works only because of the controller's temporary loosening, so it will start 422-ing when FreeshardBase/freeshard-controller#272 lands. Out of scope here — worth its own issue.

## Verification

`389 passed` (up from 368), full suite, locally. `just cleanup` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

